### PR TITLE
Fix llm-runner

### DIFF
--- a/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
+++ b/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
@@ -179,9 +179,6 @@ struct LLMRunner: AsyncParsableCommand, Sendable {
     @Option(name: .customLong("image"), help: "Path to an image file for vision-language models")
     var imagePath: String?
 
-    @Option(
-        help: "Maximum tiles for image splitting (overrides model config). 1 = single crop, no tiling.")
-
     @Flag(help: "Enable verbose logging")
     var verbose: Bool = false
 


### PR DESCRIPTION
Delete a hanging CLI option that did not have a variable definition attached to it.

Currently unused, but will be revisited in a future PR.