### PR TITLE
Fix Qwen3-VL normalization: use 0.5/0.5/0.5 from checkpoint

### DIFF
--- a/python/src/coreai_models/vlm/export.py
+++ b/python/src/coreai_models/vlm/export.py
@@ -81,8 +81,8 @@ SUPPORTED_MODELS: dict[str, VLMSpec] = {
         patch_size=16,
         spatial_merge_size=2,
         temporal_patch_size=2,  # Qwen frames-per-image (single image -> duplicated)
-        image_mean=(0.48145466, 0.4578275, 0.40821073),
-        image_std=(0.26862954, 0.26130258, 0.27577711),
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
         rescale_factor=1.0,
     ),
 }


### PR DESCRIPTION
The qwen3-vl VLMSpec hardcoded OpenAI-CLIP normalization stats, but Qwen3-VL checkpoints specify image_mean=image_std=[0.5, 0.5, 0.5]. This caused a silent ~1.86x overscale on every pixel fed to the vision encoder.

Fixes #82.

Tested locally. Now it identifies background colors more correctly.