### PR TITLE
Use views in consuming manner, not mutating

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -300,7 +300,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     // MARK: - Causal Mask
 
     private static func fillCausalMask(
-        _ view: inout NDArray.MutableView<LogitsScalarType>,
+        _ view: consuming NDArray.MutableView<LogitsScalarType>,
         tokensInBatch: Int,
         alignedStep: Int
     ) {
@@ -501,8 +501,8 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         // Causal mask
         if case .ndArray(let nd) = desc.inputDescriptor(of: "causal_mask") {
             var mask = NDArray(descriptor: nd)
-            var maskView = mask.mutableView(as: LogitsScalarType.self)
-            Self.fillCausalMask(&maskView, tokensInBatch: tokensInBatch, alignedStep: alignedStep)
+            let maskView = mask.mutableView(as: LogitsScalarType.self)
+            Self.fillCausalMask(maskView, tokensInBatch: tokensInBatch, alignedStep: alignedStep)
             inputs["causal_mask"] = mask
         }
 


### PR DESCRIPTION
Since views are themselves immutable and non-owning, it's best to pass them around as `consuming`, not `inout`. Currently this is just a semantic improvement, but CoreAI will be making some of the accessors consuming and thus taking as `inout` will cause compilation issues since an `inout` value can't be consumed.