### PR TITLE
Qwen3-VL export + runner

### DIFF
--- a/python/src/coreai_models/models/gpu/qwen3_vl.py
+++ b/python/src/coreai_models/models/gpu/qwen3_vl.py
@@ -1,0 +1,414 @@
+"""Qwen3-VL text decoder for CoreAI model export.
+
+Like qwen3.py, but for the VL checkpoint layout: text decoder weights live
+under model.language_model.*, vision encoder weights (model.visual.*) are dropped.
+"""
+
+import torch
+import torch.nn as nn
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLForConditionalGeneration as HFQwen3VLForConditionalGeneration,
+)
+from typing_extensions import Self, override
+
+from coreai_models.models.base import BaseForCausalLM
+from coreai_models.primitives.macos.cache import KVCache
+from coreai_models.primitives.macos.mlp import MLP
+from coreai_models.primitives.macos.rms_norm import RMSNorm
+from coreai_models.primitives.macos.rope import initialize_rope
+from coreai_models.primitives.macos.sdpa import SDPA
+
+
+class Attention(nn.Module):
+    def __init__(self, config: Qwen3VLTextConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+
+        dim = config.hidden_size
+        self.n_heads = n_heads = config.num_attention_heads
+        self.n_kv_heads = n_kv_heads = config.num_key_value_heads
+        self.head_dim = head_dim = getattr(config, "head_dim", dim // n_heads)
+
+        # Combined QKV projection
+        self.qkv_proj = nn.Linear(
+            dim,
+            n_heads * head_dim + n_kv_heads * head_dim + n_kv_heads * head_dim,
+            bias=False,
+        )
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+
+        self.qk_norm = RMSNorm(head_dim, eps=config.rms_norm_eps, n_heads=n_heads + n_kv_heads)
+
+        self.sdpa = SDPA(is_causal=True)
+        self.rope = initialize_rope(base=config.rope_theta)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        batch_size, query_len, _ = x.shape
+        n_heads, n_kv_heads = self.n_heads, self.n_kv_heads
+
+        qkv = (
+            self.qkv_proj(x)
+            .reshape(batch_size, query_len, n_heads + 2 * n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+
+        query_key = qkv.narrow(1, 0, n_heads + n_kv_heads)
+        value = qkv.narrow(1, n_heads + n_kv_heads, n_kv_heads)
+
+        query_key = self.qk_norm(query_key)
+
+        seq_len = position_ids.shape[-1]
+        torch._check_is_size(query_len)
+        torch._check_is_size(seq_len)
+        offset = seq_len - query_len
+        torch._check_is_size(offset)
+        rope_positions = position_ids.narrow(-1, offset, query_len)
+
+        query_key = self.rope(query_key, position_ids=rope_positions)
+        query = query_key.narrow(1, 0, n_heads)
+        key = query_key.narrow(1, n_heads, n_kv_heads)
+
+        if cache is not None:
+            key, value = cache.update_and_fetch(
+                self.layer_idx, offset, key, value, seq_len=seq_len, query_len=query_len
+            )
+
+        output = (
+            self.sdpa(query, key, value)
+            .permute(0, 2, 1, 3)
+            .reshape(batch_size, query_len, self.n_heads * self.head_dim)
+        )
+        return self.o_proj(output)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: Qwen3VLTextConfig, layer_idx: int) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        self.self_attn = Attention(config, layer_idx=layer_idx)
+        self.mlp = MLP(hidden_size, config.intermediate_size)
+
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        r = self.self_attn(self.input_layernorm(x), position_ids, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Qwen3VLModel(nn.Module):
+    def __init__(self, config: Qwen3VLTextConfig) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, hidden_size)
+        self.layers = nn.ModuleList(
+            [TransformerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor = None,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        h = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            h = layer(h, position_ids, cache)
+        return self.norm(h)
+
+
+class Qwen3VLForCausalLM(BaseForCausalLM):
+    """Engine-compatible Qwen3-VL text decoder (input_ids variant)."""
+
+    _HF_MODEL_CLASS = HFQwen3VLForConditionalGeneration
+
+    @classmethod
+    def _get_reauthored_config(
+        cls,
+        hf_config,
+        max_context_length: int | None = None,
+        num_layers: int | None = None,
+    ):
+        """Extract the text config from the VL config."""
+        text_config = hf_config.text_config
+        if max_context_length is not None:
+            text_config.max_position_embeddings = max_context_length
+        if num_layers is not None:
+            text_config.num_hidden_layers = num_layers
+        # Carry over tie_word_embeddings from top-level config
+        text_config.tie_word_embeddings = hf_config.tie_word_embeddings
+        # Extract rope_theta -- in newer transformers it's inside rope_scaling/rope_parameters
+        rope_theta = getattr(text_config, "rope_theta", None)
+        if rope_theta is None:
+            rope_params = getattr(text_config, "rope_parameters", None) or getattr(
+                text_config, "rope_scaling", None
+            )
+            if rope_params and "rope_theta" in rope_params:
+                rope_theta = rope_params["rope_theta"]
+            else:
+                rope_theta = 5_000_000  # Qwen3-VL default
+        text_config.rope_theta = float(rope_theta)
+        # Ensure rope_scaling is None for initialize_rope (we handle theta directly)
+        text_config.rope_scaling = None
+        return text_config
+
+    @override
+    def _init_model(self, config: Qwen3VLTextConfig) -> None:
+        self.model = Qwen3VLModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        if getattr(config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.embed_tokens.weight
+
+    @override
+    def _init_cache(self, config: Qwen3VLTextConfig) -> None:
+        pass
+
+    @BaseForCausalLM.cast_logits_bfloat16_to_float16
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        cache = KVCache(k_cache, v_cache)
+        out = self.model(input_ids, position_ids, cache)
+        return self.lm_head(out)
+
+    @override
+    def _mutate_state_dict(self: Self, state_dict: dict[str, torch.Tensor]) -> None:
+        # Step 1: Strip "model.language_model." prefix from text decoder keys
+        # and drop vision encoder keys (model.visual.*)
+        keys_to_process = list(state_dict.keys())
+        for key in keys_to_process:
+            if key.startswith("model.visual."):
+                del state_dict[key]
+            elif key.startswith("model.language_model."):
+                new_key = "model." + key[len("model.language_model."):]
+                state_dict[new_key] = state_dict.pop(key)
+            # lm_head.weight stays as-is
+
+        # Step 2: Fuse q/k/v projections and norms
+        max_layer = -1
+        for k in state_dict:
+            name_split = k.split(".")
+            if len(name_split) != 6:
+                continue
+            if not k.startswith("model.layers."):
+                continue
+            max_layer = max(max_layer, int(name_split[2]))
+
+        if max_layer < 0:
+            err = "invalid state_dict: no transformer layers found"
+            raise ValueError(err)
+
+        for i in range(max_layer + 1):
+            # Fuse q/k/v projections into combined qkv_proj
+            combined_weight = []
+            need_to_fuse = True
+            for proj in ["q_proj", "k_proj", "v_proj"]:
+                weight_key = f"model.layers.{i}.self_attn.{proj}.weight"
+                if weight_key not in state_dict:
+                    need_to_fuse = False
+                    continue
+                combined_weight.append(state_dict[weight_key])
+                del state_dict[weight_key]
+            if need_to_fuse:
+                state_dict[f"model.layers.{i}.self_attn.qkv_proj.weight"] = torch.concat(
+                    combined_weight, axis=0
+                )
+
+            # Fuse q_norm/k_norm into qk_norm
+            q_norm_key = f"model.layers.{i}.self_attn.q_norm.weight"
+            k_norm_key = f"model.layers.{i}.self_attn.k_norm.weight"
+
+            if q_norm_key in state_dict and k_norm_key in state_dict:
+                layer = self.model.layers[i]
+                n_heads = layer.self_attn.n_heads
+                n_kv_heads = layer.self_attn.n_kv_heads
+                head_dim = layer.self_attn.head_dim
+
+                q_norm_weight = state_dict[q_norm_key].unsqueeze(0).unsqueeze(0)
+                k_norm_weight = state_dict[k_norm_key].unsqueeze(0).unsqueeze(0)
+
+                q_repeated = q_norm_weight.expand(n_heads, 1, head_dim)
+                k_repeated = k_norm_weight.expand(n_kv_heads, 1, head_dim)
+                fused_weight = torch.cat([q_repeated, k_repeated], dim=0)
+
+                state_dict[f"model.layers.{i}.self_attn.qk_norm.weight"] = fused_weight
+
+                del state_dict[q_norm_key]
+                del state_dict[k_norm_key]
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        super().load_state_dict(state_dict, strict=strict, assign=assign)
+        if getattr(self.config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.embed_tokens.weight
+
+
+# ---------------------------------------------------------------------------
+# Embeddings variant (takes inputs_embeds instead of input_ids)
+# ---------------------------------------------------------------------------
+
+
+class Qwen3VLModelEmbeddings(nn.Module):
+    """Variant of Qwen3VLModel that accepts pre-computed embeddings."""
+
+    def __init__(self, config: Qwen3VLTextConfig) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        # No embed_tokens -- we receive pre-computed embeddings
+        self.layers = nn.ModuleList(
+            [TransformerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.IntTensor = None,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        h = inputs_embeds
+        for layer in self.layers:
+            h = layer(h, position_ids, cache)
+        return self.norm(h)
+
+
+class Qwen3VLForCausalLMEmbeddings(BaseForCausalLM):
+    """Engine-compatible Qwen3-VL text decoder (inputs_embeds variant).
+
+    forward(inputs_embeds: [1, seq, hidden], position_ids: [1, seq], k_cache, v_cache) -> logits
+    """
+
+    _HF_MODEL_CLASS = HFQwen3VLForConditionalGeneration
+
+    @classmethod
+    def _get_reauthored_config(
+        cls,
+        hf_config,
+        max_context_length: int | None = None,
+        num_layers: int | None = None,
+    ):
+        """Extract the text config from the VL config."""
+        text_config = hf_config.text_config
+        if max_context_length is not None:
+            text_config.max_position_embeddings = max_context_length
+        if num_layers is not None:
+            text_config.num_hidden_layers = num_layers
+        text_config.tie_word_embeddings = hf_config.tie_word_embeddings
+        # Extract rope_theta -- in newer transformers it's inside rope_scaling/rope_parameters
+        rope_theta = getattr(text_config, "rope_theta", None)
+        if rope_theta is None:
+            rope_params = getattr(text_config, "rope_parameters", None) or getattr(
+                text_config, "rope_scaling", None
+            )
+            if rope_params and "rope_theta" in rope_params:
+                rope_theta = rope_params["rope_theta"]
+            else:
+                rope_theta = 5_000_000
+        text_config.rope_theta = float(rope_theta)
+        text_config.rope_scaling = None
+        return text_config
+
+    @override
+    def _init_model(self, config: Qwen3VLTextConfig) -> None:
+        self.model = Qwen3VLModelEmbeddings(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    @override
+    def _init_cache(self, config: Qwen3VLTextConfig) -> None:
+        pass
+
+    @BaseForCausalLM.cast_logits_bfloat16_to_float16
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.IntTensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        cache = KVCache(k_cache, v_cache)
+        out = self.model(inputs_embeds, position_ids, cache)
+        return self.lm_head(out)
+
+    @override
+    def _mutate_state_dict(self: Self, state_dict: dict[str, torch.Tensor]) -> None:
+        # Strip prefix and drop vision keys
+        keys_to_process = list(state_dict.keys())
+        for key in keys_to_process:
+            if key.startswith("model.visual."):
+                del state_dict[key]
+            elif key.startswith("model.language_model."):
+                new_key = "model." + key[len("model.language_model."):]
+                state_dict[new_key] = state_dict.pop(key)
+
+        # Drop embed_tokens since this model doesn't have it
+        keys_to_drop = [k for k in state_dict if "embed_tokens" in k]
+        for k in keys_to_drop:
+            del state_dict[k]
+
+        # Fuse q/k/v projections
+        max_layer = -1
+        for k in state_dict:
+            name_split = k.split(".")
+            if len(name_split) != 6:
+                continue
+            if not k.startswith("model.layers."):
+                continue
+            max_layer = max(max_layer, int(name_split[2]))
+
+        if max_layer < 0:
+            err = "invalid state_dict: no transformer layers found"
+            raise ValueError(err)
+
+        for i in range(max_layer + 1):
+            combined_weight = []
+            need_to_fuse = True
+            for proj in ["q_proj", "k_proj", "v_proj"]:
+                weight_key = f"model.layers.{i}.self_attn.{proj}.weight"
+                if weight_key not in state_dict:
+                    need_to_fuse = False
+                    continue
+                combined_weight.append(state_dict[weight_key])
+                del state_dict[weight_key]
+            if need_to_fuse:
+                state_dict[f"model.layers.{i}.self_attn.qkv_proj.weight"] = torch.concat(
+                    combined_weight, axis=0
+                )
+
+            # Fuse q_norm/k_norm into qk_norm
+            q_norm_key = f"model.layers.{i}.self_attn.q_norm.weight"
+            k_norm_key = f"model.layers.{i}.self_attn.k_norm.weight"
+
+            if q_norm_key in state_dict and k_norm_key in state_dict:
+                layer = self.model.layers[i]
+                n_heads = layer.self_attn.n_heads
+                n_kv_heads = layer.self_attn.n_kv_heads
+                head_dim = layer.self_attn.head_dim
+
+                q_norm_weight = state_dict[q_norm_key].unsqueeze(0).unsqueeze(0)
+                k_norm_weight = state_dict[k_norm_key].unsqueeze(0).unsqueeze(0)
+
+                q_repeated = q_norm_weight.expand(n_heads, 1, head_dim)
+                k_repeated = k_norm_weight.expand(n_kv_heads, 1, head_dim)
+                fused_weight = torch.cat([q_repeated, k_repeated], dim=0)
+
+                state_dict[f"model.layers.{i}.self_attn.qk_norm.weight"] = fused_weight
+
+                del state_dict[q_norm_key]
+                del state_dict[k_norm_key]

--- a/python/src/coreai_models/models/registry.py
+++ b/python/src/coreai_models/models/registry.py
@@ -40,6 +40,10 @@ def _get_registry() -> dict[str, ModelEntry]:
     from coreai_models.models.macos.qwen2 import Qwen2ForCausalLM
     from coreai_models.models.macos.qwen3 import Qwen3ForCausalLM
     from coreai_models.models.macos.qwen3_moe import Qwen3MoeForCausalLM
+    from coreai_models.models.gpu.qwen3_vl import (
+        Qwen3VLForCausalLM,
+        Qwen3VLForCausalLMEmbeddings,
+    )
 
     return {
         "gemma3_text": ModelEntry(
@@ -67,6 +71,14 @@ def _get_registry() -> dict[str, ModelEntry]:
         ),
         "qwen3_moe": ModelEntry(
             macos_class=Qwen3MoeForCausalLM,
+        ),
+        # Qwen3-VL: vision-language model.
+        # macos_class = standard text decoder (input_ids, for text-only use).
+        # Use Qwen3VLForCausalLMEmbeddings for VLM export (takes inputs_embeds).
+        "qwen3_vl": ModelEntry(
+            macos_class=Qwen3VLForCausalLM,
+            hf_config_attr="text_config",
+            hf_state_dict_prefix="model.language_model.",
         ),
     }
 

--- a/python/src/coreai_models/primitives/macos/cache_scatter.py
+++ b/python/src/coreai_models/primitives/macos/cache_scatter.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Functional KV cache backed by slice_scatter."""
+
+import torch
+from typing_extensions import Self
+
+
+class KVCache:
+    HF_K_BUFFER_NAME = "_full_cached_k"
+    HF_V_BUFFER_NAME = "_full_cached_v"
+
+    def __init__(self: Self, k_cache: torch.Tensor, v_cache: torch.Tensor):
+        self._k_cache = k_cache
+        self._v_cache = v_cache
+
+    @classmethod
+    def seq_len_dim(cls) -> int:
+        return 3
+
+    @classmethod
+    def create_cache_tensors(
+        cls,
+        config,
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        n_kv_heads = config.num_key_value_heads
+        n_layers = config.num_hidden_layers
+        max_seq_len = config.max_position_embeddings
+        if hasattr(config, "head_dim") and config.head_dim is not None:
+            head_dim = config.head_dim
+        else:
+            head_dim = config.hidden_size // config.num_attention_heads
+        k_cache = torch.zeros(n_layers, 1, n_kv_heads, max_seq_len, head_dim, dtype=dtype)
+        v_cache = torch.zeros(n_layers, 1, n_kv_heads, max_seq_len, head_dim, dtype=dtype)
+        return k_cache, v_cache
+
+    @classmethod
+    def from_dimensions(cls, n_layers, n_kv_heads, max_seq_len, head_dim) -> "KVCache":
+        k_cache = torch.zeros(n_layers, 1, n_kv_heads, max_seq_len, head_dim)
+        v_cache = torch.zeros(n_layers, 1, n_kv_heads, max_seq_len, head_dim)
+        return cls(k_cache, v_cache)
+
+    def update_and_fetch(
+        self: Self,
+        layer_idx: int,
+        offset: int,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        seq_len: int | None = None,
+        query_len: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if query_len is None:
+            query_len = k.shape[-2]
+        if seq_len is None:
+            seq_len = offset + query_len
+
+        layer_k = self._k_cache.narrow(0, layer_idx, 1)
+        layer_v = self._v_cache.narrow(0, layer_idx, 1)
+
+        updated_k = torch.ops.aten.slice_scatter(
+            layer_k, k.unsqueeze(0), dim=-2, start=offset, end=offset + query_len, step=1)
+        updated_v = torch.ops.aten.slice_scatter(
+            layer_v, v.unsqueeze(0), dim=-2, start=offset, end=offset + query_len, step=1)
+
+        self._k_cache = torch.ops.aten.slice_scatter(
+            self._k_cache, updated_k, dim=0, start=layer_idx, end=layer_idx + 1, step=1)
+        self._v_cache = torch.ops.aten.slice_scatter(
+            self._v_cache, updated_v, dim=0, start=layer_idx, end=layer_idx + 1, step=1)
+
+        out_k = self._k_cache.narrow(0, layer_idx, 1).narrow(-2, 0, seq_len)
+        out_v = self._v_cache.narrow(0, layer_idx, 1).narrow(-2, 0, seq_len)
+        return out_k.squeeze(0), out_v.squeeze(0)

--- a/swift/Sources/CoreAILanguageModels/VLM/CoreAIVisionLanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/VLM/CoreAIVisionLanguageModel.swift
@@ -1,0 +1,301 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+// Foundation Models protocol adapter for VLM bundles.
+// Wires VisionEncoderRunner + EmbeddingsInferenceEngine into a LanguageModel
+// that processes image attachments from Transcript prompts.
+
+import CoreAI
+import CoreAIShared
+import CoreImage
+import CoreVideo
+import Foundation
+import FoundationModels
+import Tokenizers
+
+
+
+// MARK: - CoreAIVisionLanguageModel
+
+#if canImport(CoreAI)
+/// Foundation Models adapter for VLM .llmasset bundles.
+///
+/// ```swift
+/// let model = try await CoreAIVisionLanguageModel(resourcesAt: vlmBundleURL)
+/// let session = LanguageModelSession(model: model)
+/// let response = try await session.respond(options: options) {
+///     Attachment(imageURL: imageURL)
+///     "What is in this image?"
+/// }
+/// ```
+@available(macOS 27, iOS 27, *)
+public struct CoreAIVisionLanguageModel: LanguageModel {
+
+    @_spi(_) public typealias Executor = CoreAIVLMExecutor
+
+    @_spi(_)
+    public var capabilities: LanguageModelCapabilities {
+        LanguageModelCapabilities(capabilities: [])
+    }
+
+    @_spi(DoNotImport) public var executorConfiguration: CoreAIVLMExecutor.Configuration
+
+    public init(resourcesAt url: URL) async throws {
+        let bundle = try LanguageBundle(at: url)
+
+        guard let visionAssetURL = bundle.modelURL(for: ModelBundle.ComponentKey.vision) else {
+            throw InferenceRuntimeError.genericError("VLM bundle missing 'vision' component in assets")
+        }
+
+        guard let vlmConfig = bundle.bundle.vlm else {
+            throw InferenceRuntimeError.genericError("VLM bundle missing 'vision' config block in metadata.json")
+        }
+
+        let bundlePath = bundle.bundlePath
+        let modelURL = try bundle.requireModelURL(for: ModelBundle.ComponentKey.main)
+        let embedTableURL = bundlePath.appending(path: vlmConfig.embedTokensPath)
+
+        let config = try JSONDecoder().decode(ModelConfig.self, from: bundle.rawMetadata)
+        let tokenizer = try await bundle.loadTokenizer()
+        let visionRunner = try await VisionEncoderRunner(
+            assetURL: visionAssetURL.resolvingSymlinksInPath())
+        let engine = try await EmbeddingsInferenceEngine(
+            config: config, modelURL: modelURL.resolvingSymlinksInPath(), embedTableURL: embedTableURL)
+
+        self.executorConfiguration = CoreAIVLMExecutor.Configuration(
+            visionRunner: visionRunner, engine: engine, tokenizer: tokenizer,
+            embedTableURL: embedTableURL, hiddenSize: vlmConfig.hiddenSize,
+            imageTokenId: Int32(vlmConfig.imageTokenId), numVisualTokens: vlmConfig.numVisualTokens)
+    }
+
+    public func validate(_ transcript: some Collection<Transcript.Entry>) async throws {}
+}
+
+// MARK: - CoreAIVLMExecutor
+
+@available(macOS 27, iOS 27, *)
+@_spi(DoNotImport) @_spi(Implicit)
+public struct CoreAIVLMExecutor: LanguageModelExecutor {
+    @_spi(DoNotImport) public typealias Model = CoreAIVisionLanguageModel
+
+    @_spi(DoNotImport)
+    public struct Configuration: Hashable, Sendable {
+        let visionRunner: VisionEncoderRunner
+        let engine: EmbeddingsInferenceEngine
+        let tokenizer: any Tokenizer
+        let embedTableURL: URL
+        let hiddenSize: Int
+        let imageTokenId: Int32
+        let numVisualTokens: Int
+
+        public static func == (lhs: Configuration, rhs: Configuration) -> Bool {
+            lhs.embedTableURL == rhs.embedTableURL
+        }
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(embedTableURL)
+        }
+    }
+
+    private let visionRunner: VisionEncoderRunner
+    private let engine: EmbeddingsInferenceEngine
+    private let tokenizer: any Tokenizer
+    private let embedTableURL: URL
+    private let hiddenSize: Int
+    private let imageTokenId: Int32
+    private let numVisualTokens: Int
+
+    @_spi(_)
+    public init(configuration: Configuration) throws {
+        self.visionRunner = configuration.visionRunner
+        self.engine = configuration.engine
+        self.tokenizer = configuration.tokenizer
+        self.embedTableURL = configuration.embedTableURL
+        self.hiddenSize = configuration.hiddenSize
+        self.imageTokenId = configuration.imageTokenId
+        self.numVisualTokens = configuration.numVisualTokens
+    }
+
+    public func prewarm(transcript: Transcript) throws {}
+
+    @_spi(_)
+    public nonisolated(nonsending) func respond(
+        to request: LanguageModelExecutorGenerationRequest,
+        model: CoreAIVisionLanguageModel,
+        streamingInto channel: LanguageModelExecutorGenerationChannel
+    ) async throws {
+        var cgImage: CGImage? = nil
+        var userText = ""
+
+        for entry in request.transcript {
+            switch entry {
+            case .prompt(let prompt):
+                for segment in prompt.segments {
+                    switch segment {
+                    case .text(let text): userText += text.content
+                    case .attachment(let attachment):
+                        if case .image(let img) = attachment.content { cgImage = img.cgImage }
+                    default: break
+                    }
+                }
+            default: break
+            }
+        }
+
+        let maxTokens = request.generationOptions.maximumResponseTokens ?? 256
+        try await engine.reset()
+
+        guard let image = cgImage else {
+            await channel.send(.response(action: .appendText(
+                "No image provided. Attach an image to your prompt.",
+                segmentID: nil, tokenCount: 1)))
+            return
+        }
+
+        // Preprocess image → vision encoder
+        let pixelValues = try preprocessCGImage(image, targetSize: 448)
+        let imageFeatures = try await visionRunner.run(
+            pixelValues: pixelValues, numVisualTokens: numVisualTokens, hiddenSize: hiddenSize)
+
+        // Build chat text with image placeholders
+        let placeholder = String(repeating: "<|image_pad|>", count: numVisualTokens)
+        let chatText = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" +
+            "<|im_start|>user\n<|vision_start|>\(placeholder)<|vision_end|>\n" +
+            "\(userText)<|im_end|>\n<|im_start|>assistant\n"
+        let inputIds = tokenizer.encode(text: chatText)
+
+        // Build combined embeddings
+        let embeddings = try buildCombinedEmbeddings(inputIds: inputIds, imageFeatures: imageFeatures)
+
+        // Prefill — send progress metadata so callers know we're working
+        let seqLen = inputIds.count
+        await channel.send(.response(action: .updateMetadata([
+            "prefill_status": "started" as (any Sendable & Codable & Equatable),
+            "prefill_tokens": seqLen as (any Sendable & Codable & Equatable),
+        ])))
+        var lastLogits = try await engine.prefillWithEmbeddings(embeddings, seqLen: seqLen) { done, total in
+            CLILogger.log("Prefill \(done)/\(total)")
+        }
+        await channel.send(.response(action: .updateMetadata([
+            "prefill_status": "done" as (any Sendable & Codable & Equatable),
+        ])))
+
+        // Generate + stream
+        let eosId: Int32 = 151645
+        let eotId: Int32 = 151643
+        var samplingConfig = SamplingConfiguration(temperature: 0.7)
+        var token = samplingConfig.fallbackSampler(from: &lastLogits)
+        var generated: [Int32] = []
+        var prevDecoded = ""
+
+        for _ in 0..<maxTokens {
+            if token == eosId || token == eotId { break }
+            generated.append(token)
+            let fullText = tokenizer.decode(tokens: generated.map { Int($0) })
+            let delta = String(fullText.dropFirst(fullText.commonPrefix(with: prevDecoded).count))
+            if !delta.unicodeScalars.contains(where: { $0 == "\u{FFFD}" }) {
+                prevDecoded = fullText
+                await channel.send(.response(action: .appendText(delta, segmentID: nil, tokenCount: 1)))
+            }
+            let (_, next) = try await engine.inference(
+                inputTokens: [token], samplingConfig: samplingConfig, returnsLogits: false)
+            token = next
+        }
+    }
+
+    // MARK: - Image Preprocessing (448×448 → [784, 1536] patches)
+
+    private func preprocessCGImage(_ cgImage: CGImage, targetSize: Int) throws -> Data {
+        let patchSize = 16, temporalPatchSize = 2, mergeSize = 2, channels = 3
+        let ci = CIImage(cgImage: cgImage)
+        let sx = CGFloat(targetSize) / ci.extent.width
+        let sy = CGFloat(targetSize) / ci.extent.height
+        let resized = ci.transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+
+        var pb: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, targetSize, targetSize,
+                            kCVPixelFormatType_32BGRA,
+                            [kCVPixelBufferWidthKey: targetSize,
+                             kCVPixelBufferHeightKey: targetSize,
+                             kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA] as CFDictionary,
+                            &pb)
+        guard let pb else { throw InferenceRuntimeError.genericError("CVPixelBuffer creation failed") }
+        CIContext(options: [.useSoftwareRenderer: false]).render(resized, to: pb)
+
+        CVPixelBufferLockBaseAddress(pb, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pb, .readOnly) }
+        let base = CVPixelBufferGetBaseAddress(pb)!
+        let bpr = CVPixelBufferGetBytesPerRow(pb)
+
+        var img = [Float](repeating: 0, count: channels * targetSize * targetSize)
+        for y in 0..<targetSize {
+            let row = base.advanced(by: y * bpr).assumingMemoryBound(to: UInt8.self)
+            for x in 0..<targetSize {
+                let o = x * 4
+                img[0 * targetSize * targetSize + y * targetSize + x] = (Float(row[o+2])/255.0 - 0.5) / 0.5
+                img[1 * targetSize * targetSize + y * targetSize + x] = (Float(row[o+1])/255.0 - 0.5) / 0.5
+                img[2 * targetSize * targetSize + y * targetSize + x] = (Float(row[o+0])/255.0 - 0.5) / 0.5
+            }
+        }
+
+        let gridH = targetSize / patchSize, gridW = targetSize / patchSize
+        let patchDim = channels * temporalPatchSize * patchSize * patchSize
+        let numPatches = gridH * gridW
+        var patches = [Float](repeating: 0, count: numPatches * patchDim)
+        let hB = gridH / mergeSize, wB = gridW / mergeSize
+
+        for hb in 0..<hB {
+            for wb in 0..<wB {
+                for mh in 0..<mergeSize {
+                    for mw in 0..<mergeSize {
+                        let pi = hb*wB*mergeSize*mergeSize + wb*mergeSize*mergeSize + mh*mergeSize + mw
+                        var off = 0
+                        for c in 0..<channels {
+                            for _ in 0..<temporalPatchSize {
+                                for ph in 0..<patchSize {
+                                    for pw in 0..<patchSize {
+                                        let sy = (hb*mergeSize+mh)*patchSize+ph
+                                        let sx = (wb*mergeSize+mw)*patchSize+pw
+                                        patches[pi*patchDim+off] = img[c*targetSize*targetSize+sy*targetSize+sx]
+                                        off += 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return Data(bytes: patches, count: patches.count * MemoryLayout<Float>.size)
+    }
+
+    // MARK: - Embedding Builder
+
+    private func buildCombinedEmbeddings(inputIds: [Int], imageFeatures: [LogitsScalarType]) throws -> Data {
+        let embedData = try Data(contentsOf: embedTableURL)
+        let seqLen = inputIds.count
+        var combined = [LogitsScalarType](repeating: 0, count: seqLen * hiddenSize)
+
+        embedData.withUnsafeBytes { raw in
+            let table = raw.bindMemory(to: LogitsScalarType.self)
+            var vi = 0
+            for i in 0..<seqLen {
+                let tid = Int32(inputIds[i])
+                if tid == imageTokenId && vi < numVisualTokens {
+                    let src = vi * hiddenSize
+                    for h in 0..<hiddenSize { combined[i*hiddenSize+h] = imageFeatures[src+h] }
+                    vi += 1
+                } else {
+                    let src = Int(tid) * hiddenSize
+                    for h in 0..<hiddenSize { combined[i*hiddenSize+h] = table[src+h] }
+                }
+            }
+        }
+        return Data(bytes: combined, count: combined.count * MemoryLayout<LogitsScalarType>.size)
+    }
+}
+
+
+
+#endif

--- a/swift/Sources/CoreAILanguageModels/VLM/EmbeddingsInferenceEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/VLM/EmbeddingsInferenceEngine.swift
@@ -1,0 +1,430 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+// Embeddings Inference Engine for Qwen3-VL.
+// Accepts inputs_embeds (f16) instead of input_ids (i32) for vision-language prefill.
+
+import CoreAI
+import CoreAIShared
+import Foundation
+import Metal
+
+
+
+// MARK: - Embeddings Inference Engine
+
+/// CoreAI inference engine for models that accept `inputs_embeds` (f16) instead of `input_ids`.
+/// Used for Qwen3-VL where vision features are fused into the embedding sequence externally.
+#if canImport(CoreAI)
+@available(macOS 27, iOS 27, *)
+public final class EmbeddingsInferenceEngine: @unchecked Sendable {
+    public var vocabSize: Int { config.vocabSize }
+    public let config: ModelConfig
+
+    private let function: InferenceFunction
+    private let functionDescriptor: InferenceFunctionDescriptor
+
+    private let inputEmbedsName: String
+    private let positionIdsName: String
+    private let keyCacheName: String
+    private let valueCacheName: String
+    private let logitsName: String
+    // Explicit KV mode: these are the output names for updated KV caches
+    private let keyCacheOutputName: String
+    private let valueCacheOutputName: String
+    private let explicitKV: Bool
+
+    private let inputEmbedsDescriptor: NDArrayDescriptor
+    private let positionIdsDescriptor: NDArrayDescriptor
+    private let logitsDescriptor: NDArrayDescriptor
+    private let keyCacheDescriptor: NDArrayDescriptor
+    private let valueCacheDescriptor: NDArrayDescriptor
+
+    private let hiddenSize: Int
+    private let positionIdsRank: Int
+
+    private var keyCache: NDArray
+    private var valueCache: NDArray
+    private var logitsArray: NDArray
+    private var currentKVCapacity: Int
+    private var processedTokenCount: Int = 0
+    private var embedTable: UnsafeBufferPointer<LogitsScalarType>?
+    private var embedTableData: Data?
+    private var prefillDone: Bool = false
+
+    public init(
+        config: ModelConfig,
+        modelURL: URL,
+        embedTableURL: URL?,
+        options: EngineOptions = EngineOptions()
+    ) async throws {
+        self.config = config
+
+        let model = try await AIModel(contentsOf: modelURL, options: .default)
+
+        guard let descriptor = model.functionDescriptor(for: config.function) else {
+            throw InferenceRuntimeError.functionNotFound(config.function)
+        }
+        self.functionDescriptor = descriptor
+
+        // Detect mode: stateful (2 inputs, 2 states) vs explicit KV (4 inputs, 0 states)
+        let isExplicitKV = descriptor.stateNames.isEmpty && descriptor.inputNames.count == 4
+        let isStateful = descriptor.stateNames.count == 2 && descriptor.inputNames.count == 2
+        guard isStateful || isExplicitKV else {
+            throw InferenceRuntimeError.genericError(
+                "Unexpected signature: inputs=\(descriptor.inputNames.count) states=\(descriptor.stateNames.count). " +
+                "Expected stateful(2in+2states) or explicit-KV(4in+0states).")
+        }
+        self.explicitKV = isExplicitKV
+        CLILogger.log("EmbeddingsEngine: mode=\(isExplicitKV ? "explicit-KV" : "stateful"), inputs=\(descriptor.inputNames), states=\(descriptor.stateNames), outputs=\(descriptor.outputNames)")
+
+        if isExplicitKV {
+            self.inputEmbedsName = descriptor.inputNames[0]
+            self.positionIdsName = descriptor.inputNames[1]
+            self.keyCacheName = descriptor.inputNames[2]
+            self.valueCacheName = descriptor.inputNames[3]
+            // Outputs: [keyCache_out, valueCache_out, logits]
+            self.logitsName = descriptor.outputNames[2]
+            self.keyCacheOutputName = descriptor.outputNames[0]
+            self.valueCacheOutputName = descriptor.outputNames[1]
+        } else {
+            self.inputEmbedsName = descriptor.inputNames[0]
+            self.positionIdsName = descriptor.inputNames[1]
+            self.keyCacheName = descriptor.stateNames[0]
+            self.valueCacheName = descriptor.stateNames[1]
+            self.logitsName = descriptor.outputNames[0]
+            self.keyCacheOutputName = ""
+            self.valueCacheOutputName = ""
+        }
+
+        guard case .ndArray(let embedsDesc) = descriptor.inputDescriptor(of: inputEmbedsName) else {
+            throw InferenceRuntimeError.genericError("Cannot get descriptor for '\(inputEmbedsName)'")
+        }
+        self.inputEmbedsDescriptor = embedsDesc
+
+        guard case .ndArray(let posDesc) = descriptor.inputDescriptor(of: positionIdsName) else {
+            throw InferenceRuntimeError.genericError("Cannot get descriptor for '\(positionIdsName)'")
+        }
+        self.positionIdsDescriptor = posDesc
+
+        guard case .ndArray(let logitsDesc) = descriptor.outputDescriptor(of: logitsName) else {
+            throw InferenceRuntimeError.genericError("Cannot get descriptor for '\(logitsName)'")
+        }
+        self.logitsDescriptor = logitsDesc
+
+        // Get KV cache descriptors — from states (stateful) or inputs (explicit KV)
+        let keyCacheDesc: NDArrayDescriptor
+        let valueCacheDesc: NDArrayDescriptor
+        if isExplicitKV {
+            guard case .ndArray(let kd) = descriptor.inputDescriptor(of: keyCacheName),
+                  case .ndArray(let vd) = descriptor.inputDescriptor(of: valueCacheName)
+            else { throw InferenceRuntimeError.genericError("Cannot get KV cache input descriptors") }
+            keyCacheDesc = kd; valueCacheDesc = vd
+        } else {
+            guard case .ndArray(let kd) = descriptor.stateDescriptor(of: keyCacheName),
+                  case .ndArray(let vd) = descriptor.stateDescriptor(of: valueCacheName)
+            else { throw InferenceRuntimeError.genericError("Cannot get KV cache state descriptors") }
+            keyCacheDesc = kd; valueCacheDesc = vd
+        }
+        self.keyCacheDescriptor = keyCacheDesc
+        self.valueCacheDescriptor = valueCacheDesc
+
+        self.hiddenSize = embedsDesc.shape[2]
+        self.positionIdsRank = posDesc.shape.count
+
+        let isDynamic = keyCacheDesc.shape.contains { $0 < 0 }
+        let initialCapacity = isDynamic ? min(256, config.maxContextLength) : config.maxContextLength
+        self.currentKVCapacity = initialCapacity
+
+        let resolvedKeyDesc = isDynamic
+            ? keyCacheDesc.resolvingDynamicDimensions(keyCacheDesc.shape.map { $0 < 0 ? initialCapacity : $0 })
+            : keyCacheDesc
+        let resolvedValueDesc = isDynamic
+            ? valueCacheDesc.resolvingDynamicDimensions(valueCacheDesc.shape.map { $0 < 0 ? initialCapacity : $0 })
+            : valueCacheDesc
+
+        var keyCache = NDArray(descriptor: resolvedKeyDesc)
+        var valueCache = NDArray(descriptor: resolvedValueDesc)
+        let kcCount = resolvedKeyDesc.shape.reduce(1, *)
+        let vcCount = resolvedValueDesc.shape.reduce(1, *)
+        fillNDArray(&keyCache, as: LogitsScalarType.self, count: kcCount) { _ in LogitsScalarType(0) }
+        fillNDArray(&valueCache, as: LogitsScalarType.self, count: vcCount) { _ in LogitsScalarType(0) }
+        self.keyCache = keyCache
+        self.valueCache = valueCache
+
+        let initLogitsDesc = logitsDesc.resolvingDynamicDimensions([1, 1, config.vocabSize])
+        self.logitsArray = NDArray(descriptor: initLogitsDesc)
+
+        guard let fn = try model.loadFunction(named: config.function) else {
+            throw InferenceRuntimeError.functionNotFound(config.function)
+        }
+        self.function = fn
+
+        if let embedTableURL = embedTableURL {
+            try loadEmbedTable(from: embedTableURL)
+        }
+    }
+
+    // MARK: - Embedding Table
+
+    private func loadEmbedTable(from url: URL) throws {
+        let data = try Data(contentsOf: url)
+        let expectedSize = config.vocabSize * hiddenSize * MemoryLayout<LogitsScalarType>.size
+        guard data.count == expectedSize else {
+            throw InferenceRuntimeError.genericError(
+                "embed_tokens size mismatch: got \(data.count), expected \(expectedSize)")
+        }
+        self.embedTableData = data
+        data.withUnsafeBytes { rawPtr in
+            let ptr = rawPtr.bindMemory(to: LogitsScalarType.self)
+            self.embedTable = UnsafeBufferPointer(start: ptr.baseAddress, count: ptr.count)
+        }
+    }
+
+    // MARK: - KV Cache Growth
+
+    private func ensureKVCapacity(forContextLength needed: Int) throws {
+        guard needed > currentKVCapacity else { return }
+        guard needed <= config.maxContextLength else {
+            throw InferenceRuntimeError.contextLengthExceeded(needed, config.maxContextLength)
+        }
+        var newCapacity = currentKVCapacity
+        while newCapacity < needed { newCapacity *= 2 }
+        newCapacity = min(newCapacity, config.maxContextLength)
+
+        let resolvedKeyDesc = keyCacheDescriptor.resolvingDynamicDimensions(
+            keyCacheDescriptor.shape.map { $0 < 0 ? newCapacity : $0 })
+        let resolvedValueDesc = valueCacheDescriptor.resolvingDynamicDimensions(
+            valueCacheDescriptor.shape.map { $0 < 0 ? newCapacity : $0 })
+
+        var newKeyCache = NDArray(descriptor: resolvedKeyDesc)
+        var newValueCache = NDArray(descriptor: resolvedValueDesc)
+        copyCache(from: keyCache, to: &newKeyCache)
+        copyCache(from: valueCache, to: &newValueCache)
+        keyCache = newKeyCache
+        valueCache = newValueCache
+        currentKVCapacity = newCapacity
+    }
+
+    private func copyCache(from source: NDArray, to destination: inout NDArray) {
+        let srcShape = source.shape
+        let dstShape = destination.shape
+        // Sequence dim is 3 for 5D KV cache [layers, batch, heads, seq, head_dim]
+        let seqDim = srcShape.count == 5 ? 3 : 2
+        let headDim = srcShape.last!
+        let numBlocks = srcShape[..<seqDim].reduce(1, *)
+        let oldSeqLen = srcShape[seqDim]
+        let copySize = oldSeqLen * headDim
+        let srcBlockStride = srcShape[seqDim...].reduce(1, *)
+        let dstBlockStride = dstShape[seqDim...].reduce(1, *)
+        source.view(as: LogitsScalarType.self).withUnsafePointer { srcPtr, _, _ in
+            destination.view(as: LogitsScalarType.self).withUnsafePointer { dstPtr, _, _ in
+                let dst = UnsafeMutablePointer(mutating: dstPtr)
+                for block in 0..<numBlocks {
+                    dst.advanced(by: block * dstBlockStride)
+                        .update(from: srcPtr.advanced(by: block * srcBlockStride), count: copySize)
+                }
+            }
+        }
+    }
+
+    // MARK: - Execute Forward Pass
+
+    private func executeEmbeddingsBatch(
+        embeddings: Data, byteOffset: Int, byteCount: Int, batchSize: Int
+    ) async throws -> [LogitsScalarType] {
+        try ensureKVCapacity(forContextLength: processedTokenCount + batchSize)
+
+        let resolvedEmbedsDesc = inputEmbedsDescriptor.resolvingDynamicDimensions([1, batchSize, hiddenSize])
+        var inputEmbedsArray = NDArray(descriptor: resolvedEmbedsDesc)
+        embeddings.withUnsafeBytes { rawPtr in
+            var view = inputEmbedsArray.mutableView(as: LogitsScalarType.self)
+            view.withUnsafeMutablePointer { ptr, _, _ in
+                let src = rawPtr.baseAddress! + byteOffset
+                let count = byteCount / MemoryLayout<LogitsScalarType>.size
+                src.assumingMemoryBound(to: LogitsScalarType.self)
+                    .withMemoryRebound(to: LogitsScalarType.self, capacity: count) { srcPtr in
+                        ptr.update(from: srcPtr, count: count)
+                    }
+            }
+        }
+
+        let totalPositions = processedTokenCount + batchSize
+        let posShape: [Int] = positionIdsRank == 3 ? [1, 3, totalPositions] : [1, totalPositions]
+        let resolvedPosDesc = positionIdsDescriptor.resolvingDynamicDimensions(posShape)
+        var positionIdsArray = NDArray(descriptor: resolvedPosDesc)
+        fillNDArray(&positionIdsArray, as: Int32.self, count: posShape.reduce(1, *)) { idx in
+            Int32(idx % totalPositions)
+        }
+
+        let resolvedLogitsDesc = logitsDescriptor.resolvingDynamicDimensions([1, batchSize, config.vocabSize])
+        logitsArray = NDArray(descriptor: resolvedLogitsDesc)
+
+        if explicitKV {
+            // Explicit KV mode: pass KV cache as inputs, read updated cache from outputs
+            var keyCacheOut = NDArray(descriptor: keyCacheDescriptor)
+            var valueCacheOut = NDArray(descriptor: valueCacheDescriptor)
+            var outputBackings = InferenceFunction.MutableViews()
+            outputBackings.insert(&keyCacheOut, for: keyCacheOutputName)
+            outputBackings.insert(&valueCacheOut, for: valueCacheOutputName)
+            outputBackings.insert(&logitsArray, for: logitsName)
+            _ = try await function.run(
+                inputs: [inputEmbedsName: inputEmbedsArray, positionIdsName: positionIdsArray,
+                         keyCacheName: keyCache, valueCacheName: valueCache],
+                states: InferenceFunction.MutableViews(),
+                outputViews: consume outputBackings
+            )
+            keyCache = keyCacheOut
+            valueCache = valueCacheOut
+        } else {
+            // Stateful mode: KV cache managed as states
+            var states = InferenceFunction.MutableViews()
+            states.insert(&keyCache, for: keyCacheName)
+            states.insert(&valueCache, for: valueCacheName)
+            var outputBackings = InferenceFunction.MutableViews()
+            outputBackings.insert(&logitsArray, for: logitsName)
+            _ = try await function.run(
+                inputs: [inputEmbedsName: inputEmbedsArray, positionIdsName: positionIdsArray],
+                states: consume states,
+                outputViews: consume outputBackings
+            )
+        }
+
+        let totalLogits = batchSize * config.vocabSize
+        let logitBuffer = readNDArray(logitsArray, as: LogitsScalarType.self, count: totalLogits)
+        processedTokenCount += batchSize
+        return logitBuffer
+    }
+
+    private func executeTokenBatch(tokenId: Int32) async throws -> [LogitsScalarType] {
+        guard let table = embedTable else {
+            fatalError("EmbeddingsEngine: embed_tokens not loaded")
+        }
+
+        try ensureKVCapacity(forContextLength: processedTokenCount + 1)
+
+        let resolvedEmbedsDesc = inputEmbedsDescriptor.resolvingDynamicDimensions([1, 1, hiddenSize])
+        var inputEmbedsArray = NDArray(descriptor: resolvedEmbedsDesc)
+        let offset = Int(tokenId) * hiddenSize
+        var view = inputEmbedsArray.mutableView(as: LogitsScalarType.self)
+        view.withUnsafeMutablePointer { ptr, _, _ in
+            ptr.update(from: table.baseAddress! + offset, count: hiddenSize)
+        }
+
+        let totalPositions = processedTokenCount + 1
+        let posShape: [Int] = positionIdsRank == 3 ? [1, 3, totalPositions] : [1, totalPositions]
+        let resolvedPosDesc = positionIdsDescriptor.resolvingDynamicDimensions(posShape)
+        var positionIdsArray = NDArray(descriptor: resolvedPosDesc)
+        fillNDArray(&positionIdsArray, as: Int32.self, count: posShape.reduce(1, *)) { idx in
+            Int32(idx % totalPositions)
+        }
+
+        let resolvedLogitsDesc = logitsDescriptor.resolvingDynamicDimensions([1, 1, config.vocabSize])
+        logitsArray = NDArray(descriptor: resolvedLogitsDesc)
+
+        if explicitKV {
+            var keyCacheOut = NDArray(descriptor: keyCacheDescriptor)
+            var valueCacheOut = NDArray(descriptor: valueCacheDescriptor)
+            var outputBackings = InferenceFunction.MutableViews()
+            outputBackings.insert(&keyCacheOut, for: keyCacheOutputName)
+            outputBackings.insert(&valueCacheOut, for: valueCacheOutputName)
+            outputBackings.insert(&logitsArray, for: logitsName)
+            _ = try await function.run(
+                inputs: [inputEmbedsName: inputEmbedsArray, positionIdsName: positionIdsArray,
+                         keyCacheName: keyCache, valueCacheName: valueCache],
+                states: InferenceFunction.MutableViews(),
+                outputViews: consume outputBackings
+            )
+            keyCache = keyCacheOut
+            valueCache = valueCacheOut
+        } else {
+            var states = InferenceFunction.MutableViews()
+            states.insert(&keyCache, for: keyCacheName)
+            states.insert(&valueCache, for: valueCacheName)
+            var outputBackings = InferenceFunction.MutableViews()
+            outputBackings.insert(&logitsArray, for: logitsName)
+            _ = try await function.run(
+                inputs: [inputEmbedsName: inputEmbedsArray, positionIdsName: positionIdsArray],
+                states: consume states,
+                outputViews: consume outputBackings
+            )
+        }
+
+        let logitBuffer = readNDArray(logitsArray, as: LogitsScalarType.self, count: config.vocabSize)
+        processedTokenCount += 1
+        return logitBuffer
+    }
+
+    // MARK: - Public Prefill API
+
+    /// Prefill with pre-computed combined embeddings (vision + text).
+    public func prefillWithEmbeddings(
+        _ embeddings: Data,
+        seqLen: Int,
+        progressHandler: ((Int, Int) -> Void)? = nil
+    ) async throws -> [LogitsScalarType] {
+        let chunkSize = min(seqLen, 32)
+
+        var lastLogits: [LogitsScalarType] = []
+        var offset = 0
+        let reportInterval = max(1, seqLen / 10)
+
+        while offset < seqLen {
+            let currentChunk = min(chunkSize, seqLen - offset)
+            let byteOffset = offset * hiddenSize * MemoryLayout<LogitsScalarType>.size
+            let byteCount = currentChunk * hiddenSize * MemoryLayout<LogitsScalarType>.size
+            lastLogits = try await executeEmbeddingsBatch(
+                embeddings: embeddings, byteOffset: byteOffset, byteCount: byteCount, batchSize: currentChunk)
+            offset += currentChunk
+            if offset % reportInterval < currentChunk || offset == seqLen {
+                progressHandler?(min(offset, seqLen), seqLen)
+            }
+        }
+
+        // Extract last-token logits
+        let tokensInLast = lastLogits.count / config.vocabSize
+        let lastOffset = (tokensInLast - 1) * config.vocabSize
+        prefillDone = true
+        return Array(lastLogits[lastOffset..<(lastOffset + config.vocabSize)])
+    }
+
+    // MARK: - InferenceEngine Protocol
+
+    public func inference(
+        inputTokens: [Int32], samplingConfig: SamplingConfiguration, returnsLogits: Bool
+    ) async throws -> (logits: [LogitsScalarType]?, token: Int32) {
+        guard prefillDone else {
+            throw InferenceRuntimeError.genericError("Must call prefillWithEmbeddings before inference()")
+        }
+        let logits = try await executeTokenBatch(tokenId: inputTokens.last!)
+        var mutableLogits = logits
+        let nextToken = samplingConfig.fallbackSampler(from: &mutableLogits)
+        return (logits: returnsLogits ? logits : nil, token: nextToken)
+    }
+
+    public func reset() async throws {
+        processedTokenCount = 0
+        prefillDone = false
+        zeroFill(&keyCache)
+        zeroFill(&valueCache)
+    }
+
+    public func cleanup() {
+        embedTable = nil
+        embedTableData = nil
+    }
+
+    public func warmup(queryLength: Int, sampling: SamplingConfiguration?) async throws {}
+    public func validateSamplingStrategy(_ config: SamplingConfiguration) throws {}
+
+    private func zeroFill(_ array: inout NDArray) {
+        let count = array.shape.reduce(1, *)
+        fillNDArray(&array, as: LogitsScalarType.self, count: count) { _ in LogitsScalarType(0) }
+    }
+}
+
+
+
+#endif

--- a/swift/Sources/CoreAILanguageModels/VLM/VisionEncoderRunner.swift
+++ b/swift/Sources/CoreAILanguageModels/VLM/VisionEncoderRunner.swift
@@ -1,0 +1,108 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+// Vision Encoder Runner for Qwen3-VL.
+// Loads a vision .aimodel and runs inference to transform pixel patches into visual features.
+
+import CoreAI
+import CoreAIShared
+import Foundation
+
+
+
+// MARK: - Vision Encoder Runner
+
+/// Runs a vision encoder model to transform pixel patches into visual features.
+///
+/// ## Model Signature
+/// - Input: `pixel_values: f32[784, 1536]`
+/// - Output: `image_features: f32[196, 2048]` (converted to f16)
+#if canImport(CoreAI)
+@available(macOS 27, iOS 27, *)
+public class VisionEncoderRunner: @unchecked Sendable {
+    private let function: InferenceFunction
+    private let inputName: String
+    private let outputName: String
+    private let inputDescriptor: NDArrayDescriptor
+    private let outputDescriptor: NDArrayDescriptor
+
+    public init(assetURL: URL) async throws {
+        let model = try await AIModel(contentsOf: assetURL, options: .default)
+
+        guard let descriptor = model.functionDescriptor(for: "main") else {
+            throw InferenceRuntimeError.functionNotFound("main in vision encoder")
+        }
+        guard descriptor.inputNames.count >= 1, descriptor.outputNames.count >= 1 else {
+            throw InferenceRuntimeError.genericError("vision encoder needs 1+ input and output")
+        }
+
+        self.inputName = descriptor.inputNames[0]
+        self.outputName = descriptor.outputNames[0]
+
+        guard case .ndArray(let inDesc) = descriptor.inputDescriptor(of: inputName) else {
+            throw InferenceRuntimeError.genericError("Cannot get input descriptor")
+        }
+        self.inputDescriptor = inDesc
+
+        guard case .ndArray(let outDesc) = descriptor.outputDescriptor(of: outputName) else {
+            throw InferenceRuntimeError.genericError("Cannot get output descriptor")
+        }
+        self.outputDescriptor = outDesc
+
+        guard let fn = try model.loadFunction(named: "main") else {
+            throw InferenceRuntimeError.functionNotFound("main in vision encoder")
+        }
+        self.function = fn
+    }
+
+    /// Run vision encoder on preprocessed pixel values [784, 1536] float32.
+    /// Returns [numVisualTokens * hiddenSize] Float16 values.
+    public func run(
+        pixelValues: Data,
+        numVisualTokens: Int = 196,
+        hiddenSize: Int = 2048
+    ) async throws -> [LogitsScalarType] {
+        let inputShape = inputDescriptor.shape
+        let resolvedInputDesc = inputDescriptor.resolvingDynamicDimensions(inputShape)
+        var inputArray = NDArray(descriptor: resolvedInputDesc)
+
+        pixelValues.withUnsafeBytes { src in
+            var view = inputArray.mutableView(as: Float.self)
+            view.withUnsafeMutablePointer { ptr, _, _ in
+                let count = pixelValues.count / MemoryLayout<Float>.size
+                src.baseAddress!.assumingMemoryBound(to: Float.self)
+                    .withMemoryRebound(to: Float.self, capacity: count) { srcPtr in
+                        ptr.update(from: srcPtr, count: count)
+                    }
+            }
+        }
+
+        let outputShape = outputDescriptor.shape
+        let resolvedOutputDesc = outputDescriptor.resolvingDynamicDimensions(outputShape)
+        var outputArray = NDArray(descriptor: resolvedOutputDesc)
+
+        var outputBackings = InferenceFunction.MutableViews()
+        outputBackings.insert(&outputArray, for: outputName)
+
+        _ = try await function.run(
+            inputs: [inputName: inputArray],
+            states: InferenceFunction.MutableViews(),
+            outputViews: consume outputBackings
+        )
+
+        let totalElements = numVisualTokens * hiddenSize
+        var features = [LogitsScalarType](repeating: 0, count: totalElements)
+        outputArray.view(as: Float.self).withUnsafePointer { ptr, _, _ in
+            for i in 0..<totalElements {
+                features[i] = LogitsScalarType(ptr[i])
+            }
+        }
+        return features
+    }
+}
+
+
+
+#endif

--- a/swift/Sources/CoreAIShared/Bundle/VLMConfig.swift
+++ b/swift/Sources/CoreAIShared/Bundle/VLMConfig.swift
@@ -1,0 +1,48 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+
+/// VLM-specific configuration block from the `"vision"` key in metadata.json.
+///
+/// Decoded from bundles with `kind == .vlm`. Provides vision encoder parameters
+/// and the path to the embed_tokens table used for embedding fusion.
+public struct VLMConfig: Codable, Sendable, Equatable {
+    /// Token ID used for image patch placeholders (e.g. `<|image_pad|>` = 151655 in Qwen3-VL).
+    public let imageTokenId: Int
+    /// Number of visual tokens the vision encoder produces (e.g. 196 for 448×448 / merge_size=2).
+    public let numVisualTokens: Int
+    /// Hidden dimension of the LLM decoder (must match `inputs_embeds` second dim).
+    public let hiddenSize: Int
+    /// Bundle-relative path to the float16 embedding table (vocab_size × hidden_size).
+    public let embedTokensPath: String
+
+    enum CodingKeys: String, CodingKey {
+        case imageTokenId = "image_token_id"
+        case numVisualTokens = "num_visual_tokens"
+        case hiddenSize = "hidden_size"
+        case embedTokensPath = "embed_tokens_path"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 151655
+        numVisualTokens = try c.decodeIfPresent(Int.self, forKey: .numVisualTokens) ?? 196
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 2048
+        embedTokensPath = try c.decode(String.self, forKey: .embedTokensPath)
+    }
+}
+
+// MARK: - ModelBundle extension
+
+extension ModelBundle {
+    /// Decoded `vision` block for VLM bundles. Returns nil for LLM/diffusion bundles
+    /// or if the vision block is absent or malformed.
+    public var vlm: VLMConfig? {
+        guard kind == .vlm else { return nil }
+        struct Wrapper: Decodable { let vision: VLMConfig? }
+        return (try? JSONDecoder().decode(Wrapper.self, from: raw))?.vision
+    }
+}

--- a/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
+++ b/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
@@ -56,10 +56,17 @@ struct LLMRunner: AsyncParsableCommand, Sendable {
     )
 
     @Option(
-        name: .customLong("model"),
+        name: [.customLong("model"), .customLong("model-assets")],
         help: "Path to a model bundle directory"
     )
     var model: String?
+
+    @Option(
+        name: .customLong("model-path"),
+        help:
+            "Search path for models (colon-separated). Default: ./:./exports/:~/.coreai-models/ (override with COREAI_MODEL_PATH env)"
+    )
+    var modelPath: String?
 
     @Option(help: "Input text prompt for generation (default: 'Hello, how are you?')")
     var prompt: String?
@@ -69,6 +76,12 @@ struct LLMRunner: AsyncParsableCommand, Sendable {
 
     @Option(name: .customLong("raw-tokens"), help: "JSON file with pre-tokenized tokens: {\"tokens\": [...]}")
     var rawTokens: String?
+
+    @Option(
+        name: .customLong("image"),
+        help: "Path to an image file for VLM inference (bundle must have a 'vision' component)."
+    )
+    var imagePath: String?
 
     @Option(help: "Maximum number of tokens to generate (default: 50)")
     var maxTokens: Int = 50
@@ -196,8 +209,21 @@ struct LLMRunner: AsyncParsableCommand, Sendable {
         let verboseLevel = max(self.verboseLevel ?? 0, verbose ? 1 : 0)
         CLILogger.setLevel(to: verboseLevel)
 
-        let resolver = ModelPaths()
+        let resolver = ModelPaths(override: modelPath)
         let resolvedPath = try validateAndResolveModelPath(resolver: resolver)
+
+        // VLM dispatch: --image triggers a focused multimodal path that
+        // bypasses the text-only multi-model orchestration below.
+        if let imagePath = imagePath {
+            try await VLMDispatch.run(
+                bundlePath: resolvedPath,
+                imagePath: imagePath,
+                prompt: prompt ?? "Describe this image.",
+                maxTokens: maxTokens,
+                sampling: try parseSamplingStrategy()
+            )
+            return
+        }
 
         // Test signpost right at the start
         InstrumentsProfiler.logMemoryUsage(phase: "AppStart")

--- a/swift/Sources/Tools/llm-runner/VLMDispatch.swift
+++ b/swift/Sources/Tools/llm-runner/VLMDispatch.swift
@@ -1,0 +1,48 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import ArgumentParser
+import CoreAILanguageModels
+import CoreAIShared
+import Foundation
+import FoundationModels
+
+struct VLMDispatch {
+    @available(macOS 27, iOS 27, *)
+    static func run(
+        bundlePath: String,
+        imagePath: String,
+        prompt: String,
+        maxTokens: Int,
+        sampling: SamplingConfiguration
+    ) async throws {
+        await PerformanceMetrics.shared.reset()
+        await PerformanceMetrics.shared.startOverallTiming()
+
+        let modelLoadSpan = InstrumentsProfiler.beginModelLoad(name: (bundlePath as NSString).lastPathComponent)
+        let model = try await CoreAIVisionLanguageModel(resourcesAt: URL(fileURLWithPath: bundlePath))
+        modelLoadSpan.end()
+
+        let session = LanguageModelSession(model: model)
+        let imageURL = URL(fileURLWithPath: (imagePath as NSString).expandingTildeInPath)
+        let options = GenerationOptions(maximumResponseTokens: maxTokens)
+
+        print("Generating...")
+        let t0 = ContinuousClock.now
+        var tokenCount = 0
+        for try await partial in session.streamResponse(options: options) {
+            Attachment(imageURL: imageURL)
+            prompt
+        } onPartialResponse: { partial in
+            print(partial.content, terminator: "")
+            fflush(stdout)
+            tokenCount += 1
+        }
+        let elapsed = (ContinuousClock.now - t0).inSeconds
+        print("\n\n--- \(tokenCount) tokens  \(String(format: "%.1f", Double(tokenCount) / elapsed)) tok/s ---")
+        await PerformanceMetrics.shared.endOverallTiming()
+        await PerformanceMetrics.shared.printSummary(verbose: CLILogger.isVerbose)
+    }
+}


### PR DESCRIPTION
Qwen3-VL vision-language pipeline: GPU text-decoder, a slice_scatter-based KV cache, and runner that wires into both the llm-runner CLI and the Foundation Models protocol.

```
import FoundationModels
import CoreAILanguageModels

// Load
let model = try await CoreAIQwen3VLLanguageModel(
    resourcesAt: URL(fileURLWithPath: "/path/to/qwen3_vl_folder"))
let session = LanguageModelSession(model: model)

// Single response
let response = try await session.respond(
    options: GenerationOptions(maximumResponseTokens: 200)
) {
    Attachment(imageURL: URL(fileURLWithPath: "/path/to/image.png"))
    "What is in this image?"
}
print(response.content)

// Streaming
for try await partial in session.streamResponse(
    options: GenerationOptions(maximumResponseTokens: 200)
) {
    Attachment(imageURL: imageURL)
    prompt
} {
    print(partial.content)
}
```