### PR TITLE
Fix pipelined engine reset(): cancel before drain

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -186,12 +186,17 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
     }
 
     func reset() {
-        drain()
+        // Cancel active generation BEFORE draining — otherwise drain() waits
+        // forever for a producer that will never release the engine.
         _activeToken.withLock {
             $0?.cancel()
             $0 = nil
         }
-        _generationTask.withLock { $0 = nil }
+        _generationTask.withLock {
+            $0?.cancel()
+            $0 = nil
+        }
+        drain()
         guard tryAcquireEngine() else { return }
         defer { releaseEngine() }
         engine.reset()


### PR DESCRIPTION
The producer task holds the engine lock until it finishes. If the consumer stops early (e.g. EOS detected), the producer may still be running. drain() waits for the lock to be released, but cancellation was only happening AFTER drain — creating a deadlock that triggers the 5-second fatalError timeout.

Fix: cancel the GenerationToken and Task before calling drain(). The producer checks isCancelled on its next loop iteration, releases the lock, and drain() can proceed.

Fixes #41