### PR TITLE
Add InferenceStream with StopReason for structured generation termination

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -87,7 +87,7 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
         with input: [TokenId],
         samplingConfiguration: SamplingConfiguration,
         inferenceOptions: InferenceOptions
-    ) throws -> some AsyncSequence<InferenceOutput, Error> {
+    ) throws -> InferenceStream {
         if inferenceOptions.includeLogits {
             throw InferenceRuntimeError.invalidArgument(
                 "CoreAI pipelined engine does not support logits (GPU-side sampling). "
@@ -101,18 +101,14 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
             )
         }
         let maxTokens = inferenceOptions.maxTokens
-        let (stream, outputContinuation) = AsyncThrowingStream<InferenceOutput, any Error>.makeStream()
+        let (inferenceStream, outputContinuation) = InferenceStream.makeStream()
         Task {
             self.acquireEngine()
             defer { self.releaseEngine() }
             do {
-                // Bridge: runCompletion yields TokenId via a TokenId continuation.
-                // We wrap each token into InferenceOutput in the yield callback.
                 let (tokenStream, tokenContinuation) =
                     AsyncThrowingStream<InferenceEngine.TokenId, any Error>.makeStream()
 
-                // Forward tokens from tokenStream → outputContinuation as InferenceOutput.
-                // This must run concurrently with runCompletion.
                 async let forwarding: Void = {
                     do {
                         for try await token in tokenStream {
@@ -131,12 +127,17 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
                 )
                 tokenContinuation.finish()
                 await forwarding
+                inferenceStream.setStopReason(.maxTokens)
+                outputContinuation.finish()
+            } catch is CancellationError {
+                inferenceStream.setStopReason(.cancelled)
                 outputContinuation.finish()
             } catch {
+                inferenceStream.setStopReason(.error)
                 outputContinuation.finish(throwing: error)
             }
         }
-        return stream
+        return inferenceStream
     }
 
     /// Wait for any in-flight generate() Task to return the engine.

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
@@ -338,72 +338,77 @@ public final class CoreAISequentialEngine: InferenceEngine, @unchecked Sendable 
         with input: [TokenId],
         samplingConfiguration: SamplingConfiguration,
         inferenceOptions: InferenceOptions
-    ) throws -> some AsyncSequence<InferenceOutput, Error> {
-        AsyncThrowingStream { continuation in
-            Task {
-                self.generating.withLock { $0 = true }
-                defer { self.generating.withLock { $0 = false } }
-                do {
-                    let maxTokens: Int
-                    if let forced = inferenceOptions.forcedContinuation {
-                        maxTokens = forced.count
-                    } else {
-                        maxTokens = min(
-                            inferenceOptions.maxTokens ?? Int.max,
-                            max(0, self.config.maxContextLength - input.count)
-                        )
-                    }
-                    let returnsLogits = inferenceOptions.includeLogits
-                    var inputTokens = input
-
-                    for i in 0..<maxTokens {
-                        try Task.checkCancellation()
-
-                        guard self.processedTokenCount < inputTokens.count else {
-                            throw InferenceRuntimeError.invalidState("No new tokens to process")
-                        }
-
-                        let newTokens = inputTokens[self.processedTokenCount...]
-                        let strategy = self.selectPrefillStrategy(newTokenCount: newTokens.count)
-
-                        let logitBuffer: [LogitsScalarType]
-                        switch strategy {
-                        case .chunked(let chunkSize):
-                            logitBuffer = try await self.processChunkedPrompt(
-                                tokens: newTokens, chunkSize: chunkSize)
-                        case .wholeBatch:
-                            let allLogits = try await self.processTokenBatch(newTokens)
-                            logitBuffer = lastTokenLogits(
-                                from: allLogits, vocabSize: self.config.vocabSize)
-                        case .oneAtATime:
-                            var lastLogits: [LogitsScalarType] = []
-                            for j in newTokens.indices {
-                                lastLogits = try await self.processTokenBatch(newTokens[j...j])
-                            }
-                            logitBuffer = lastLogits
-                        }
-
-                        let nextToken: Int32
-                        if let forced = inferenceOptions.forcedContinuation {
-                            nextToken = forced[i]
-                        } else {
-                            var mutableLogits = logitBuffer
-                            nextToken = samplingConfiguration.fallbackSampler(from: &mutableLogits)
-                        }
-
-                        continuation.yield(
-                            InferenceOutput(
-                                tokenId: nextToken,
-                                logits: returnsLogits ? logitBuffer : nil
-                            ))
-                        inputTokens.append(nextToken)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
+    ) throws -> InferenceStream {
+        let (stream, continuation) = InferenceStream.makeStream()
+        Task {
+            self.generating.withLock { $0 = true }
+            defer { self.generating.withLock { $0 = false } }
+            do {
+                let maxTokens: Int
+                if let forced = inferenceOptions.forcedContinuation {
+                    maxTokens = forced.count
+                } else {
+                    maxTokens = min(
+                        inferenceOptions.maxTokens ?? Int.max,
+                        max(0, self.config.maxContextLength - input.count)
+                    )
                 }
+                let returnsLogits = inferenceOptions.includeLogits
+                var inputTokens = input
+
+                for i in 0..<maxTokens {
+                    try Task.checkCancellation()
+
+                    guard self.processedTokenCount < inputTokens.count else {
+                        throw InferenceRuntimeError.invalidState("No new tokens to process")
+                    }
+
+                    let newTokens = inputTokens[self.processedTokenCount...]
+                    let strategy = self.selectPrefillStrategy(newTokenCount: newTokens.count)
+
+                    let logitBuffer: [LogitsScalarType]
+                    switch strategy {
+                    case .chunked(let chunkSize):
+                        logitBuffer = try await self.processChunkedPrompt(
+                            tokens: newTokens, chunkSize: chunkSize)
+                    case .wholeBatch:
+                        let allLogits = try await self.processTokenBatch(newTokens)
+                        logitBuffer = lastTokenLogits(
+                            from: allLogits, vocabSize: self.config.vocabSize)
+                    case .oneAtATime:
+                        var lastLogits: [LogitsScalarType] = []
+                        for j in newTokens.indices {
+                            lastLogits = try await self.processTokenBatch(newTokens[j...j])
+                        }
+                        logitBuffer = lastLogits
+                    }
+
+                    let nextToken: Int32
+                    if let forced = inferenceOptions.forcedContinuation {
+                        nextToken = forced[i]
+                    } else {
+                        var mutableLogits = logitBuffer
+                        nextToken = samplingConfiguration.fallbackSampler(from: &mutableLogits)
+                    }
+
+                    continuation.yield(
+                        InferenceOutput(
+                            tokenId: nextToken,
+                            logits: returnsLogits ? logitBuffer : nil
+                        ))
+                    inputTokens.append(nextToken)
+                }
+                stream.setStopReason(.maxTokens)
+                continuation.finish()
+            } catch is CancellationError {
+                stream.setStopReason(.cancelled)
+                continuation.finish()
+            } catch {
+                stream.setStopReason(.error)
+                continuation.finish(throwing: error)
             }
         }
+        return stream
     }
 
     // MARK: - Lifecycle

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -316,48 +316,51 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         with input: [TokenId],
         samplingConfiguration: SamplingConfiguration,
         inferenceOptions: InferenceOptions
-    ) throws -> some AsyncSequence<InferenceOutput, Error> {
-        AsyncThrowingStream { continuation in
-            Task {
-                do {
-                    let forced = inferenceOptions.forcedContinuation
-                    let maxTokens: Int
-                    if let forced {
-                        maxTokens = forced.count
-                    } else {
-                        maxTokens = min(
-                            inferenceOptions.maxTokens ?? Int.max,
-                            max(0, self.config.maxContextLength - input.count)
-                        )
-                    }
-                    let returnsLogits = inferenceOptions.includeLogits
-                    var inputTokens = input
-
-                    for i in 0..<maxTokens {
-                        try Task.checkCancellation()
-                        // When forced, we still need the forward pass (for logits + KV cache update)
-                        // but skip the sampler — the next token is predetermined.
-                        let (logits, sampledToken) = try await self.inference(
-                            inputTokens: inputTokens,
-                            samplingConfig: samplingConfiguration,
-                            returnsLogits: returnsLogits || forced != nil
-                        )
-
-                        let nextToken = forced?[i] ?? sampledToken
-
-                        continuation.yield(
-                            InferenceOutput(
-                                tokenId: nextToken,
-                                logits: returnsLogits ? logits : nil
-                            ))
-                        inputTokens.append(nextToken)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
+    ) throws -> InferenceStream {
+        let (stream, continuation) = InferenceStream.makeStream()
+        Task {
+            do {
+                let forced = inferenceOptions.forcedContinuation
+                let maxTokens: Int
+                if let forced {
+                    maxTokens = forced.count
+                } else {
+                    maxTokens = min(
+                        inferenceOptions.maxTokens ?? Int.max,
+                        max(0, self.config.maxContextLength - input.count)
+                    )
                 }
+                let returnsLogits = inferenceOptions.includeLogits
+                var inputTokens = input
+
+                for i in 0..<maxTokens {
+                    try Task.checkCancellation()
+                    let (logits, sampledToken) = try await self.inference(
+                        inputTokens: inputTokens,
+                        samplingConfig: samplingConfiguration,
+                        returnsLogits: returnsLogits || forced != nil
+                    )
+
+                    let nextToken = forced?[i] ?? sampledToken
+
+                    continuation.yield(
+                        InferenceOutput(
+                            tokenId: nextToken,
+                            logits: returnsLogits ? logits : nil
+                        ))
+                    inputTokens.append(nextToken)
+                }
+                stream.setStopReason(.maxTokens)
+                continuation.finish()
+            } catch is CancellationError {
+                stream.setStopReason(.cancelled)
+                continuation.finish()
+            } catch {
+                stream.setStopReason(.error)
+                continuation.finish(throwing: error)
             }
         }
+        return stream
     }
 
     // MARK: - Inference

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/InferenceEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/InferenceEngine.swift
@@ -85,7 +85,6 @@ public enum ConfigurationError: Error, LocalizedError {
 ///
 /// KV cache is preserved between `generate()` calls. Call `reset()` to clear.
 public protocol InferenceEngine: Sendable {
-    associatedtype OutputSequence: AsyncSequence<InferenceOutput, Error>
     typealias TokenId = Int32
 
     // MARK: - Primary API
@@ -96,12 +95,12 @@ public protocol InferenceEngine: Sendable {
     ///   - input: Token IDs (prompt, context, or continuation).
     ///   - sampling: Sampling configuration (temperature, topK, etc.).
     ///   - generation: Inference options (maxTokens, includeLogits).
-    /// - Returns: Async sequence of `InferenceOutput`.
+    /// - Returns: `InferenceStream` — iterate for tokens, read `stopReason` after.
     func generate(
         with input: [TokenId],
         samplingConfiguration: SamplingConfiguration,
         inferenceOptions: InferenceOptions
-    ) throws -> OutputSequence
+    ) throws -> InferenceStream
 
     // MARK: - Lifecycle
 

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/InferenceStream.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/InferenceStream.swift
@@ -1,0 +1,93 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Synchronization
+
+/// Concrete async sequence returned by `InferenceEngine.generate()`.
+///
+/// Wraps an `AsyncThrowingStream<InferenceOutput, any Error>` and tracks
+/// why generation ended. Reference type — the producer sets `stopReason`
+/// and the consumer reads it after iteration.
+public final class InferenceStream: AsyncSequence, Sendable {
+    public typealias Element = InferenceOutput
+
+    // MARK: - StopReason
+
+    /// Why token generation terminated.
+    public enum StopReason: Sendable, Equatable {
+        /// The maximum token limit was reached.
+        case maxTokens
+        /// An end-of-sequence token was generated.
+        case eos
+        /// A stop sequence was matched in the output.
+        case stopSequence(String)
+        /// Generation was cancelled (Task cancellation or explicit cancel).
+        case cancelled
+        /// An unrecoverable error occurred during generation.
+        case error
+    }
+
+    // MARK: - Init
+
+    private let base: AsyncThrowingStream<InferenceOutput, any Error>
+    private let _stopReason: Mutex<StopReason?>
+
+    init(base: AsyncThrowingStream<InferenceOutput, any Error>) {
+        self.base = base
+        self._stopReason = Mutex(nil)
+    }
+
+    // MARK: - Public API
+
+    /// Why generation stopped. Nil while the stream is still active.
+    /// Guaranteed non-nil after the `for try await` loop exits.
+    public var stopReason: StopReason? {
+        _stopReason.withLock { $0 }
+    }
+
+    // MARK: - Package-internal
+
+    /// Engines and decoders call this when they know why generation ended.
+    func setStopReason(_ reason: StopReason) {
+        _stopReason.withLock { $0 = reason }
+    }
+
+    // MARK: - Factory
+
+    /// Create a stream + continuation pair for engines to drive.
+    static func makeStream() -> (
+        stream: InferenceStream,
+        continuation: AsyncThrowingStream<InferenceOutput, any Error>.Continuation
+    ) {
+        let (base, continuation) = AsyncThrowingStream<InferenceOutput, any Error>.makeStream()
+        return (InferenceStream(base: base), continuation)
+    }
+
+    // MARK: - AsyncSequence
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        var base: AsyncThrowingStream<InferenceOutput, any Error>.AsyncIterator
+        let stream: InferenceStream
+
+        public mutating func next() async throws -> InferenceOutput? {
+            do {
+                guard let element = try await base.next() else {
+                    return nil
+                }
+                return element
+            } catch is CancellationError {
+                stream.setStopReason(.cancelled)
+                throw CancellationError()
+            } catch {
+                stream.setStopReason(.error)
+                throw error
+            }
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(base: base.makeAsyncIterator(), stream: self)
+    }
+}

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -355,10 +355,14 @@ public struct CoreAILanguageModel: LanguageModel {
                 ToolCallParser(openMarker: $0.open, closeMarker: $0.close)
             }
             var generatedTokenCount: Int = 0
+            var reasoningTokenCount: Int = 0
 
             for try await output in tokenStream {
                 let token = output.tokenId
-                if let eos = eosTokenId, Int(token) == eos { break }
+                if let eos = eosTokenId, Int(token) == eos {
+                    tokenStream.setStopReason(.eos)
+                    break
+                }
 
                 pendingTokens.append(token)
                 tokenStep += 1
@@ -391,6 +395,7 @@ public struct CoreAILanguageModel: LanguageModel {
                 }
 
                 for event in thinkParser.consume(delta) {
+                    if case .reasoning = event { reasoningTokenCount += 1 }
                     await dispatch(event: event, toolCallParser: &toolCallParser, channel: channel)
                 }
 
@@ -424,9 +429,13 @@ public struct CoreAILanguageModel: LanguageModel {
                 toolCallParser = tcp
             }
 
-            // Usage telemetry placeholder — awaiting Usage(input:output:) API.
-            _ = promptTokens.count
-            _ = generatedTokenCount
+            await channel.send(.response(action: .updateUsage(
+                input: .init(totalTokenCount: promptTokens.count, cachedTokenCount: 0),
+                output: .init(
+                    totalTokenCount: generatedTokenCount,
+                    reasoningTokenCount: reasoningTokenCount
+                )
+            )))
 
             // Yield to let the engine's tokenSequence Task finish cleanup
             // (putBackEngine, state reset, etc.) before the next respond().

--- a/swift/Tests/LanguageModelsTests/InferenceStreamTests.swift
+++ b/swift/Tests/LanguageModelsTests/InferenceStreamTests.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Testing
+
+@testable import CoreAILanguageModels
+
+@Suite("InferenceStream")
+struct InferenceStreamTests {
+    @Test("iterates all tokens and sets .maxTokens on normal completion")
+    func normalCompletion() async throws {
+        let engine = MockEngine(tokens: [1, 2, 3], maxContextLength: 100)
+        let stream = try engine.generate(
+            with: [0],
+            samplingConfiguration: .greedy,
+            inferenceOptions: InferenceOptions(maxTokens: 3)
+        )
+
+        var collected: [Int32] = []
+        for try await output in stream {
+            collected.append(output.tokenId)
+        }
+
+        #expect(collected == [1, 2, 3])
+        #expect(stream.stopReason == .maxTokens)
+    }
+
+    @Test("stopReason is .eos when set by decoder")
+    func eosSetByDecoder() async throws {
+        let eosToken: Int32 = 99
+        let engine = MockEngine(tokens: [10, 20, eosToken, 40], maxContextLength: 100)
+        let stream = try engine.generate(
+            with: [0],
+            samplingConfiguration: .greedy,
+            inferenceOptions: InferenceOptions(maxTokens: 10)
+        )
+
+        for try await output in stream {
+            if output.tokenId == eosToken {
+                stream.setStopReason(.eos)
+                break
+            }
+        }
+
+        #expect(stream.stopReason == .eos)
+    }
+}

--- a/swift/Tests/LanguageModelsTests/TestUtilities.swift
+++ b/swift/Tests/LanguageModelsTests/TestUtilities.swift
@@ -53,47 +53,52 @@ class MockEngine: InferenceEngine, @unchecked Sendable {
         with input: [TokenId],
         samplingConfiguration: SamplingConfiguration,
         inferenceOptions: InferenceOptions
-    ) throws -> AsyncThrowingStream<InferenceOutput, Error> {
-        AsyncThrowingStream { continuation in
-            Task {
-                do {
-                    let forced = inferenceOptions.forcedContinuation
-                    let maxTokens =
-                        forced?.count
-                        ?? min(
-                            inferenceOptions.maxTokens ?? Int.max,
-                            max(0, self.config.maxContextLength - input.count)
-                        )
-                    let returnsLogits = inferenceOptions.includeLogits
+    ) throws -> InferenceStream {
+        let (stream, continuation) = InferenceStream.makeStream()
+        Task {
+            do {
+                let forced = inferenceOptions.forcedContinuation
+                let maxTokens =
+                    forced?.count
+                    ?? min(
+                        inferenceOptions.maxTokens ?? Int.max,
+                        max(0, self.config.maxContextLength - input.count)
+                    )
+                let returnsLogits = inferenceOptions.includeLogits
 
-                    for i in 0..<maxTokens {
-                        try Task.checkCancellation()
-                        let idx = self.inferenceCallCount % self.tokenSequence.count
-                        let sequenceToken = self.tokenSequence[idx]
-                        self.inferenceCallCount += 1
+                for i in 0..<maxTokens {
+                    try Task.checkCancellation()
+                    let idx = self.inferenceCallCount % self.tokenSequence.count
+                    let sequenceToken = self.tokenSequence[idx]
+                    self.inferenceCallCount += 1
 
-                        let nextToken = forced?[i] ?? sequenceToken
+                    let nextToken = forced?[i] ?? sequenceToken
 
-                        let logits: [Float16]?
-                        if returnsLogits, let vocabSize = self.vocabSize {
-                            var dist = [Float16](repeating: Float16(-10.0), count: vocabSize)
-                            let tokenIdx = Int(nextToken)
-                            if tokenIdx >= 0 && tokenIdx < vocabSize {
-                                dist[tokenIdx] = Float16(10.0)
-                            }
-                            logits = dist
-                        } else {
-                            logits = nil
+                    let logits: [Float16]?
+                    if returnsLogits, let vocabSize = self.vocabSize {
+                        var dist = [Float16](repeating: Float16(-10.0), count: vocabSize)
+                        let tokenIdx = Int(nextToken)
+                        if tokenIdx >= 0 && tokenIdx < vocabSize {
+                            dist[tokenIdx] = Float16(10.0)
                         }
-
-                        continuation.yield(InferenceOutput(tokenId: nextToken, logits: logits))
+                        logits = dist
+                    } else {
+                        logits = nil
                     }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
+
+                    continuation.yield(InferenceOutput(tokenId: nextToken, logits: logits))
                 }
+                stream.setStopReason(.maxTokens)
+                continuation.finish()
+            } catch is CancellationError {
+                stream.setStopReason(.cancelled)
+                continuation.finish()
+            } catch {
+                stream.setStopReason(.error)
+                continuation.finish(throwing: error)
             }
         }
+        return stream
     }
 
     func reset() async throws {


### PR DESCRIPTION
Introduces InferenceStream as a concrete return type from InferenceEngine.generate(), replacing the opaque
`some AsyncSequence<InferenceOutput, Error>`. The nested `StopReason enum (.maxTokens, .eos, .stopSequence, .cancelled, .error)` gives callers structured visibility into why generation ended — previously they had to guess from local state.

- `InferenceStream`: final class, AsyncSequence, Sendable
- Engines set `.maxTokens/.cancelled/.error`; decoders set `.eos`
- FM adaptor (`respondVanilla`) sets `.eos` on EOS token detection
- Removes associatedtype `OutputSequence` from `InferenceEngine` protocol
- All existing callers compile unchanged (for-await still works)