### PR TITLE
Fix missing await on generate() in ConstrainedGenerator

### DIFF
--- a/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedGenerator.swift
+++ b/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedGenerator.swift
@@ -191,7 +191,7 @@ public struct ConstrainedGenerator: DecodingStrategy {
             let options = InferenceOptions(maxTokens: 1, includeLogits: true)
 
             var rawLogits: [LogitsScalarType]? = nil
-            for try await output in try inferenceEngine.generate(
+            for try await output in try await inferenceEngine.generate(
                 with: inputTokens,
                 samplingConfiguration: samplingConfiguration,
                 inferenceOptions: options


### PR DESCRIPTION
Fixes #86.

`ConstrainedGenerator.decode()` calls `InferenceEngine.generate()` which is `async throws`, but was missing the `await` keyword — causing a compile error.

```diff
-            for try await output in try inferenceEngine.generate(
+            for try await output in try await inferenceEngine.generate(
```