### PR TITLE
Fix --platform filter being ignored for utility models

### DIFF
--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -14,7 +14,7 @@ CLI:
     uv run coreai.model.registry --model-info clip-vit-b32 --type utility --as-export-args
 
 `--type` selects the preset table (`llm`, `diffusion`, or `utility`).
-`--platform` (`macOS` / `iOS`) is meaningful for LLM only.
+`--platform` (`macOS` / `iOS`) filters LLM variants and utility model platforms.
 """
 
 from __future__ import annotations
@@ -508,12 +508,15 @@ def filter_utility_models(
     *,
     model_type: str | None = None,
     task: str | None = None,
+    platform: str | None = None,
 ) -> list[UtilityModel]:
     out: list[UtilityModel] = []
     for u in UTILITY_PRESETS:
         if model_type is not None and u.model_type != model_type:
             continue
         if task is not None and u.task != task:
+            continue
+        if platform is not None and platform not in u.platforms:
             continue
         out.append(u)
     return out
@@ -649,7 +652,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--platform",
         choices=KNOWN_VARIANTS,
-        help="Platform filter (macOS / iOS). LLM-only; "
+        help="Platform filter (macOS / iOS). Filters LLM variants and utility model platforms; "
         "diffusion entries are excluded when --platform is set.",
     )
     parser.add_argument(
@@ -757,7 +760,7 @@ def _action_list_families(args: argparse.Namespace) -> None:
 
 
 def _action_list_utility_models(args: argparse.Namespace) -> None:
-    models = filter_utility_models(model_type=args.family, task=args.task)
+    models = filter_utility_models(model_type=args.family, task=args.task, platform=args.platform)
     if args.format == "json":
         print(json.dumps([asdict(u) for u in models], indent=2))
     elif args.format == "tsv":
@@ -801,7 +804,9 @@ def _action_list_models(args: argparse.Namespace) -> None:
         if args.type:
             print(json.dumps([asdict(p) for p in presets], indent=2))
         else:
-            util = filter_utility_models(model_type=args.family, task=args.task)
+            util = filter_utility_models(
+                model_type=args.family, task=args.task, platform=args.platform
+            )
             combined = [asdict(p) for p in presets] + [asdict(u) for u in util]
             print(json.dumps(combined, indent=2))
     elif args.format == "tsv":
@@ -816,7 +821,9 @@ def _action_list_models(args: argparse.Namespace) -> None:
             ]
             print("\t".join(cols))
         if not args.type:
-            for u in filter_utility_models(model_type=args.family, task=args.task):
+            for u in filter_utility_models(
+                model_type=args.family, task=args.task, platform=args.platform
+            ):
                 print(
                     "\t".join(
                         [
@@ -844,7 +851,7 @@ def _action_list_models(args: argparse.Namespace) -> None:
 def _print_all_tables(presets: list[ModelPreset], args: argparse.Namespace) -> None:
     llm = [p for p in presets if p.type == "llm"]
     diffusion = [p for p in presets if p.type == "diffusion"]
-    util = filter_utility_models(model_type=args.family, task=args.task)
+    util = filter_utility_models(model_type=args.family, task=args.task, platform=args.platform)
 
     if llm:
         print("=== LLM ===")
@@ -914,6 +921,9 @@ def _action_utility_model_info(args: argparse.Namespace) -> None:
     model = lookup_utility_model(args.model_info)
     if not model:
         sys.stderr.write(f"Error: no utility model {args.model_info!r}\n")
+        sys.exit(1)
+    if args.platform is not None and args.platform not in model.platforms:
+        sys.stderr.write(f"Error: model {args.model_info!r} has no --platform {args.platform!r}\n")
         sys.exit(1)
     if args.format == "export-args":
         print(" ".join(_utility_to_export_args(model)))

--- a/python/tests/test_model_units/test_model_registry.py
+++ b/python/tests/test_model_units/test_model_registry.py
@@ -16,6 +16,7 @@ from coreai_models.model_registry import (
     _preset_to_export_args,
     _preset_to_output_name,
     filter_presets,
+    filter_utility_models,
     lookup_preset,
     presets_for_type,
     try_lookup_preset,
@@ -168,3 +169,10 @@ def test_try_lookup_with_explicit_variant() -> None:
     result = try_lookup_preset("qwen3-0.6b", model_type="llm", variant="iOS")
     assert result is not None
     assert result.variant == "iOS"
+
+
+def test_utility_platform_filter_excludes_macos_only() -> None:
+    ios_models = filter_utility_models(platform="iOS")
+    names = [u.short_name for u in ios_models]
+    assert "depth-anything-3-small" not in names
+    assert "clip-vit-b32" in names


### PR DESCRIPTION
The registry CLI accepted --platform for utility model queries but never applied it, causing macOS-only models to appear in iOS-filtered results.

Closes apple/coreai-models#2