### PR TITLE
ci: run CI on self-hosted Apple Silicon macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,37 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    if: github.repository == 'apple/coreai-models'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Ensure uv
+        run: |
+          command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: uv tool install ruff
       - run: ruff check python/src/ python/tests/
       - run: ruff format --check python/src/ python/tests/
 
   swift-format:
-    runs-on: ubuntu-latest
+    if: github.repository == 'apple/coreai-models'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode-latest.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
-      - run: swift-format lint --strict --recursive swift/Sources/ swift/Tests/
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - run: swift format lint --strict --recursive swift/Sources/ swift/Tests/
 
   python-test:
-    runs-on: ubuntu-latest
+    if: github.repository == 'apple/coreai-models'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Ensure uv
+        run: |
+          command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: uv run pytest python/tests/test_model_units -x -q

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -429,13 +429,15 @@ public struct CoreAILanguageModel: LanguageModel {
                 toolCallParser = tcp
             }
 
-            await channel.send(.response(action: .updateUsage(
-                input: .init(totalTokenCount: promptTokens.count, cachedTokenCount: 0),
-                output: .init(
-                    totalTokenCount: generatedTokenCount,
-                    reasoningTokenCount: reasoningTokenCount
-                )
-            )))
+            await channel.send(
+                .response(
+                    action: .updateUsage(
+                        input: .init(totalTokenCount: promptTokens.count, cachedTokenCount: 0),
+                        output: .init(
+                            totalTokenCount: generatedTokenCount,
+                            reasoningTokenCount: reasoningTokenCount
+                        )
+                    )))
 
             // Yield to let the engine's tokenSequence Task finish cleanup
             // (putBackEngine, state reset, etc.) before the next respond().


### PR DESCRIPTION
## Summary
Moves all CI jobs onto self-hosted Apple Silicon macOS runners (`[self-hosted, macos, tahoe, ARM64]`).

The previous `ubuntu-latest` `python-test` job could not work: `coreai-torch`/`coreai-core` ship as Apple-Silicon macOS wheels and the model-unit tests need MPS. Lint and swift-format are co-located on the same runners.

## Changes
- `lint`, `swift-format`, `python-test` → `runs-on: [self-hosted, macos, tahoe, ARM64]`
- Swift toolchain now comes from Xcode via `DEVELOPER_DIR` (drops the Linux-oriented `swift-actions/setup-swift`; uses `swift format lint`)
- Pin `actions/checkout` to a full commit SHA and install `uv` via its official install script instead of third-party setup actions
- `if: github.repository == 'apple/coreai-models'` guard so forks don't run on the self-hosted runners
- Added `timeout-minutes` to every job
