### PR TITLE
Swift lint on Package.swift and add Package.resolved for remote URL

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ada7bcbc202c8eeb445ad002cc4eaf91f862ef83d27dfe4f9bd72c6d039b0729",
+  "originHash" : "2a286d1351e25ad1fe90e9af62a33aeaa646452e3532732ed2f08a2134cfd2d6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -98,6 +98,15 @@
       "state" : {
         "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "xgrammar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlc-ai/xgrammar",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4d145cc13d878c751ebeed36af1c013074be76bc"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
         .target(
             name: "CXGrammar",
             dependencies: [
-                .product(name: "XGrammar", package: "xgrammar"),
+                .product(name: "XGrammar", package: "xgrammar")
             ],
             path: "swift/Sources/lib/CXGrammar",
             publicHeadersPath: "include"


### PR DESCRIPTION
## Purpose

SPM fetches all declared dependencies and writes the exact resolved versions to Package.resolved. Since we added xgrammar to Package.swift, we want to add the xgrammar pin to Package.resolved.


## Changes
  - Package.resolved: adds xgrammar remote pin
  - Package.swift: removes trailing comma flagged by swift-format