### PR TITLE
Tool calling support

### DIFF
--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -176,7 +176,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// gpt-oss / Harmony), a different parser is needed; this one
         /// covers the `<open>...</close>` shape.
         private static func detectThinkingMarkers(
-            using tokenizer: some Tokenizer
+            using tokenizer: any Tokenizer
         ) -> (open: String, close: String) {
             let candidates: [(open: String, close: String)] = [
                 ("<think>", "</think>"),
@@ -203,7 +203,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// matches the bare token without a trailing space — `parseToolCalls`
         /// already trims leading whitespace so optional spacing is handled.
         fileprivate static func detectToolCallMarkers(
-            using tokenizer: some Tokenizer
+            using tokenizer: any Tokenizer
         ) -> (open: String, close: String)? {
             // Standard tag-pair formats — both markers must be special tokens.
             let tagPairs: [(open: String, close: String)] = [

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -45,7 +45,7 @@ public struct CoreAILanguageModel: LanguageModel {
     public var capabilities: LanguageModelCapabilities {
         var caps: [LanguageModelCapabilities.Capability] = []
         if supportsToolCalling { caps.append(.toolCalling) }
-        if supportsReasoning   { caps.append(.reasoning) }
+        if supportsReasoning { caps.append(.reasoning) }
         if engine.supportsLogits { caps.append(.guidedGeneration) }
         return LanguageModelCapabilities(capabilities: caps)
     }
@@ -210,7 +210,8 @@ public struct CoreAILanguageModel: LanguageModel {
                 ("<tool_call>", "</tool_call>"),
                 ("<function_calls>", "</function_calls>"),
             ]
-            for pair in tagPairs where tokenizer.convertTokenToId(pair.open) != nil
+            for pair in tagPairs
+            where tokenizer.convertTokenToId(pair.open) != nil
                 && tokenizer.convertTokenToId(pair.close) != nil
             {
                 return pair
@@ -577,7 +578,8 @@ public struct CoreAILanguageModel: LanguageModel {
             from entries: [Transcript.Entry],
             using tokenizer: any Tokenizer,
             tools: [Transcript.ToolDefinition] = [],
-            component: String = "CoreAIExecutor"        ) -> [Int] {
+            component: String = "CoreAIExecutor"
+        ) -> [Int] {
             var messages: [Message] = []
 
             for entry in entries {
@@ -676,26 +678,26 @@ public struct CoreAILanguageModel: LanguageModel {
 
             init(_ value: Any) {
                 switch value {
-                case let s as String:        self = .string(s)
+                case let s as String: self = .string(s)
                 case let n as NSNumber where CFGetTypeID(n) == CFBooleanGetTypeID():
                     self = .bool(n.boolValue)
                 case let n as NSNumber:
                     let d = n.doubleValue
                     self = (d == d.rounded() && !d.isInfinite) ? .int(n.intValue) : .double(d)
-                case let a as [Any]:         self = .array(a.map { JSONValue($0) })
+                case let a as [Any]: self = .array(a.map { JSONValue($0) })
                 case let o as [String: Any]: self = .object(o.mapValues { JSONValue($0) })
-                default:                     self = .null
+                default: self = .null
                 }
             }
 
             var sendable: any Sendable {
                 switch self {
                 case .string(let v): return v
-                case .int(let v):    return v
+                case .int(let v): return v
                 case .double(let v): return v
-                case .bool(let v):   return v
-                case .null:          return NSNull()
-                case .array(let v):  return v.map(\.sendable)
+                case .bool(let v): return v
+                case .null: return NSNull()
+                case .array(let v): return v.map(\.sendable)
                 case .object(let v): return v.mapValues(\.sendable)
                 }
             }

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -104,7 +104,7 @@ public struct CoreAILanguageModel: LanguageModel {
         self.modelIdentifier = modelIdentifier
         self.samplingConfig = samplingConfig
         self.vocabSize = vocabSize
-        self.supportsToolCalling = CoreAIExecutor.detectToolCallMarkers(tokenizer: tokenizer) != nil
+        self.supportsToolCalling = CoreAIExecutor.detectToolCallMarkers(using: tokenizer) != nil
         self.supportsReasoning =
             tokenizer.convertTokenToId("<think>") != nil
             || tokenizer.convertTokenToId("<|reasoning_start|>") != nil
@@ -160,8 +160,8 @@ public struct CoreAILanguageModel: LanguageModel {
             self.modelIdentifier = configuration.modelIdentifier
             self.samplingConfig = configuration.samplingConfig
             self.vocabSize = configuration.vocabSize
-            self.thinkingMarkers = Self.detectThinkingMarkers(configuration.tokenizer)
-            self.toolCallMarkers = Self.detectToolCallMarkers(tokenizer: configuration.tokenizer)
+            self.thinkingMarkers = Self.detectThinkingMarkers(using: configuration.tokenizer)
+            self.toolCallMarkers = Self.detectToolCallMarkers(using: configuration.tokenizer)
         }
 
         /// Probes the tokenizer for known reasoning marker pairs. Each
@@ -176,7 +176,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// gpt-oss / Harmony), a different parser is needed; this one
         /// covers the `<open>...</close>` shape.
         private static func detectThinkingMarkers(
-            _ tokenizer: any Tokenizer
+            using tokenizer: some Tokenizer
         ) -> (open: String, close: String) {
             let candidates: [(open: String, close: String)] = [
                 ("<think>", "</think>"),
@@ -203,7 +203,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// matches the bare token without a trailing space — `parseToolCalls`
         /// already trims leading whitespace so optional spacing is handled.
         fileprivate static func detectToolCallMarkers(
-            tokenizer: any Tokenizer
+            using tokenizer: some Tokenizer
         ) -> (open: String, close: String)? {
             // Standard tag-pair formats — both markers must be special tokens.
             let tagPairs: [(open: String, close: String)] = [
@@ -266,8 +266,8 @@ public struct CoreAILanguageModel: LanguageModel {
         ) async throws {
             // Tokenization span
             let tokenizationSpan = InstrumentsProfiler.beginTokenization(inputLength: 0)
-            let promptTokens = Self.transcriptToTokens(
-                Array(request.transcript),
+            let promptTokens = Self.makeTokens(
+                from: Array(request.transcript),
                 using: tokenizer,
                 tools: request.enabledToolDefinitions,
                 component: "CoreAIExecutor"
@@ -351,7 +351,7 @@ public struct CoreAILanguageModel: LanguageModel {
             // Routes tool call markup to .toolCalls(...) channel events.
             // nil when the model's tokenizer has no tool call tokens.
             var toolCallParser: ToolCallParser? = toolCallMarkers.map {
-                ToolCallParser(open: $0.open, close: $0.close)
+                ToolCallParser(openMarker: $0.open, closeMarker: $0.close)
             }
             var generatedTokenCount: Int = 0
 
@@ -542,6 +542,17 @@ public struct CoreAILanguageModel: LanguageModel {
 
         // MARK: - Transcript → Tokens
 
+        /// Extracts plain text from a segment collection, joining with `separator`.
+        private static func textContent(
+            of segments: some Collection<Transcript.Segment>,
+            separator: String = ""
+        ) -> String {
+            segments.compactMap {
+                if case .text(let t) = $0 { return t.content }
+                return nil
+            }.joined(separator: separator)
+        }
+
         /// Tool call entry for the assistant message's `tool_calls` array.
         private struct ToolCallEntry: Sendable {
             let id: String
@@ -562,42 +573,26 @@ public struct CoreAILanguageModel: LanguageModel {
         /// Handles all entry types including prior tool calls and tool outputs.
         /// Tool definitions are forwarded to `applyChatTemplate` so the model
         /// sees the available functions in the system prompt.
-        static func transcriptToTokens(
-            _ entries: [Transcript.Entry],
+        static func makeTokens(
+            from entries: [Transcript.Entry],
             using tokenizer: any Tokenizer,
             tools: [Transcript.ToolDefinition] = [],
-            component: String = "CoreAIExecutor"
-        ) -> [Int] {
+            component: String = "CoreAIExecutor"        ) -> [Int] {
             var messages: [Message] = []
 
             for entry in entries {
                 switch entry {
                 case .instructions(let instructions):
-                    let text = instructions.segments.compactMap {
-                        if case .text(let t) = $0 { return t.content }
-                        return nil
-                    }.joined(separator: "\n")
-                    if !text.isEmpty {
-                        messages.append(["role": "system", "content": text])
-                    }
+                    let text = textContent(of: instructions.segments, separator: "\n")
+                    if !text.isEmpty { messages.append(["role": "system", "content": text]) }
 
                 case .prompt(let prompt):
-                    let text = prompt.segments.compactMap {
-                        if case .text(let t) = $0 { return t.content }
-                        return nil
-                    }.joined()
-                    if !text.isEmpty {
-                        messages.append(["role": "user", "content": text])
-                    }
+                    let text = textContent(of: prompt.segments)
+                    if !text.isEmpty { messages.append(["role": "user", "content": text]) }
 
                 case .response(let response):
-                    let text = response.segments.compactMap {
-                        if case .text(let t) = $0 { return t.content }
-                        return nil
-                    }.joined()
-                    if !text.isEmpty {
-                        messages.append(["role": "assistant", "content": text])
-                    }
+                    let text = textContent(of: response.segments)
+                    if !text.isEmpty { messages.append(["role": "assistant", "content": text]) }
 
                 case .toolCalls(let toolCalls):
                     let calls = toolCalls.map {
@@ -611,10 +606,7 @@ public struct CoreAILanguageModel: LanguageModel {
 
                 case .toolOutput(let output):
                     // Tool result turn.
-                    let content = output.segments.compactMap { segment -> String? in
-                        if case .text(let t) = segment { return t.content }
-                        return nil
-                    }.joined()
+                    let content = textContent(of: output.segments)
                     messages.append([
                         "role": "tool",
                         "tool_call_id": output.id,

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -35,16 +35,19 @@ public struct CoreAILanguageModel: LanguageModel {
     private let modelIdentifier: String
     private let samplingConfig: SamplingConfiguration
     private let vocabSize: Int?
+    private let supportsToolCalling: Bool
+    private let supportsReasoning: Bool
 
     // MARK: - Protocol Requirements
 
     public typealias Executor = CoreAIExecutor
 
     public var capabilities: LanguageModelCapabilities {
-        if engine.supportsLogits {
-            return LanguageModelCapabilities(capabilities: [.guidedGeneration])
-        }
-        return LanguageModelCapabilities(capabilities: [])
+        var caps: [LanguageModelCapabilities.Capability] = []
+        if supportsToolCalling { caps.append(.toolCalling) }
+        if supportsReasoning   { caps.append(.reasoning) }
+        if engine.supportsLogits { caps.append(.guidedGeneration) }
+        return LanguageModelCapabilities(capabilities: caps)
     }
 
     public var executorConfiguration: CoreAIExecutor.Configuration {
@@ -101,61 +104,13 @@ public struct CoreAILanguageModel: LanguageModel {
         self.modelIdentifier = modelIdentifier
         self.samplingConfig = samplingConfig
         self.vocabSize = vocabSize
-    }
-
-    // MARK: - Helper Methods
-
-    /// Converts transcript entries to tokens using the provided tokenizer.
-    /// Shared implementation used by both `CoreAILanguageModel` and `CoreAIExecutor`.
-    static func transcriptToTokens(
-        _ entries: [Transcript.Entry],
-        using tokenizer: any Tokenizer,
-        component: String = "CoreAILanguageModel"
-    ) -> [Int]? {
-        var messages: [[String: String]] = []
-
-        for entry in entries {
-            switch entry {
-            case .instructions(let instructions):
-                for segment in instructions.segments {
-                    if case .text(let text) = segment {
-                        messages.append(["role": "system", "content": text.content])
-                    }
-                }
-
-            case .prompt(let prompt):
-                for segment in prompt.segments {
-                    if case .text(let text) = segment {
-                        messages.append(["role": "user", "content": text.content])
-                    }
-                }
-
-            case .response(let response):
-                for segment in response.segments {
-                    if case .text(let text) = segment {
-                        messages.append(["role": "assistant", "content": text.content])
-                    }
-                }
-
-            default:
-                continue
-            }
-        }
-
-        if !messages.isEmpty {
-            do {
-                CLILogger.log("Applying chat template via tokenizer", component: component)
-                return try tokenizer.applyChatTemplate(messages: messages)
-            } catch {
-                CLILogger.log(
-                    "Failed to apply chat template: \(error), falling back to simple encoding",
-                    component: component)
-                let text = messages.compactMap { $0["content"] }.joined(separator: "\n")
-                return tokenizer.encode(text: text)
-            }
-        }
-
-        return nil
+        self.supportsToolCalling =
+            tokenizer.convertTokenToId("<tool_call>") != nil
+            || tokenizer.convertTokenToId("<function_calls>") != nil
+            || tokenizer.convertTokenToId("[TOOL_CALLS]") != nil
+        self.supportsReasoning =
+            tokenizer.convertTokenToId("<think>") != nil
+            || tokenizer.convertTokenToId("<|reasoning_start|>") != nil
     }
 
     // MARK: - Executor
@@ -194,8 +149,13 @@ public struct CoreAILanguageModel: LanguageModel {
         /// reasoning, the markers still default to `<think>`/`</think>` and
         /// the parser passes everything through as `.text`.
         private let thinkingMarkers: (open: String, close: String)
+        /// Open / close marker pair the model uses for tool call blocks,
+        /// discovered from the tokenizer's known token ids at init
+        /// (see `detectToolCallMarkers`). nil when the model's tokenizer
+        /// has no tool call tokens.
+        private let toolCallMarkers: (open: String, close: String)?
 
-        // MARK: - Initialization (new API)
+        // MARK: - Initialization
 
         public init(configuration: Configuration) throws {
             self.engine = configuration.engine
@@ -204,6 +164,7 @@ public struct CoreAILanguageModel: LanguageModel {
             self.samplingConfig = configuration.samplingConfig
             self.vocabSize = configuration.vocabSize
             self.thinkingMarkers = Self.detectThinkingMarkers(configuration.tokenizer)
+            self.toolCallMarkers = Self.detectToolCallMarkers(tokenizer: configuration.tokenizer)
         }
 
         /// Probes the tokenizer for known reasoning marker pairs. Each
@@ -232,6 +193,37 @@ public struct CoreAILanguageModel: LanguageModel {
                 }
             }
             return ("<think>", "</think>")
+        }
+
+        /// Probes the tokenizer for known tool call marker pairs. Each
+        /// candidate tag-pair is verified to exist as special tokens via
+        /// `convertTokenToId(_:)`. Returns nil when the model's tokenizer
+        /// has no tool call tokens at all.
+        ///
+        /// Mistral uses `[TOOL_CALLS]` as a single special token with no
+        /// paired close token; `"\n"` is used as a synthetic close because
+        /// the JSON array is always emitted on a single line. The open marker
+        /// matches the bare token without a trailing space — `parseToolCalls`
+        /// already trims leading whitespace so optional spacing is handled.
+        private static func detectToolCallMarkers(
+            tokenizer: any Tokenizer
+        ) -> (open: String, close: String)? {
+            // Standard tag-pair formats — both markers must be special tokens.
+            let tagPairs: [(open: String, close: String)] = [
+                ("<tool_call>", "</tool_call>"),
+                ("<function_calls>", "</function_calls>"),
+            ]
+            for pair in tagPairs where tokenizer.convertTokenToId(pair.open) != nil
+                && tokenizer.convertTokenToId(pair.close) != nil
+            {
+                return pair
+            }
+            // Mistral: [TOOL_CALLS] is a special token but has no paired close token.
+            // Use "\n" as a synthetic close — the JSON array is always on a single line.
+            if tokenizer.convertTokenToId("[TOOL_CALLS]") != nil {
+                return (open: "[TOOL_CALLS]", close: "\n")
+            }
+            return nil
         }
 
         // MARK: - Prewarm
@@ -277,13 +269,13 @@ public struct CoreAILanguageModel: LanguageModel {
         ) async throws {
             // Tokenization span
             let tokenizationSpan = InstrumentsProfiler.beginTokenization(inputLength: 0)
-            guard
-                let promptTokens = CoreAILanguageModel.transcriptToTokens(
-                    Array(request.transcript),
-                    using: tokenizer,
-                    component: "CoreAIExecutor"
-                )
-            else {
+            let promptTokens = Self.transcriptToTokens(
+                Array(request.transcript),
+                using: tokenizer,
+                tools: request.enabledToolDefinitions,
+                component: "CoreAIExecutor"
+            )
+            guard !promptTokens.isEmpty else {
                 tokenizationSpan.end()
                 throw LanguageModelError.unsupportedTranscriptContent(
                     .init(
@@ -303,10 +295,7 @@ public struct CoreAILanguageModel: LanguageModel {
             try await engine.reset()
 
             // FoundationModels now threads entry identity itself based on event
-            // ordering — we no longer mint an entryID and pass it down. Same for
-            // metadata: updateMetadata is available on every entry type, but
-            // we don't emit any from here today (metadata flows from the
-            // upstream PromptCompletion pipeline once that lands).
+            // ordering — we no longer mint an entryID and pass it down.
 
             // Check if guided generation is requested
             if let schema = request.schema {
@@ -358,10 +347,15 @@ public struct CoreAILanguageModel: LanguageModel {
             // its own `Transcript.Reasoning` entry, not mixed into the
             // user-facing `Transcript.Response`. Markers were resolved at
             // executor init from the tokenizer's known token ids.
-            var parser = ThinkTagParser(
+            var thinkParser = ThinkTagParser(
                 open: thinkingMarkers.open,
                 close: thinkingMarkers.close
             )
+            // Routes tool call markup to .toolCalls(...) channel events.
+            // nil when the model's tokenizer has no tool call tokens.
+            var toolCallParser: ToolCallParser? = toolCallMarkers.map {
+                ToolCallParser(open: $0.open, close: $0.close)
+            }
             var generatedTokenCount: Int = 0
 
             for try await output in tokenStream {
@@ -398,8 +392,8 @@ public struct CoreAILanguageModel: LanguageModel {
                     continue
                 }
 
-                for event in parser.consume(delta) {
-                    await dispatch(event, channel: channel)
+                for event in thinkParser.consume(delta) {
+                    await dispatch(event: event, toolCallParser: &toolCallParser, channel: channel)
                 }
 
                 // Retain the last token as O(1) context for the next decode.
@@ -408,7 +402,7 @@ public struct CoreAILanguageModel: LanguageModel {
                 // new token in isolation and drops inter-word spaces.
                 // Keeping one token bounds re-decode cost to 2 tokens per step.
                 // Safe for all supported tokenizers: decode([last]) is a prefix of
-                // decode([last, next]) when addPrefixSpace=true (Mistral, Qwen)
+                // decode([last, next]) when addPrefixSpace=true (Mistral, Llama, Qwen)
                 // and for ByteLevel tokenizers (GPT-2 style) where spaces are direct bytes.
                 if let last = pendingTokens.last {
                     pendingTokens = [last]
@@ -419,11 +413,17 @@ public struct CoreAILanguageModel: LanguageModel {
                 }
             }
 
-            // Flush any buffered content the parser was holding back for a
-            // possible marker match. Without this, content right at the EOS
-            // boundary (or inside an unclosed `<think>` block) would be lost.
-            for event in parser.flush() {
-                await dispatch(event, channel: channel)
+            // Flush parsers — drains any content held back waiting for a marker.
+            // Without this, content right at the EOS boundary (or inside an
+            // unclosed block) would be lost.
+            for event in thinkParser.flush() {
+                await dispatch(event: event, toolCallParser: &toolCallParser, channel: channel)
+            }
+            if var tcp = toolCallParser {
+                for event in tcp.flush() {
+                    await dispatchToolCall(for: event, channel: channel)
+                }
+                toolCallParser = tcp
             }
 
             // Usage telemetry placeholder — awaiting Usage(input:output:) API.
@@ -435,27 +435,65 @@ public struct CoreAILanguageModel: LanguageModel {
             await Task.yield()
         }
 
-        /// Routes a parser event to the matching FoundationModels channel
-        /// event. Text becomes `.response(...).appendText`; reasoning becomes
-        /// a top-level `.reasoning(...).appendText`. Reasoning is a sibling
-        /// of response/tool-calls in the new API (not nested under response)
+        // MARK: - Event Dispatch
+
+        /// Routes a parser event to the matching FoundationModels channel event.
+        /// Text is forwarded to the tool call parser (if present) or emitted as
+        /// `.response(...).appendText`. Reasoning becomes a top-level
+        /// `.reasoning(...).appendText`. Reasoning is a sibling of
+        /// response/tool-calls in the new API (not nested under response)
         /// because at parse time we don't yet know whether the model will
         /// follow the thought block with a response or a tool call.
         ///
         /// We deliberately do not pass `entryID` — FoundationModels threads
         /// entry identity itself based on event ordering.
         private func dispatch(
-            _ event: ThinkTagParser.Event,
+            event: ThinkTagParser.Event,
+            toolCallParser: inout ToolCallParser?,
+            channel: LanguageModelExecutorGenerationChannel
+        ) async {
+            switch event {
+            case .reasoning(let text):
+                await channel.send(
+                    .reasoning(action: .appendText(text, tokenCount: 1))
+                )
+            case .text(let text):
+                if var tcp = toolCallParser {
+                    for toolEvent in tcp.consume(text) {
+                        await dispatchToolCall(for: toolEvent, channel: channel)
+                    }
+                    toolCallParser = tcp
+                } else if !text.isEmpty {
+                    await channel.send(
+                        .response(action: .appendText(text, tokenCount: 1))
+                    )
+                }
+            }
+        }
+
+        private func dispatchToolCall(
+            for event: ToolCallParser.Event,
             channel: LanguageModelExecutorGenerationChannel
         ) async {
             switch event {
             case .text(let text):
+                if !text.isEmpty {
+                    await channel.send(
+                        .response(action: .appendText(text, tokenCount: 1))
+                    )
+                }
+            case .toolCall(let id, let name, let argsJSON):
+                CLILogger.log(
+                    "ToolCallParser: dispatching tool call id=\(id) name=\(name) args=\(argsJSON)",
+                    component: "CoreAIExecutor")
                 await channel.send(
-                    .response(action: .appendText(text, tokenCount: 1))
-                )
-            case .reasoning(let text):
-                await channel.send(
-                    .reasoning(action: .appendText(text, tokenCount: 1))
+                    .toolCalls(
+                        action: .toolCall(
+                            id: id,
+                            name: name,
+                            action: .appendArguments(argsJSON, tokenCount: 1)
+                        )
+                    )
                 )
             }
         }
@@ -503,6 +541,175 @@ public struct CoreAILanguageModel: LanguageModel {
             // Yield to let the engine's tokenSequence Task finish cleanup
             // (putBackEngine, state reset, etc.) before the next respond().
             await Task.yield()
+        }
+
+        // MARK: - Transcript → Tokens
+
+        /// Tool call entry for the assistant message's `tool_calls` array.
+        private struct ToolCallEntry: Sendable {
+            let id: String
+            let name: String
+            let arguments: String
+
+            var message: [String: any Sendable] {
+                [
+                    "id": id,
+                    "type": "function",
+                    "function": ["name": name, "arguments": arguments] as [String: any Sendable],
+                ]
+            }
+        }
+
+        /// Converts transcript entries to tokens using the provided tokenizer.
+        ///
+        /// Handles all entry types including prior tool calls and tool outputs.
+        /// Tool definitions are forwarded to `applyChatTemplate` so the model
+        /// sees the available functions in the system prompt.
+        static func transcriptToTokens(
+            _ entries: [Transcript.Entry],
+            using tokenizer: any Tokenizer,
+            tools: [Transcript.ToolDefinition] = [],
+            component: String = "CoreAIExecutor"
+        ) -> [Int] {
+            var messages: [Message] = []
+
+            for entry in entries {
+                switch entry {
+                case .instructions(let instructions):
+                    let text = instructions.segments.compactMap {
+                        if case .text(let t) = $0 { return t.content }
+                        return nil
+                    }.joined(separator: "\n")
+                    if !text.isEmpty {
+                        messages.append(["role": "system", "content": text])
+                    }
+
+                case .prompt(let prompt):
+                    let text = prompt.segments.compactMap {
+                        if case .text(let t) = $0 { return t.content }
+                        return nil
+                    }.joined()
+                    if !text.isEmpty {
+                        messages.append(["role": "user", "content": text])
+                    }
+
+                case .response(let response):
+                    let text = response.segments.compactMap {
+                        if case .text(let t) = $0 { return t.content }
+                        return nil
+                    }.joined()
+                    if !text.isEmpty {
+                        messages.append(["role": "assistant", "content": text])
+                    }
+
+                case .toolCalls(let toolCalls):
+                    let calls = toolCalls.map {
+                        ToolCallEntry(id: $0.id, name: $0.toolName, arguments: $0.arguments.jsonString)
+                    }
+                    messages.append([
+                        "role": "assistant",
+                        "content": "" as any Sendable,
+                        "tool_calls": calls.map(\.message) as any Sendable,
+                    ])
+
+                case .toolOutput(let output):
+                    // Tool result turn.
+                    let content = output.segments.compactMap { segment -> String? in
+                        if case .text(let t) = segment { return t.content }
+                        return nil
+                    }.joined()
+                    messages.append([
+                        "role": "tool",
+                        "tool_call_id": output.id,
+                        "name": output.toolName,
+                        "content": content,
+                    ])
+
+                case .reasoning:
+                    // Don't echo the model's prior reasoning back into the prompt.
+                    continue
+
+                @unknown default:
+                    continue
+                }
+            }
+
+            if messages.isEmpty { return [] }
+
+            let toolSpecs: [ToolSpec]? = tools.isEmpty ? nil : tools.compactMap { makeToolSpec(from: $0) }
+
+            do {
+                CLILogger.log("Applying chat template via tokenizer", component: component)
+                return try tokenizer.applyChatTemplate(messages: messages, tools: toolSpecs)
+            } catch {
+                CLILogger.log(
+                    "Failed to apply chat template: \(error), falling back to simple encoding",
+                    component: component)
+                let text = messages.compactMap { $0["content"] as? String }.joined(separator: "\n")
+                return tokenizer.encode(text: text)
+            }
+        }
+
+        /// Converts a `ToolDefinition` into the `ToolSpec` format expected by
+        /// `applyChatTemplate`. Parameters are decoded into a typed `JSONValue`
+        /// tree — avoids passing raw `Any` through the codebase.
+        private static func makeToolSpec(from definition: Transcript.ToolDefinition) -> ToolSpec? {
+            guard
+                let schemaData = try? JSONEncoder().encode(definition.parameters),
+                let rawObj = try? JSONSerialization.jsonObject(with: schemaData),
+                let dict = rawObj as? [String: Any]
+            else {
+                CLILogger.log(
+                    "Failed to encode parameters for tool '\(definition.name)'",
+                    component: "CoreAIExecutor")
+                return nil
+            }
+            let function: [String: any Sendable] = [
+                "name": definition.name,
+                "description": definition.description,
+                "parameters": dict.mapValues { JSONValue($0).sendable },
+            ]
+            return ["type": "function", "function": function]
+        }
+
+        /// Typed, `Sendable` representation of an arbitrary JSON value.
+        ///
+        /// Bridges the `NSObject`-bridged output of `JSONSerialization` into an
+        /// explicit Swift enum so nothing untyped escapes into the rest of the code.
+        private indirect enum JSONValue: Sendable {
+            case string(String)
+            case int(Int)
+            case double(Double)
+            case bool(Bool)
+            case array([JSONValue])
+            case object([String: JSONValue])
+            case null
+
+            init(_ value: Any) {
+                switch value {
+                case let s as String:        self = .string(s)
+                case let n as NSNumber where CFGetTypeID(n) == CFBooleanGetTypeID():
+                    self = .bool(n.boolValue)
+                case let n as NSNumber:
+                    let d = n.doubleValue
+                    self = (d == d.rounded() && !d.isInfinite) ? .int(n.intValue) : .double(d)
+                case let a as [Any]:         self = .array(a.map { JSONValue($0) })
+                case let o as [String: Any]: self = .object(o.mapValues { JSONValue($0) })
+                default:                     self = .null
+                }
+            }
+
+            var sendable: any Sendable {
+                switch self {
+                case .string(let v): return v
+                case .int(let v):    return v
+                case .double(let v): return v
+                case .bool(let v):   return v
+                case .null:          return NSNull()
+                case .array(let v):  return v.map(\.sendable)
+                case .object(let v): return v.mapValues(\.sendable)
+                }
+            }
         }
 
         // MARK: - Helper Methods

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -104,10 +104,7 @@ public struct CoreAILanguageModel: LanguageModel {
         self.modelIdentifier = modelIdentifier
         self.samplingConfig = samplingConfig
         self.vocabSize = vocabSize
-        self.supportsToolCalling =
-            tokenizer.convertTokenToId("<tool_call>") != nil
-            || tokenizer.convertTokenToId("<function_calls>") != nil
-            || tokenizer.convertTokenToId("[TOOL_CALLS]") != nil
+        self.supportsToolCalling = CoreAIExecutor.detectToolCallMarkers(tokenizer: tokenizer) != nil
         self.supportsReasoning =
             tokenizer.convertTokenToId("<think>") != nil
             || tokenizer.convertTokenToId("<|reasoning_start|>") != nil
@@ -205,7 +202,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// the JSON array is always emitted on a single line. The open marker
         /// matches the bare token without a trailing space — `parseToolCalls`
         /// already trims leading whitespace so optional spacing is handled.
-        private static func detectToolCallMarkers(
+        fileprivate static func detectToolCallMarkers(
             tokenizer: any Tokenizer
         ) -> (open: String, close: String)? {
             // Standard tag-pair formats — both markers must be special tokens.

--- a/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
+++ b/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
@@ -15,11 +15,11 @@ struct ToolCallParser {
     private let openMarker: String
     private let closeMarker: String
     private var buffer: String = ""
-    private var insideToolCall: Bool = false
+    private var isInsideToolCall: Bool = false
 
-    init(open: String = "<tool_call>", close: String = "</tool_call>") {
-        self.openMarker = open
-        self.closeMarker = close
+    init(openMarker: String = "<tool_call>", closeMarker: String = "</tool_call>") {
+        self.openMarker = openMarker
+        self.closeMarker = closeMarker
     }
 
     mutating func consume(_ delta: String) -> [Event] {
@@ -40,21 +40,17 @@ struct ToolCallParser {
 
     private mutating func drain(isFinal: Bool) -> [Event] {
         var events: [Event] = []
-        while true {
-            let marker = insideToolCall ? closeMarker : openMarker
-            if let range = buffer.range(of: marker) {
-                processMarker(at: range, events: &events)
-                insideToolCall.toggle()
-            } else {
-                processRemainder(isFinal: isFinal, events: &events)
-                return events
-            }
+        while let range = buffer.range(of: isInsideToolCall ? closeMarker : openMarker) {
+            processMarker(at: range, events: &events)
+            isInsideToolCall.toggle()
         }
+        processRemainder(of: &events, isFinal: isFinal)
+        return events
     }
 
     private mutating func processMarker(at range: Range<String.Index>, events: inout [Event]) {
         let before = String(buffer[buffer.startIndex..<range.lowerBound])
-        if insideToolCall {
+        if isInsideToolCall {
             events.append(contentsOf: parseToolCalls(from: before))
         } else if !before.isEmpty {
             events.append(.text(before))
@@ -62,8 +58,8 @@ struct ToolCallParser {
         buffer = String(buffer[range.upperBound...])
     }
 
-    private mutating func processRemainder(isFinal: Bool, events: inout [Event]) {
-        if insideToolCall {
+    private mutating func processRemainder(of events: inout [Event], isFinal: Bool) {
+        if isInsideToolCall {
             guard isFinal else { return }
             // Newline-terminated formats (e.g. Mistral) have no dedicated close
             // token — the block ends at EOS. Try to parse what we have.
@@ -133,4 +129,3 @@ struct ToolCallParser {
         return buffer.endIndex
     }
 }
-

--- a/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
+++ b/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
@@ -1,0 +1,136 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+
+/// Streaming parser that detects tool call blocks in the model's token stream.
+struct ToolCallParser {
+    enum Event {
+        case text(String)
+        case toolCall(id: String, name: String, argsJSON: String)
+    }
+
+    private let openMarker: String
+    private let closeMarker: String
+    private var buffer: String = ""
+    private var insideToolCall: Bool = false
+
+    init(open: String = "<tool_call>", close: String = "</tool_call>") {
+        self.openMarker = open
+        self.closeMarker = close
+    }
+
+    mutating func consume(_ delta: String) -> [Event] {
+        buffer.append(delta)
+        return drain(isFinal: false)
+    }
+
+    /// Emit any pending buffered content as final events.
+    ///
+    /// Required at end of stream — without it, text held back to wait for a
+    /// possible marker match is silently lost. An unclosed `<tool_call>` block
+    /// at EOS is dropped (malformed JSON is not useful to surface as text).
+    /// Exception: newline-terminated formats (e.g. Mistral's `[TOOL_CALLS]`)
+    /// have no trailing close token, so the buffered content is parsed on EOS.
+    mutating func flush() -> [Event] {
+        drain(isFinal: true)
+    }
+
+    private mutating func drain(isFinal: Bool) -> [Event] {
+        var events: [Event] = []
+        while true {
+            let marker = insideToolCall ? closeMarker : openMarker
+            if let range = buffer.range(of: marker) {
+                processMarker(at: range, events: &events)
+                insideToolCall.toggle()
+            } else {
+                processRemainder(isFinal: isFinal, events: &events)
+                return events
+            }
+        }
+    }
+
+    private mutating func processMarker(at range: Range<String.Index>, events: inout [Event]) {
+        let before = String(buffer[buffer.startIndex..<range.lowerBound])
+        if insideToolCall {
+            events.append(contentsOf: parseToolCalls(from: before))
+        } else if !before.isEmpty {
+            events.append(.text(before))
+        }
+        buffer = String(buffer[range.upperBound...])
+    }
+
+    private mutating func processRemainder(isFinal: Bool, events: inout [Event]) {
+        if insideToolCall {
+            guard isFinal else { return }
+            // Newline-terminated formats (e.g. Mistral) have no dedicated close
+            // token — the block ends at EOS. Try to parse what we have.
+            // For tag-pair formats, an unclosed block is malformed: drop it.
+            if closeMarker == "\n" {
+                events.append(contentsOf: parseToolCalls(from: buffer))
+            }
+            buffer = ""
+        } else {
+            let safe = isFinal ? buffer.endIndex : lastSafeIndex(for: openMarker)
+            if safe > buffer.startIndex {
+                let toEmit = String(buffer[buffer.startIndex..<safe])
+                if !toEmit.isEmpty { events.append(.text(toEmit)) }
+                buffer = String(buffer[safe...])
+            }
+        }
+    }
+
+    /// Single object `{"name":..}` (Qwen3) or array `[{"name":..},..]` (Mistral).
+    private func parseToolCalls(from json: String) -> [Event] {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8) else { return [] }
+
+        if trimmed.hasPrefix("["),
+            let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        {
+            return array.compactMap { makeToolCallEvent(from: $0) }
+        }
+
+        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return makeToolCallEvent(from: obj).map { [$0] } ?? []
+        }
+
+        return []
+    }
+
+    private func makeToolCallEvent(from obj: [String: Any]) -> Event? {
+        guard let name = obj["name"] as? String else { return nil }
+
+        let argsJSON: String
+        if let argsDict = obj["arguments"] as? [String: Any],
+            let argsData = try? JSONSerialization.data(withJSONObject: argsDict),
+            let argsStr = String(data: argsData, encoding: .utf8)
+        {
+            argsJSON = argsStr
+        } else if let argsStr = obj["arguments"] as? String {
+            argsJSON = argsStr
+        } else {
+            argsJSON = "{}"
+        }
+
+        return .toolCall(id: UUID().uuidString, name: name, argsJSON: argsJSON)
+    }
+
+    /// Rightmost index such that the suffix from there to end-of-buffer is NOT
+    /// a non-empty prefix of `tag`. Same implementation as `ThinkTagParser`.
+    private func lastSafeIndex(for tag: String) -> String.Index {
+        let maxHold = tag.count - 1
+        guard !buffer.isEmpty, maxHold > 0 else { return buffer.endIndex }
+        let holdStart = buffer.index(buffer.endIndex, offsetBy: -min(maxHold, buffer.count))
+        for offset in 0..<buffer.distance(from: holdStart, to: buffer.endIndex) {
+            let idx = buffer.index(holdStart, offsetBy: offset)
+            if tag.starts(with: buffer[idx...]) {
+                return idx
+            }
+        }
+        return buffer.endIndex
+    }
+}
+


### PR DESCRIPTION
## Purpose

Models like Qwen3 emit tool calls as inline markup mixed into the token stream:

```tool_call
<tool_call>{"name":"get_weather","arguments":{"city":"London"}}</tool_call>
```

Without interception, this markup leaks into `response.content` as plain text and the FoundationModels session never invokes the tool. This PR routes tool call blocks to the correct FM channel events so `LanguageModelSession` tool calling works end-to-end with CoreAI-backed models.

## Changes

**`ToolCallParser.swift`** — new streaming state machine that splits the token stream at configurable open/close markers. Emits `.text` or `.toolCall(id:name:argsJSON:)` events. Handles both Qwen3's `<tool_call>...</tool_call>` tag-pair format and Mistral's `[TOOL_CALLS] [{...}]` single-line array format.

**`CoreAILanguageModel.swift`** — three additions:
- `CoreAIExecutor` detects tool call markers from the tokenizer vocabulary at init and wires `ToolCallParser` into the generation pipeline (`ThinkTagParser` → `ToolCallParser` → channel)
- `transcriptToTokens` now handles `.toolCalls` and `.toolOutput` transcript entries, serializing them for the chat template so multi-turn tool-use history is correctly formatted on each subsequent turn
- `capabilities` is now tokenizer-aware: `.toolCalling` and `.reasoning` are only advertised when the tokenizer's vocabulary contains the corresponding special tokens
## Usage

Standard `LanguageModelSession` with tools 🎉 

```swift
import FoundationModels
import CoreAILanguageModels

struct WeatherTool: Tool {
    let name = "get_weather"
    let description = "Returns the current weather for a city."

    func call(arguments: GeneratedContent) async throws -> String {
        let city = try arguments.value(String.self, forProperty: "city")
        return "72°F and sunny in \(city)."
    }
}

let model = try await CoreAILanguageModel(resourcesAt: modelURL)
let session = LanguageModelSession(model: model, tools: [WeatherTool()])

let response = try await session.respond(
    to: "What's the weather in Cupertino?"
)
// response.content contains the model's final answer after tool execution
print(response.content)
```
