### PR TITLE
Add macOS guards for macOS-specific function inside image-segmenter

### DIFF
--- a/swift/Sources/Tools/image-segmenter/ImageSegmentationRunnerMain.swift
+++ b/swift/Sources/Tools/image-segmenter/ImageSegmentationRunnerMain.swift
@@ -382,7 +382,9 @@ struct ImageSegmenterCLI: AsyncParsableCommand {
         }
         try writeImage(rendered, to: resolvedOutputPath)
         print("Output image written to \(resolvedOutputPath)")
+        #if os(macOS)
         openFile(at: resolvedOutputPath)
+        #endif
     }
 
     // MARK: - Rendering
@@ -503,6 +505,7 @@ struct ImageSegmenterCLI: AsyncParsableCommand {
         }
     }
 
+    #if os(macOS)
     private func openFile(at path: String) {
         let expanded = NSString(string: path).expandingTildeInPath
         let process = Process()
@@ -510,6 +513,7 @@ struct ImageSegmenterCLI: AsyncParsableCommand {
         process.arguments = [expanded]
         try? process.run()
     }
+    #endif
 
     // MARK: - Parity helpers (.npy reader + CGImage builder + metrics)
 


### PR DESCRIPTION
## Summary

The `image-segmenter` CLI tool allows users to test image segmentation. There is currently some macOS-specific behavior in it that will cause the `coreai-models-Package` build to fail if targeting iOS. This PR adds a `if os(macOS)` guard for the specific code (a helper function that opens the segmented output image after model inference was using `Process()`).

## Reproduce

In Xcode, build the `coreai-models-Package` scheme targeting `Any IOS Device`.  The build will fail with `Cannot find 'Process' in scope`.

## Verification

With this fix, that build will succeed.