### PR TITLE
Enable multi-turn KV cache reuse

### DIFF
--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -305,9 +305,6 @@ public struct CoreAILanguageModel: LanguageModel {
             let effectiveSamplingConfig = createSamplingConfig(from: request.generationOptions)
             let maxTokens = request.generationOptions.maximumResponseTokens ?? 512
 
-            // Reset engine state for new generation
-            try await engine.reset()
-
             // FoundationModels now threads entry identity itself based on event
             // ordering — we no longer mint an entryID and pass it down.
 


### PR DESCRIPTION
## Summary

- Remove unconditional `engine.reset()` from `CoreAIExecutor.respond()` to let the KV cache persist across turns
- The engine's implicit prefix caching (`TokenHistory.resolve`) already handles all cases: same-prefix reuse, divergence rewinding, and full re-processing
- Saves re-prefill of shared conversation history on every turn

## Local benchmarks (Qwen3 0.6B, M2 Max)

Multi-turn test with 2 prompts through `LanguageModelSession`:

| | Prompt 1 | Prompt 2 |
|---|---|---|
| **Before** (full reset each turn) | 0.5s | 3.0s |
| **After** (cache reuse) | 0.5s | 2.4s |

~20% improvement on prompt 2, scaling with conversation length (longer shared prefix = more prefill skipped).

Pipelined and sequential engines produce identical output with cache reuse enabled.

Closes #42

## Test plan

- [x] Full test suite passes
- [x] Multi-turn FM API verification — both engine variants pass, outputs match
- [x] LLM runner parity — determinism 3/3, quality 12/12, pipelined vs sequential match
- [x] Verify `engine.lastPrefixHitCount > 0` on turn 2+