### PR TITLE
VLM export: download tokenizer files for a clean cache

### DIFF
--- a/python/src/coreai_models/vlm/export.py
+++ b/python/src/coreai_models/vlm/export.py
@@ -260,7 +260,15 @@ async def export_text_bundle(
     logging.info(f"Downloading {spec.hf_model_id}...")
     model_dir = snapshot_download(
         spec.hf_model_id,
-        allow_patterns=["*.safetensors", "*.safetensors.index.json", "config.json"],
+        allow_patterns=[
+            "*.safetensors",
+            "*.safetensors.index.json",
+            "config.json",
+            "tokenizer*",
+            "vocab.json",
+            "merges.txt",
+            "*.model",
+        ],
     )
     raw_cfg = AutoConfig.from_pretrained(model_dir)
     text_cfg = raw_cfg.text_config


### PR DESCRIPTION
## Purpose
Without the tokenizer already cached, a fresh export fails at saving tokenizer step

## Changes
Add the tokenizer patterns (`tokenizer*`, `vocab.json`, `merges.txt`, `*.model`) to `allowed_patterns`