### PR TITLE
Avoid copying embedding table in static shape runner

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -182,23 +182,16 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
             throw InferenceRuntimeError.invalidState("Cannot load 'load_embeddings'")
         }
 
-        guard case .ndArray(let embeddingDesc) = embeddingFunction.descriptor.outputDescriptor(of: "embedding_table")
+        var outputs = try await embeddingFunction.run(inputs: [:])
+        guard let embeddingTableValue = outputs.remove("embedding_table"),
+            let embeddingTableArray = embeddingTableValue.ndArray
         else {
             throw InferenceRuntimeError.invalidState(
-                "load_embeddings has no 'embedding_table' ndArray output descriptor")
+                "load_embeddings function should have output NDArray named embedding_table")
         }
-        var embeddingArray = NDArray(descriptor: embeddingDesc)
 
-        var outputViews = InferenceFunction.MutableViews()
-        outputViews.insert(&embeddingArray, for: "embedding_table")
-
-        _ = try await embeddingFunction.run(
-            inputs: [:],
-            outputViews: consume outputViews
-        )
-
-        CLILogger.log("Embeddings loaded: shape=\(embeddingArray.shape)")
-        return embeddingArray
+        CLILogger.log("Embeddings loaded: shape=\(embeddingTableArray.shape)")
+        return embeddingTableArray
     }
 
     // MARK: - Function Loading (lazy)


### PR DESCRIPTION
We currently provide a pre-allocated output view for the embedding table to CoreAI, which has it copy the embedding table into it. However since it's a constant, if we don't use the pre-allocated output view flow, it'll return an NDArray backed by the constant directly without making a copy.