### PR TITLE
Record build tool versions in exported bundle metadata

### DIFF
--- a/python/src/coreai_models/export/bundle.py
+++ b/python/src/coreai_models/export/bundle.py
@@ -5,6 +5,7 @@
 
 """Create model bundles from exported .aimodel files."""
 
+import importlib.metadata
 import json
 import logging
 from datetime import datetime
@@ -16,6 +17,26 @@ from transformers import AutoTokenizer
 logger = logging.getLogger(__name__)
 
 METADATA_VERSION = "0.2"
+
+_BUILD_INFO_PACKAGES = [
+    "coreai-core",
+    "coreai-torch",
+    "coreai-opt",
+    "coreai-models",
+    "torch",
+    "transformers",
+]
+
+
+def _get_build_info() -> dict[str, str]:
+    """Collect versions of key packages used during export."""
+    versions: dict[str, str] = {}
+    for pkg in _BUILD_INFO_PACKAGES:
+        try:
+            versions[pkg] = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            pass
+    return versions
 
 
 def bundle_llm_asset(
@@ -67,6 +88,7 @@ def _write_metadata(
             "date": datetime.now().astimezone().isoformat(),
             "targets": [],
         },
+        "build_info": _get_build_info(),
     }
     metadata_path = bundle_path / "metadata.json"
     with open(metadata_path, "w") as f:

--- a/python/tests/test_model_units/test_export/test_bundle.py
+++ b/python/tests/test_model_units/test_export/test_bundle.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+from coreai_models.export.bundle import _get_build_info
+
+
+def test_build_info_includes_core_packages():
+    info = _get_build_info()
+    assert "coreai-core" in info
+    assert "coreai-torch" in info
+    assert "coreai-opt" in info
+    assert "torch" in info
+    for version in info.values():
+        assert version  # non-empty string


### PR DESCRIPTION
Adds a `build_info` section to metadata.json capturing the versions of coreai-core, coreai-torch, coreai-opt, coreai-models, torch, and transformers used during export. This makes bundles self-documenting for debugging version-specific issues.

Example metadata.json output:
```json
  "build_info": {
    "coreai-core": "1.0.0b1",
    "coreai-torch": "0.4.0",
    "coreai-opt": "0.2.0",
    "coreai-models": "0.1.0",
    "torch": "2.9.0",
    "transformers": "4.57.6"
  }
```

Verified still accepted by the llm-runner:

```sh
% ./llm-runner --model exports/qwen3_0_6b_4bit_dynamic

⏳ Preparing AI asset from source... done in 1.160s

Generating...
<think>
Okay, the user is asking, "Hello, how are you?" I need to respond in a friendly and helpful way. Let me start by acknowledging their greeting. Since I'm an AI assistant, I should be polite and make sure to

⏱️  Performance Summary:
==================================================
Model Load: 1160.5ms
Prompt:     29.8ms, 14 tokens, 469.1 tokens/sec
Generation: 158.7ms, 50 tokens, 315.1 tokens/sec
Total:      1.539s
==================================================
```