### PR TITLE
Lazy runner design: defer engine load

### DIFF
--- a/swift/Sources/CoreAIDiffusionPipeline/Components/CoreAIDiffusionModelFunction.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Components/CoreAIDiffusionModelFunction.swift
@@ -4,6 +4,7 @@
 // be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
 import CoreAI
+import CoreAIShared
 import Foundation
 
 /// Core AI diffusion model function — loads a fresh InferenceFunction per call

--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/Pipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/Pipeline.swift
@@ -4,6 +4,7 @@
 // be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
 import CoreAI
+import CoreAIShared
 import CoreGraphics
 
 /// Result from image generation — both displayable images and raw latents.

--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/SD3Pipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/SD3Pipeline.swift
@@ -5,6 +5,7 @@
 
 import Accelerate
 import CoreAI
+import CoreAIShared
 import CoreGraphics
 import Foundation
 

--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/StableDiffusionPipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/StableDiffusionPipeline.swift
@@ -5,6 +5,7 @@
 
 import Accelerate
 import CoreAI
+import CoreAIShared
 import CoreGraphics
 import Foundation
 

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -14,30 +14,43 @@ import Tokenizers
 /// Wraps any `InferenceEngine` (pipelined, sequential, or static-shape) and exposes it
 /// through the FoundationModels `LanguageModel` protocol. It uses the modern `tokenSequence()`
 /// API for efficient streaming token generation.
-///
 /// ## Engine Selection
 /// The engine type is determined by `EngineFactory` based on model structure:
-/// - **Pipelined**: GPU-accelerated with pipeline-depth-matched buffering (fastest for GPU models)
+/// - **Pipelined**: GPU-accelerated with double buffering (fastest for GPU models)
 /// - **Sequential**: CPU-based synchronous execution (fallback)
 /// - **Static-shape**: Neural Engine optimized for chunked static models
 ///
 /// ## Usage
 /// ```swift
-/// let engine = try await EngineFactory.createEngine(...)
-/// let model = CoreAILanguageModel(engine: engine, tokenizer: tokenizer)
+/// let model = try await CoreAILanguageModel(resourcesAt: url)  // .lazy by default
+/// print(model.estimatedSizeOnDiskBytes ?? 0)
+/// try await model.load()                                       // optional; respond auto-loads
 /// let session = LanguageModelSession(model: model)
+/// // ... generate ...
+/// model.unload()
 /// ```
 public struct CoreAILanguageModel: LanguageModel {
+    public enum LoadMode: Sendable {
+        case lazy
+        case eager
+    }
+
     // MARK: - Properties
 
-    private let engine: any InferenceEngine
-    private let tokenizer: any Tokenizer
-    private let modelIdentifier: String
-    private let samplingConfig: SamplingConfiguration
-    private let vocabSize: Int?
+    private let url: URL
+    private let variant: String?
+    private let kvCacheStrategy: KVCacheStrategy
+    fileprivate let samplingConfig: SamplingConfiguration
+    fileprivate let bundle: LanguageBundle
+    fileprivate let tokenizer: any Tokenizer
+    fileprivate let thinkingMarkers: (open: String, close: String)
+    fileprivate let toolCallMarkers: (open: String, close: String)?
     private let supportsToolCalling: Bool
-    private let supportsReasoning: Bool
-    private let additionalEosTokenIds: [Int32]
+    fileprivate let supportsReasoning: Bool
+    fileprivate let resources: ModelResources
+    /// All EOS-like token IDs beyond the tokenizer's main `eosTokenId` — e.g.
+    /// Gemma's `<end_of_turn>`, read from tokenizer_config.json at init.
+    fileprivate let additionalEosTokenIds: [Int32]
 
     // MARK: - Protocol Requirements
 
@@ -47,71 +60,124 @@ public struct CoreAILanguageModel: LanguageModel {
         var caps: [LanguageModelCapabilities.Capability] = []
         if supportsToolCalling { caps.append(.toolCalling) }
         if supportsReasoning { caps.append(.reasoning) }
-        if engine.supportsLogits { caps.append(.guidedGeneration) }
+        if isGuidedGenerationSupported { caps.append(.guidedGeneration) }
         return LanguageModelCapabilities(capabilities: caps)
     }
 
     public var executorConfiguration: CoreAIExecutor.Configuration {
         CoreAIExecutor.Configuration(
-            engine: engine,
-            tokenizer: tokenizer,
-            modelIdentifier: modelIdentifier,
+            url: url,
+            variant: variant,
+            kvCacheStrategy: kvCacheStrategy,
+            modelIdentifier: bundle.name,
             samplingConfig: samplingConfig,
-            vocabSize: vocabSize,
-            additionalEosTokenIds: additionalEosTokenIds
+            vocabSize: bundle.vocabSize
         )
     }
 
     // MARK: - Initialization
 
-    /// Creates a CoreAILanguageModel by loading a model bundle from the given URL.
-    ///
-    /// This convenience initializer handles the full pipeline: asset loading, engine creation
-    /// (auto-detected based on model structure), and tokenizer initialization.
+    /// Creates a model from a resource bundle on disk.
     ///
     /// ```swift
-    /// let model = try await CoreAILanguageModel(resourcesAt: url)
-    /// let session = LanguageModelSession(model: model)
+    /// let model = try await CoreAILanguageModel(resourcesAt: url)             // lazy
+    /// let model = try await CoreAILanguageModel(resourcesAt: url, mode: .eager)
     /// ```
     ///
     /// - Parameter url: URL to the model bundle directory.
+    /// - Parameter mode: When to load the engine. Defaults to `.lazy`. With
+    ///   `.eager`, the tokenizer and engine load concurrently
     /// - Parameter variant: Engine variant override (e.g. "coreai-sequential",
     ///   "ane"). Nil for auto-detect from model structure.
     /// - Parameter kvCacheStrategy: KV cache memory strategy. Defaults to
     ///   `.auto` (256-token initial size for dynamic models). Pass
     ///   `.fixedSize` to pre-allocate at full `maxContextLength`.
-    /// - Throws: If the asset bundle is invalid, engine creation fails, or tokenizer loading fails.
+    /// - Throws: If the asset bundle is invalid or the tokenizer fails to load.
+    ///   With `.eager`, also throws on engine-creation failure.
     public init(
         resourcesAt url: URL,
+        mode: LoadMode = .lazy,
         variant: String? = nil,
         kvCacheStrategy: KVCacheStrategy = .auto
     ) async throws {
-        let runner = try CoreAIRunner(
-            contentsOf: url,
+        let bundle = try LanguageBundle(at: url)
+        let configuration = CoreAIExecutor.Configuration(
+            url: url,
             variant: variant,
-            kvCacheStrategy: kvCacheStrategy
+            kvCacheStrategy: kvCacheStrategy,
+            modelIdentifier: bundle.name,
+            samplingConfig: .greedy,
+            vocabSize: bundle.vocabSize
         )
-        self = try await runner.makeLanguageModel()
+        let resources = ModelResources.shared(for: configuration)
+
+        async let engineLoad: Void = {
+            if mode == .eager { try await resources.loadResources() }
+        }()
+
+        let tokenizerLoadSpan = InstrumentsProfiler.beginTokenizerLoad(id: bundle.tokenizer)
+        let tokenizer = try await bundle.loadTokenizer()
+        tokenizerLoadSpan.end()
+
+        try await engineLoad
+        self.init(
+            configuration: configuration, bundle: bundle, tokenizer: tokenizer,
+            resources: resources)
     }
 
-    init(
-        engine: any InferenceEngine,
+    private init(
+        configuration: CoreAIExecutor.Configuration,
+        bundle: LanguageBundle,
         tokenizer: any Tokenizer,
-        modelIdentifier: String = "coreai-model",
-        samplingConfig: SamplingConfiguration = .greedy,
-        vocabSize: Int? = nil,
-        additionalEosTokenIds: [Int32] = []
+        resources: ModelResources
     ) {
-        self.engine = engine
+        let toolCallMarkers = CoreAIExecutor.detectToolCallMarkers(using: tokenizer)
+        self.url = configuration.url
+        self.variant = configuration.variant
+        self.kvCacheStrategy = configuration.kvCacheStrategy
+        self.samplingConfig = configuration.samplingConfig
+        self.bundle = bundle
         self.tokenizer = tokenizer
-        self.modelIdentifier = modelIdentifier
-        self.samplingConfig = samplingConfig
-        self.vocabSize = vocabSize
-        self.additionalEosTokenIds = additionalEosTokenIds
-        self.supportsToolCalling = CoreAIExecutor.detectToolCallMarkers(using: tokenizer) != nil
+        self.thinkingMarkers = CoreAIExecutor.detectThinkingMarkers(using: tokenizer)
+        self.toolCallMarkers = toolCallMarkers
+        self.supportsToolCalling = toolCallMarkers != nil
         self.supportsReasoning =
             tokenizer.convertTokenToId("<think>") != nil
             || tokenizer.convertTokenToId("<|reasoning_start|>") != nil
+        self.resources = resources
+        // Read additional stop token IDs from tokenizer_config.json (e.g. Gemma's
+        // <end_of_turn>). Empty when the bundle has no tokenizer directory.
+        if let tokenizerDir = bundle.tokenizerPath {
+            self.additionalEosTokenIds = LanguageConfig.additionalStopTokenIds(
+                from: tokenizerDir, tokenizer: tokenizer)
+        } else {
+            self.additionalEosTokenIds = []
+        }
+    }
+
+    // MARK: - Resource control
+
+    /// Estimated on-disk size of the model's main asset, in bytes.
+
+    public var estimatedSizeOnDiskBytes: Int? {
+        guard let assetURL = bundle.modelURL(for: ModelBundle.ComponentKey.main) else { return nil }
+        return assetURL.recursiveFileSizeInBytes()
+    }
+
+    public func load() async throws {
+        try await resources.loadResources()
+    }
+
+    public func unload() {
+        resources.unloadResources()
+    }
+
+    /// Whether guided generation is available for this model.
+    private var isGuidedGenerationSupported: Bool {
+        if let supportsLogits = resources.loadedEngineSupportsLogits {
+            return supportsLogits
+        }
+        return variant != "coreai-pipelined"
     }
 
     // MARK: - Executor
@@ -120,64 +186,22 @@ public struct CoreAILanguageModel: LanguageModel {
         public typealias Model = CoreAILanguageModel
 
         public struct Configuration: Hashable, Sendable {
-            fileprivate let engine: any InferenceEngine
-            fileprivate let tokenizer: any Tokenizer
-            fileprivate let modelIdentifier: String
-            fileprivate let samplingConfig: SamplingConfiguration
-            fileprivate let vocabSize: Int?
-            fileprivate let additionalEosTokenIds: [Int32]
-
-            public static func == (lhs: Configuration, rhs: Configuration) -> Bool {
-                lhs.modelIdentifier == rhs.modelIdentifier
-                    && lhs.samplingConfig == rhs.samplingConfig
-            }
-
-            public func hash(into hasher: inout Hasher) {
-                hasher.combine(modelIdentifier)
-                hasher.combine(samplingConfig)
-            }
+            let url: URL
+            let variant: String?
+            let kvCacheStrategy: KVCacheStrategy
+            let modelIdentifier: String
+            let samplingConfig: SamplingConfiguration
+            let vocabSize: Int?
         }
 
         // MARK: - Properties
 
-        private let engine: any InferenceEngine
-        private let tokenizer: any Tokenizer
-        private let modelIdentifier: String
-        private let samplingConfig: SamplingConfiguration
-        private let vocabSize: Int?
-        /// All EOS-like token IDs: the main `eosTokenId` plus any additional
-        /// stop tokens from tokenizer_config.json (e.g. Gemma's `<end_of_turn>`).
-        private let eosTokenIds: Set<Int32>
-        /// Open / close marker pair the model uses for chain-of-thought
-        /// blocks, discovered from the tokenizer's known token ids at init
-        /// (see `detectThinkingMarkers`). For models that don't emit
-        /// reasoning, the markers still default to `<think>`/`</think>` and
-        /// the parser passes everything through as `.text`.
-        private let thinkingMarkers: (open: String, close: String)
-        /// Open / close marker pair the model uses for tool call blocks,
-        /// discovered from the tokenizer's known token ids at init
-        /// (see `detectToolCallMarkers`). nil when the model's tokenizer
-        /// has no tool call tokens.
-        private let toolCallMarkers: (open: String, close: String)?
+        private let resources: ModelResources
 
         // MARK: - Initialization
 
         public init(configuration: Configuration) throws {
-            self.engine = configuration.engine
-            self.tokenizer = configuration.tokenizer
-            self.modelIdentifier = configuration.modelIdentifier
-            self.samplingConfig = configuration.samplingConfig
-            self.vocabSize = configuration.vocabSize
-            self.thinkingMarkers = Self.detectThinkingMarkers(using: configuration.tokenizer)
-            self.toolCallMarkers = Self.detectToolCallMarkers(using: configuration.tokenizer)
-
-            // Build the full set of EOS-like token IDs
-            var eos = Set<Int32>()
-            if let id = configuration.tokenizer.eosTokenId {
-                eos.insert(Int32(id))
-            }
-            eos.formUnion(configuration.additionalEosTokenIds)
-            self.eosTokenIds = eos
+            self.resources = ModelResources.shared(for: configuration)
         }
 
         /// Probes the tokenizer for known reasoning marker pairs. Each
@@ -191,7 +215,7 @@ public struct CoreAILanguageModel: LanguageModel {
         /// markers. For models with non-pair-symmetric formats (e.g.
         /// gpt-oss / Harmony), a different parser is needed; this one
         /// covers the `<open>...</close>` shape.
-        private static func detectThinkingMarkers(
+        fileprivate static func detectThinkingMarkers(
             using tokenizer: any Tokenizer
         ) -> (open: String, close: String) {
             let candidates: [(open: String, close: String)] = [
@@ -240,38 +264,11 @@ public struct CoreAILanguageModel: LanguageModel {
             return nil
         }
 
-        // MARK: - Prewarm
+        // MARK: - Prewarm (FoundationModels, synchronous)
 
-        public func prewarm(transcript: Transcript) throws {
-            // Use engine's warmup method - blocks until warmup completes.
-            //
-            // We dispatch async work onto a dedicated DispatchQueue instead of using
-            // Task { } + semaphore.wait(). This avoids deadlock: if prewarm() is called
-            // from a Swift Concurrency cooperative thread, semaphore.wait() would block
-            // a cooperative thread while Task { } needs one to run — thread starvation.
-            //
-            // With DispatchQueue, the async work runs on a GCD thread (not the cooperative
-            // pool), so semaphore.wait() on the calling thread is safe.
-            let semaphore = DispatchSemaphore(value: 0)
-            let warmupError: Mutex<(any Error)?> = Mutex(nil)
-
-            let queue = DispatchQueue(label: "com.coreai.prewarm")
-            queue.async {
-                Task {
-                    do {
-                        try await self.engine.warmup(queryLength: 1, sampling: nil)
-                    } catch {
-                        warmupError.withLock({ $0 = error })
-                    }
-                    semaphore.signal()
-                }
-            }
-
-            semaphore.wait()
-
-            if let error: any Error = warmupError.withLock(\.self) {
-                throw error
-            }
+        /// Kicks off the engine load in the background.
+        public func prewarm(model: CoreAILanguageModel, transcript: Transcript) {
+            Task { try? await resources.loadResources() }
         }
 
         // MARK: - respond(to:model:streamingInto:) — new channel-based API
@@ -285,7 +282,7 @@ public struct CoreAILanguageModel: LanguageModel {
             let tokenizationSpan = InstrumentsProfiler.beginTokenization(inputLength: 0)
             let promptTokens = Self.makeTokens(
                 from: Array(request.transcript),
-                using: tokenizer,
+                using: model.tokenizer,
                 tools: request.enabledToolDefinitions,
                 component: "CoreAIExecutor"
             )
@@ -302,47 +299,75 @@ public struct CoreAILanguageModel: LanguageModel {
 
             CLILogger.log("Tokenized \(promptTokens.count) tokens", component: "CoreAIExecutor")
 
-            let effectiveSamplingConfig = createSamplingConfig(from: request.generationOptions)
-            let maxTokens = request.generationOptions.maximumResponseTokens ?? 512
+            let effectiveSamplingConfig = makeSamplingConfig(
+                from: request.generationOptions, base: model.samplingConfig)
+            let defaultMaxTokens = model.supportsReasoning ? 2048 : 512
+            let maxTokens = request.generationOptions.maximumResponseTokens ?? defaultMaxTokens
 
-            // FoundationModels now threads entry identity itself based on event
-            // ordering — we no longer mint an entryID and pass it down.
+            // Borrow the engine for the whole generation.
+            try await resources.withEngine { engine in
+                // Reset engine state for new generation
+                try await engine.reset()
 
-            // Check if guided generation is requested
-            if let schema = request.schema {
-                try await respondConstrained(
-                    schema: schema,
-                    promptTokens: promptTokens,
-                    samplingConfig: effectiveSamplingConfig,
-                    maxTokens: maxTokens,
-                    channel: channel
-                )
-            } else {
-                try await respondVanilla(
-                    promptTokens: promptTokens,
-                    samplingConfig: effectiveSamplingConfig,
-                    maxTokens: maxTokens,
-                    channel: channel
-                )
+                // FoundationModels now threads entry identity itself based on event
+                // ordering — we no longer mint an entryID and pass it down.
+
+                // Check if guided generation is requested
+                if let schema = request.schema {
+                    guard engine.supportsLogits else {
+                        throw LanguageModelError.unsupportedCapability(
+                            .init(
+                                capability: .guidedGeneration,
+                                debugDescription:
+                                    "This model's inference engine does not support guided generation "
+                                    + "(constrained decoding requires per-step logits)."
+                            )
+                        )
+                    }
+                    try await respondConstrained(
+                        engine: engine,
+                        model: model,
+                        schema: schema,
+                        promptTokens: promptTokens,
+                        samplingConfig: effectiveSamplingConfig,
+                        maxTokens: maxTokens,
+                        channel: channel
+                    )
+                } else {
+                    try await respondVanilla(
+                        engine: engine,
+                        model: model,
+                        promptTokens: promptTokens,
+                        samplingConfig: effectiveSamplingConfig,
+                        maxTokens: maxTokens,
+                        channel: channel
+                    )
+                }
             }
         }
 
         // MARK: - Vanilla Generation (no schema)
 
         private func respondVanilla(
+            engine: any InferenceEngine,
+            model: CoreAILanguageModel,
             promptTokens: [Int],
             samplingConfig: SamplingConfiguration,
             maxTokens: Int,
             channel: LanguageModelExecutorGenerationChannel
         ) async throws {
+            let tokenizer = model.tokenizer
             let tokenStream = try await engine.generate(
                 with: promptTokens.map(Int32.init),
                 samplingConfiguration: samplingConfig,
                 inferenceOptions: InferenceOptions(maxTokens: maxTokens)
             )
 
-            // Use pre-computed set of all EOS-like tokens (main + additional)
-            let eosTokens = eosTokenIds
+            // All EOS-like tokens: the tokenizer's main EOS plus any additional
+            // stop tokens from tokenizer_config.json (e.g. Gemma's <end_of_turn>).
+            var eosTokens = Set<Int32>()
+            if let id = tokenizer.eosTokenId { eosTokens.insert(Int32(id)) }
+            eosTokens.formUnion(model.additionalEosTokenIds)
             // Incremental-decode buffer. After a clean emit, one token is
             // retained as context for the next step (see below). During a
             // multi-byte sequence that hasn't decoded cleanly yet, multiple
@@ -358,14 +383,14 @@ public struct CoreAILanguageModel: LanguageModel {
             // to a top-level `.reasoning(...)` channel event so it lands as
             // its own `Transcript.Reasoning` entry, not mixed into the
             // user-facing `Transcript.Response`. Markers were resolved at
-            // executor init from the tokenizer's known token ids.
+            // model init from the tokenizer's known token ids.
             var thinkParser = ThinkTagParser(
-                open: thinkingMarkers.open,
-                close: thinkingMarkers.close
+                open: model.thinkingMarkers.open,
+                close: model.thinkingMarkers.close
             )
             // Routes tool call markup to .toolCalls(...) channel events.
             // nil when the model's tokenizer has no tool call tokens.
-            var toolCallParser: ToolCallParser? = toolCallMarkers.map {
+            var toolCallParser: ToolCallParser? = model.toolCallMarkers.map {
                 ToolCallParser(openMarker: $0.open, closeMarker: $0.close)
             }
             var generatedTokenCount: Int = 0
@@ -524,6 +549,8 @@ public struct CoreAILanguageModel: LanguageModel {
         // MARK: - Constrained Generation (with schema)
 
         private func respondConstrained(
+            engine: any InferenceEngine,
+            model: CoreAILanguageModel,
             schema: GenerationSchema,
             promptTokens: [Int],
             samplingConfig: SamplingConfiguration,
@@ -536,15 +563,16 @@ public struct CoreAILanguageModel: LanguageModel {
                 preconditionFailure("GenerationSchema JSON encoding produced invalid UTF-8")
             }
 
-            let strategy = ConstrainedDecodingStrategy(jsonSchema: jsonSchema, vocabSize: vocabSize)
+            let strategy = ConstrainedDecodingStrategy(
+                jsonSchema: jsonSchema, vocabSize: model.bundle.vocabSize)
             let stopSequences = StopSequences(
-                for: tokenizer,
-                additionalEosTokenIds: Array(eosTokenIds)
+                for: model.tokenizer,
+                additionalEosTokenIds: model.additionalEosTokenIds
             )
 
             let stream = try await strategy.decode(
                 from: .tokens(promptTokens),
-                tokenizer: tokenizer,
+                tokenizer: model.tokenizer,
                 inferenceEngine: engine,
                 samplingConfiguration: samplingConfig,
                 options: InferenceOptions(maxTokens: maxTokens),
@@ -560,9 +588,15 @@ public struct CoreAILanguageModel: LanguageModel {
                 )
             }
 
-            // Usage telemetry placeholder — awaiting Usage(input:output:) API.
-            _ = promptTokens.count
-            _ = generatedTokenCount
+            await channel.send(
+                .response(
+                    action: .updateUsage(
+                        input: .init(totalTokenCount: promptTokens.count, cachedTokenCount: 0),
+                        output: .init(
+                            totalTokenCount: generatedTokenCount,
+                            reasoningTokenCount: 0
+                        )
+                    )))
 
             // Yield to let the engine's tokenSequence Task finish cleanup
             // (putBackEngine, state reset, etc.) before the next respond().
@@ -733,11 +767,14 @@ public struct CoreAILanguageModel: LanguageModel {
 
         // MARK: - Helper Methods
 
-        private func createSamplingConfig(from options: GenerationOptions) -> SamplingConfiguration {
+        private func makeSamplingConfig(
+            from options: GenerationOptions,
+            base: SamplingConfiguration
+        ) -> SamplingConfiguration {
             if let temperature = options.temperature {
                 return SamplingConfiguration(temperature: temperature)
             }
-            return samplingConfig
+            return base
         }
     }
 }

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -16,7 +16,7 @@ import Tokenizers
 /// API for efficient streaming token generation.
 /// ## Engine Selection
 /// The engine type is determined by `EngineFactory` based on model structure:
-/// - **Pipelined**: GPU-accelerated with double buffering (fastest for GPU models)
+/// - **Pipelined**: GPU-accelerated with pipeline-depth-matched buffering (fastest for GPU models)
 /// - **Sequential**: CPU-based synchronous execution (fallback)
 /// - **Static-shape**: Neural Engine optimized for chunked static models
 ///

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -306,9 +306,6 @@ public struct CoreAILanguageModel: LanguageModel {
 
             // Borrow the engine for the whole generation.
             try await resources.withEngine { engine in
-                // Reset engine state for new generation
-                try await engine.reset()
-
                 // FoundationModels now threads entry identity itself based on event
                 // ordering — we no longer mint an entryID and pass it down.
 

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAIRunner.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAIRunner.swift
@@ -14,8 +14,7 @@ import Tokenizers
 /// ```swift
 /// let url = URL(fileURLWithPath: "/path/to/model")
 /// let runner = try CoreAIRunner(contentsOf: url)
-/// let model = try await runner.makeLanguageModel()
-/// let session = LanguageModelSession(model: model)
+/// let engine = try await runner.makeInferenceEngine()
 /// ```
 public struct CoreAIRunner {
     // MARK: - Properties
@@ -66,36 +65,6 @@ public struct CoreAIRunner {
             config: configData,
             modelURL: try bundle.requireModelURL(for: ModelBundle.ComponentKey.main),
             options: options
-        )
-    }
-
-    /// Creates a LanguageModel for FM API usage.
-    func makeLanguageModel() async throws -> CoreAILanguageModel {
-        let modelLoadSpan = InstrumentsProfiler.beginModelLoad(name: bundle.name)
-        let engine = try await makeInferenceEngine()
-        modelLoadSpan.end()
-
-        let tokenizerLoadSpan = InstrumentsProfiler.beginTokenizerLoad(
-            id: bundle.tokenizer)
-        let tokenizer = try await bundle.loadTokenizer()
-        tokenizerLoadSpan.end()
-
-        // Read additional stop token IDs from tokenizer_config.json
-        let additionalEos: [Int32]
-        if let tokenizerDir = bundle.tokenizerPath {
-            additionalEos = LanguageConfig.additionalStopTokenIds(
-                from: tokenizerDir, tokenizer: tokenizer)
-        } else {
-            additionalEos = []
-        }
-
-        return CoreAILanguageModel(
-            engine: engine,
-            tokenizer: tokenizer,
-            modelIdentifier: bundle.name,
-            samplingConfig: SamplingConfiguration.greedy,
-            vocabSize: bundle.vocabSize,
-            additionalEosTokenIds: additionalEos
         )
     }
 

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/ModelResources.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/ModelResources.swift
@@ -1,0 +1,163 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAIShared
+import Foundation
+import Synchronization
+
+// MARK: - Resource management
+
+/// Owns the load / unload lifecycle of a single inference engine.
+final class ModelResources: ResourceManaging {
+    private struct State {
+        var loaded: (any InferenceEngine)?
+        var inFlight: Task<any InferenceEngine, any Error>?
+        var activeBorrows: Int = 0
+        /// Set when `unloadResources()` is called mid-borrow.
+        var unloadPending: Bool = false
+        /// Bumped by every teardown; lets an in-flight load detect it was cancelled.
+        var generation: Int = 0
+    }
+
+    private let state = Mutex(State())
+    private let loader: @Sendable () async throws -> any InferenceEngine
+
+    /// Production initializer: loads via `CoreAIRunner` from the configuration.
+    init(configuration: CoreAILanguageModel.CoreAIExecutor.Configuration) {
+        self.loader = { try await ModelResources.loadEngine(configuration) }
+    }
+
+    /// Testable initializer: inject a custom engine loader.
+    init(loader: @escaping @Sendable () async throws -> any InferenceEngine) {
+        self.loader = loader
+    }
+
+    var isLoaded: Bool { state.withLock { $0.loaded != nil } }
+
+    /// `supportsLogits` of the resident engine, or `nil` when nothing is loaded.
+    /// Used only for best-effort capability reporting before a load.
+    var loadedEngineSupportsLogits: Bool? {
+        state.withLock { $0.loaded?.supportsLogits }
+    }
+
+    /// Returns the engine, loading it on first use. Concurrent callers share one
+    /// load; later callers get the warmed engine instantly.
+    func engine() async throws -> any InferenceEngine {
+        if let loaded = state.withLock({ $0.loaded }) { return loaded }
+
+        let (task, generation): (Task<any InferenceEngine, any Error>, Int) = state.withLock {
+            current in
+            if let inFlight = current.inFlight { return (inFlight, current.generation) }
+            let task = Task { try await self.loader() }
+            current.inFlight = task
+            return (task, current.generation)
+        }
+
+        do {
+            let engine = try await task.value
+            state.withLock { current in
+                // Only commit if we weren't unloaded mid-flight.
+                guard current.generation == generation else { return }
+                current.loaded = engine
+                current.inFlight = nil
+            }
+            return engine
+        } catch {
+            state.withLock { current in
+                guard current.generation == generation else { return }
+                // Don't cache failures — drop the task so the next caller retries.
+                current.inFlight = nil
+            }
+            throw error
+        }
+    }
+
+    /// Borrows the engine for the duration of `body`, counting it as an active
+    /// use. A concurrent `unloadResources()` defers its teardown until the last
+    /// borrow returns, so the engine is never freed mid-generation.
+    func withEngine<T>(
+        _ body: (any InferenceEngine) async throws -> T
+    ) async throws -> T {
+        let engine = try await engine()
+        state.withLock { $0.activeBorrows += 1 }
+        defer {
+            let shouldTeardown = state.withLock { current -> Bool in
+                current.activeBorrows -= 1
+                guard current.activeBorrows == 0, current.unloadPending else { return false }
+                current.unloadPending = false
+                return true
+            }
+            if shouldTeardown { teardown() }
+        }
+        return try await body(engine)
+    }
+
+    // MARK: - ResourceManaging
+
+    /// Explicitly loads + warms the engine. No-op if already loaded.
+    func loadResources() async throws {
+        _ = try await engine()
+    }
+
+    func unloadResources() {
+        let deferred = state.withLock { current -> Bool in
+            guard current.activeBorrows > 0 else { return false }
+            current.unloadPending = true
+            return true
+        }
+        if deferred { return }
+        teardown()
+    }
+
+    /// Drops the cached engine and cancels any in-flight load
+    private func teardown() {
+        state.withLock { current in
+            current.inFlight?.cancel()
+            current.inFlight = nil
+            current.loaded = nil
+            current.generation &+= 1
+        }
+    }
+
+    // MARK: - Shared registry
+
+    /// Weak box so the registry doesn't keep a `ModelResources` (and its engine)
+    /// alive after every owning model/executor has been released.
+    private final class WeakBox {
+        weak var value: ModelResources?
+        init(_ value: ModelResources) { self.value = value }
+    }
+
+    private static let registry =
+        Mutex<[CoreAILanguageModel.CoreAIExecutor.Configuration: WeakBox]>([:])
+
+    static func shared(
+        for configuration: CoreAILanguageModel.CoreAIExecutor.Configuration
+    ) -> ModelResources {
+        registry.withLock { table in
+            if let existing = table[configuration]?.value { return existing }
+            let resources = ModelResources(configuration: configuration)
+            table[configuration] = WeakBox(resources)
+            table = table.filter { $0.value.value != nil }
+            return resources
+        }
+    }
+
+    private static func loadEngine(
+        _ configuration: CoreAILanguageModel.CoreAIExecutor.Configuration
+    ) async throws -> any InferenceEngine {
+        let modelLoadSpan = InstrumentsProfiler.beginModelLoad(name: configuration.modelIdentifier)
+        let runner = try CoreAIRunner(
+            contentsOf: configuration.url,
+            variant: configuration.variant,
+            kvCacheStrategy: configuration.kvCacheStrategy
+        )
+        let engine = try await runner.makeInferenceEngine()
+        modelLoadSpan.end()
+
+        try await engine.warmup(queryLength: 1, sampling: nil)
+        return engine
+    }
+}

--- a/swift/Sources/CoreAIShared/Runtime/FileSize.swift
+++ b/swift/Sources/CoreAIShared/Runtime/FileSize.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+
+extension URL {
+    /// Recursively sums the on-disk byte size of the file or directory at this URL.
+    ///
+    /// For a single file this is its size; for a directory it is the sum of all
+    /// contained files' sizes (descending into subdirectories). This reflects
+    /// bytes on disk, not resident memory.
+    ///
+    /// - Returns: Total size in bytes, or `nil` if the path does not exist or
+    ///   its attributes cannot be read.
+    public func recursiveFileSizeInBytes() -> Int? {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: path, isDirectory: &isDirectory) else { return nil }
+
+        if !isDirectory.boolValue {
+            return (try? fm.attributesOfItem(atPath: path)[.size] as? Int) ?? nil
+        }
+
+        guard
+            let enumerator = fm.enumerator(
+                at: self, includingPropertiesForKeys: [.fileSizeKey], options: [])
+        else { return nil }
+
+        var total = 0
+        for case let fileURL as URL in enumerator {
+            if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += size
+            }
+        }
+        return total
+    }
+}

--- a/swift/Sources/CoreAIShared/Runtime/ResourceManaging.swift
+++ b/swift/Sources/CoreAIShared/Runtime/ResourceManaging.swift
@@ -6,6 +6,7 @@
 import Foundation
 
 /// Lifecycle management for lazily-loaded resources (models, buffers).
+///
 public protocol ResourceManaging: Sendable {
     /// Load model weights and allocate inference buffers.
     func loadResources() async throws

--- a/swift/Tests/CoreAISharedTests/FileSizeTests.swift
+++ b/swift/Tests/CoreAISharedTests/FileSizeTests.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+import Testing
+
+@testable import CoreAIShared
+
+@Suite("URL.recursiveFileSizeInBytes")
+struct FileSizeTests {
+    /// Creates a unique temporary directory for the test and removes it after.
+    private func withTempDirectory(_ body: (URL) throws -> Void) throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appending(
+            path: "filesize-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        try body(dir)
+    }
+
+    @Test("Single file returns its byte size")
+    func singleFile() throws {
+        try withTempDirectory { dir in
+            let file = dir.appending(path: "a.bin")
+            let bytes = Data(repeating: 0, count: 1234)
+            try bytes.write(to: file)
+            #expect(file.recursiveFileSizeInBytes() == 1234)
+        }
+    }
+
+    @Test("Directory sums all nested files")
+    func directorySumsRecursively() throws {
+        try withTempDirectory { dir in
+            try Data(repeating: 0, count: 100).write(to: dir.appending(path: "a.bin"))
+            let sub = dir.appending(path: "sub", directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            try Data(repeating: 0, count: 250).write(to: sub.appending(path: "b.bin"))
+            #expect(dir.recursiveFileSizeInBytes() == 350)
+        }
+    }
+
+    @Test("Missing path returns nil")
+    func missingPathReturnsNil() throws {
+        let missing = FileManager.default.temporaryDirectory.appending(
+            path: "does-not-exist-\(UUID().uuidString)")
+        #expect(missing.recursiveFileSizeInBytes() == nil)
+    }
+}

--- a/swift/Tests/LanguageModelsTests/ModelResourcesTests.swift
+++ b/swift/Tests/LanguageModelsTests/ModelResourcesTests.swift
@@ -1,0 +1,134 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+import Synchronization
+import Testing
+
+@testable import CoreAILanguageModels
+
+/// Unit tests for the resource lifecycle (`loadResources`/`unloadResources`,
+/// load-once, retry-on-failure, and deferred teardown during an active borrow)
+/// using an injected loader — no real engine or weights needed.
+@Suite("ModelResources lifecycle")
+struct ModelResourcesTests {
+    private struct LoadFailure: Error {}
+
+    @Test("Lazy: nothing loads until first use")
+    func lazyDefersLoad() {
+        let calls = Mutex(0)
+        let resources = ModelResources {
+            calls.withLock { $0 += 1 }
+            return MockEngine()
+        }
+        #expect(resources.isLoaded == false)
+        #expect(calls.withLock { $0 } == 0)
+    }
+
+    @Test("load() marks loaded and runs the loader exactly once")
+    func loadOnce() async throws {
+        let calls = Mutex(0)
+        let resources = ModelResources {
+            calls.withLock { $0 += 1 }
+            return MockEngine()
+        }
+
+        let first = try await resources.engine()
+        let second = try await resources.engine()
+
+        #expect(resources.isLoaded)
+        #expect(calls.withLock { $0 } == 1)
+        // Same cached instance returned both times.
+        #expect((first as? MockEngine) === (second as? MockEngine))
+    }
+
+    @Test("unload() frees the engine; next use reloads")
+    func unloadThenReload() async throws {
+        let calls = Mutex(0)
+        let resources = ModelResources {
+            calls.withLock { $0 += 1 }
+            return MockEngine()
+        }
+
+        _ = try await resources.engine()
+        #expect(resources.isLoaded)
+
+        resources.unloadResources()
+        #expect(resources.isLoaded == false)
+
+        _ = try await resources.engine()
+        #expect(resources.isLoaded)
+        #expect(calls.withLock { $0 } == 2)
+    }
+
+    @Test("Failures aren't cached — the next call retries")
+    func retriesOnFailure() async throws {
+        let calls = Mutex(0)
+        let resources = ModelResources {
+            let attempt = calls.withLock { count -> Int in
+                count += 1
+                return count
+            }
+            if attempt == 1 { throw LoadFailure() }
+            return MockEngine()
+        }
+
+        await #expect(throws: LoadFailure.self) {
+            _ = try await resources.engine()
+        }
+        #expect(resources.isLoaded == false)
+
+        // Second attempt succeeds.
+        _ = try await resources.engine()
+        #expect(resources.isLoaded)
+        #expect(calls.withLock { $0 } == 2)
+    }
+
+    @Test("Concurrent callers share a single load")
+    func concurrentCallersLoadOnce() async throws {
+        let calls = Mutex(0)
+        let resources = ModelResources {
+            calls.withLock { $0 += 1 }
+            // Widen the race window so all callers pile onto the same in-flight load.
+            try? await Task.sleep(for: .milliseconds(20))
+            return MockEngine()
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask { _ = try await resources.engine() }
+            }
+            try await group.waitForAll()
+        }
+
+        #expect(calls.withLock { $0 } == 1)
+        #expect(resources.isLoaded)
+    }
+
+    @Test("unloadResources during an active borrow defers teardown until it finishes")
+    func unloadDeferredDuringActiveBorrow() async throws {
+        let resources = ModelResources { MockEngine() }
+        let inside = Mutex(false)
+        let release = Mutex(false)
+
+        // Hold a borrow open until the test releases it.
+        async let borrow: Void = resources.withEngine { _ in
+            inside.withLock { $0 = true }
+            while !release.withLock({ $0 }) { await Task.yield() }
+        }
+
+        // Once the body is running, the borrow has been counted.
+        while !inside.withLock({ $0 }) { await Task.yield() }
+
+        // Unload requested mid-borrow must be deferred, not applied.
+        resources.unloadResources()
+        #expect(resources.isLoaded)
+
+        // Let the borrow finish; the deferred teardown then runs.
+        release.withLock { $0 = true }
+        try await borrow
+        #expect(resources.isLoaded == false)
+    }
+}

--- a/swift/Tests/LanguageModelsTests/PublicInterfaceTests.swift
+++ b/swift/Tests/LanguageModelsTests/PublicInterfaceTests.swift
@@ -32,4 +32,16 @@ struct PublicInterfaceTests {
             _ = response.content
         }
     }
+
+    /// Compile-time check that the resource-control surface
+    @Test("Resource-control API compiles (runtime throws on missing asset)")
+    func resourceControlAPICompiles() async {
+        let missing = URL(fileURLWithPath: "/nonexistent/model")
+        await #expect(throws: (any Error).self) {
+            let model = try await CoreAILanguageModel(resourcesAt: missing, mode: .lazy)
+            _ = model.estimatedSizeOnDiskBytes
+            try await model.load()
+            model.unload()
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
Introduces lazy inference-engine lifecycle management for the FoundationModels adoption layer. Instead of CoreAILanguageModel holding a live engine from construction, engine load/unload is now owned by a new ModelResources type: lazy by default, loaded on first respond(...) (or explicitly via load()), borrowed per-generation, and releasable via unload(). This lets callers construct a model cheaply, query its on-disk footprint, and control when the (expensive) engine actually loads.

## Changes

- **ModelResources (new)** — owns the engine's load/unload lifecycle. Concurrent callers share a single in-flight load; `withEngine { }` borrows the engine for the duration of a generation and defers teardown if an `unload()` races an active borrow. Shared per-configuration via a weak registry.
- **CoreAILanguageModel** — now builds directly from LanguageBundle (removes the `CoreAIRunner.makeLanguageModel()` hop). Adds:
  - `LoadMode { .lazy, .eager }` (default `.lazy`; `.eager` loads tokenizer + engine concurrently)
  - `load()` / `unload()` / `estimatedSizeOnDiskBytes`
  - guided-generation capability gating that works before the engine is resident (`isGuidedGenerationSupported`)
  - reasoning models default to a higher max-token budget
- **prewarm** — now kicks off the engine load in the background (non-blocking) instead of a synchronous semaphore wait.
- **ResourceManaging** — moved from CoreAIDiffusionPipeline/Components/ to CoreAIShared/Runtime/; diffusion pipelines updated to import it from the shared module.
- **FileSize (new)** — `URL.recursiveFileSizeInBytes()` helper backing `estimatedSizeOnDiskBytes`.
- **Tests** — ModelResourcesTests (load/unload/borrow races via an injectable loader), FileSizeTests, and PublicInterfaceTests additions.