### PR TITLE
Add GPU-based constrained sampling for pipelined engine

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -9,6 +9,7 @@ import Foundation
 import Metal
 import MetalPerformanceShaders
 import Synchronization
+import Tokenizers
 import os
 
 // MARK: - Timing
@@ -41,7 +42,7 @@ private let minimumMPSNDArrayBufferSize = 64
 /// - Pipeline-depth-matched buffer rotation for CPU/GPU overlap
 /// - Growing KV cache with pipelined expansion
 /// - All tensors are owned MTLBuffers — Core AI never allocates/frees them
-final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
+final class CoreAIPipelinedEngine: InferenceEngine, ConstrainedGenerationCapable, Sendable {
     typealias ConfigType = ModelConfig
 
     nonisolated(unsafe) private var engine: EngineImpl
@@ -59,6 +60,9 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
     // Generation lifecycle
     private let _activeToken = Mutex<GenerationToken?>(nil)
     private let _generationTask = Mutex<Task<Void, Never>?>(nil)
+
+    // Constrained session cache — checkout/checkin pattern for reuse across calls
+    private let _constrainedSessionCache = Mutex<ConstrainedSessionHandle?>(nil)
 
     var isBusy: Bool { _activeToken.withLock { $0 != nil } }
 
@@ -242,6 +246,64 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
         return GenerationSequence(base: base, stopReasonStore: stopReasonStore)
     }
 
+    // MARK: - Constrained Generation (GPU bitmask path)
+
+    /// Generate tokens with grammar-constrained sampling on GPU.
+    ///
+    /// Unlike `generate()`, this method applies an xgrammar bitmask inside the GPU sampler
+    /// each step, enabling constrained decoding without falling back to the sequential engine.
+    ///
+    /// The loop is semi-pipelined: inference overlaps with bitmask computation, but sampling
+    /// waits per token (grammar state is inherently sequential).
+    func generateConstrained(
+        with input: [TokenId],
+        samplingConfiguration: SamplingConfiguration,
+        maxTokens: Int,
+        session: ConstrainedSessionHandle
+    ) throws -> AsyncThrowingStream<TokenId, Error> {
+        let (stream, continuation) = AsyncThrowingStream<TokenId, Error>.makeStream()
+
+        let sessionBox = session
+        let isCancelled = Atomic<Bool>(false)
+        continuation.onTermination = { _ in
+            isCancelled.store(true, ordering: .relaxed)
+        }
+
+        let token = GenerationToken()
+        _activeToken.withLock { $0 = token }
+
+        let task = Task {
+            self.acquireEngine()
+            defer {
+                self.releaseEngine()
+                self.storeConstrainedSessionForReuse(sessionBox)
+                if self._activeToken.withLock({ $0 === token }) {
+                    self._activeToken.withLock { $0 = nil }
+                    self._generationTask.withLock { $0 = nil }
+                }
+            }
+            self.engine.reset()
+            do {
+                try await self.engine.runConstrainedCompletion(
+                    prompt: input,
+                    sampler: samplingConfiguration,
+                    sessionBox: sessionBox,
+                    maxTokens: maxTokens,
+                    isCancelled: isCancelled,
+                    yieldingTo: continuation
+                )
+                continuation.finish()
+            } catch is CancellationError {
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        _generationTask.withLock { $0 = task }
+
+        return stream
+    }
+
     /// Wait for any in-flight generate() Task to return the engine.
     private func drain() {
         var attempts = 0
@@ -325,6 +387,98 @@ final class CoreAIPipelinedEngine: InferenceEngine, Sendable {
         acquireEngine()
         defer { releaseEngine() }
         try await engine.performWarmup(queryLength: queryLength, samplingConfig: sampling)
+    }
+}
+
+// MARK: - Constrained Session Cache
+
+extension CoreAIPipelinedEngine {
+    /// Check out a constrained session from the cache, or create a new one.
+    /// The cache slot is emptied — concurrent calls get independent sessions.
+    func getOrCreateConstrainedSession(
+        jsonSchema: String,
+        tokenizer: any Tokenizer,
+        vocabSize: Int,
+        stopTokenIds: [Int32]?
+    ) throws -> ConstrainedSessionHandle {
+        if let cached: ConstrainedSessionHandle = _constrainedSessionCache.withLock({ cache in
+            guard let box = cache, box.schema == jsonSchema else {
+                cache = nil
+                return nil
+            }
+            cache = nil
+            return box
+        }) {
+            cached.reset()
+            return cached
+        }
+        let session = try ConstrainedGenerationSession(
+            jsonSchema: jsonSchema,
+            tokenizer: tokenizer,
+            vocabSize: vocabSize,
+            stopTokenIds: stopTokenIds
+        )
+        return ConstrainedSessionHandle(session: session, tokenizer: tokenizer)
+    }
+
+    /// Return a session box to the cache for reuse by the next call.
+    func storeConstrainedSessionForReuse(_ box: ConstrainedSessionHandle) {
+        _constrainedSessionCache.withLock { $0 = box }
+    }
+}
+
+// MARK: - Constrained Session Handle
+
+/// Thread-safe handle to a `ConstrainedGenerationSession`.
+///
+/// Access is serialized by the engine's `acquireEngine()`/`releaseEngine()` atomic
+/// gate — only one Task mutates the session at a time. The `@unchecked Sendable`
+/// conformance is justified by this single-writer guarantee.
+///
+/// The handle exposes only the operations the engine loop needs — no raw
+/// session access from outside.
+package final class ConstrainedSessionHandle: @unchecked Sendable {
+    /// Schema string is immutable after init — cached to avoid repeated access.
+    let schema: String
+
+    /// Tokenizer used for jump-forward string encoding.
+    private let tokenizer: any Tokenizer
+
+    private var _session: ConstrainedGenerationSession
+
+    init(session: consuming ConstrainedGenerationSession, tokenizer: any Tokenizer) {
+        self.schema = session.schema
+        self.tokenizer = tokenizer
+        self._session = session
+    }
+
+    var isTerminated: Bool { _session.isTerminated }
+
+    func acceptToken(_ token: Int32) -> Bool {
+        _session.acceptToken(token)
+    }
+
+    func fillBitmask(into ptr: UnsafeMutablePointer<Int32>) -> ConstrainedGenerationSession.BitmaskResult {
+        _session.fillBitmask(into: ptr)
+    }
+
+    func reset() { _session.reset() }
+
+    func rollback(_ numTokens: Int = 1) { _session.rollback(numTokens) }
+
+    func findJumpForwardString() -> String? {
+        _session.findJumpForwardString()
+    }
+
+    /// Decode a sequence of token IDs back into a string using the stored tokenizer.
+    func decodeTokens(_ tokens: [Int32]) -> String {
+        tokenizer.decode(tokens: tokens.map(Int.init))
+    }
+
+    /// Tokenize a string for jump-forward injection. Uses the stored tokenizer
+    /// without adding special tokens.
+    func tokenizeForJumpForward(_ string: String) -> [Int32] {
+        tokenizer.encode(text: string).map(Int32.init)
     }
 }
 
@@ -1057,6 +1211,341 @@ private struct EngineImpl: ~Copyable {
                 }
                 cmdBuf.addCompletedHandler { _ in sentinelCont.resume() }
                 cmdBuf.commit()
+            }
+        }
+    }
+
+    // MARK: - Constrained Run Completion
+
+    /// Semi-pipelined constrained generation loop.
+    ///
+    /// Unlike `runCompletion` which fires steps asynchronously, this awaits each token
+    /// before computing the next bitmask (grammar state is sequential).
+    mutating func runConstrainedCompletion(
+        prompt: [Int32],
+        sampler: SamplingConfiguration,
+        sessionBox: ConstrainedSessionHandle,
+        maxTokens: Int,
+        isCancelled: borrowing Atomic<Bool>,
+        yieldingTo continuation: AsyncThrowingStream<Int32, Error>.Continuation
+    ) async throws {
+        let gpuSampler = try getOrCreateSampler(for: sampler)
+
+        // Get the bitmask buffer from whichever concrete sampler we have
+        let bitmaskBuffer: MTLBuffer
+        if let composite = gpuSampler as? MPSGraphCompositeSampler {
+            bitmaskBuffer = composite.bitmaskBuffer
+        } else if let argmax = gpuSampler as? MPSGraphArgmaxSampler {
+            bitmaskBuffer = argmax.bitmaskBuffer
+        } else {
+            throw InferenceRuntimeError.invalidArgument(
+                "Constrained generation requires MPSGraphArgmaxSampler or MPSGraphCompositeSampler")
+        }
+
+        // Pre-grow KV cache
+        let totalNeeded = prompt.count + maxTokens
+        try kvCache.ensureCapacity(forContextLength: totalNeeded, queue: pipelineQueue)
+        try logits.ensureCapacity(forContextLength: 1)
+
+        // Prefill prompt (unconstrained -- grammar doesn't constrain the prompt)
+        let prefillTokens: [Int32]
+        if prompt.count > config.chunkThreshold {
+            let remaining = try await processChunkedInput(tokens: prompt)
+            prefillTokens = Array(remaining)
+        } else {
+            prefillTokens = prompt
+        }
+
+        // Fill initial bitmask — the first generated token must also be constrained
+        // (e.g. JSON schema requires '{' as first character, not '<think>')
+        let bitmaskPtr = bitmaskBuffer.contents().assumingMemoryBound(to: Int32.self)
+        let initialMask = sessionBox.fillBitmask(into: bitmaskPtr)
+        if case .terminated = initialMask {
+            return  // Grammar already terminated — nothing to generate
+        }
+        let applyInitialMask = initialMask == .constrained
+
+        // Encode prefill and sample first token
+        var lastToken: Int32 = try await withCheckedThrowingContinuation { cont in
+            do {
+                try _encodeStepForConstrainedGeneration(
+                    tokens: prefillTokens,
+                    gpuSampler: gpuSampler,
+                    applyBitmask: applyInitialMask
+                ) { token in
+                    cont.resume(returning: token)
+                }
+            } catch {
+                cont.resume(throwing: error)
+            }
+        }
+
+        continuation.yield(lastToken)
+
+        // Constrained decode loop
+        var generated = 1
+        while generated < maxTokens {
+            guard !isCancelled.load(ordering: .relaxed) else { break }
+            try Task.checkCancellation()
+
+            // Accept previous token in grammar
+            if !sessionBox.acceptToken(lastToken) { break }
+            if sessionBox.isTerminated { break }
+
+            // Check for jump-forward: deterministic grammar segments that can be
+            // batch-encoded without per-token sampling (saves N-1 round-trips)
+            if let jumpString = sessionBox.findJumpForwardString(),
+                let jumpTokens = tokenizeJumpForward(jumpString, sessionBox: sessionBox)
+            {
+                // Batch-encode jump-forward tokens + sample next token after them
+                let bitmaskPtr = bitmaskBuffer.contents().assumingMemoryBound(to: Int32.self)
+                let postJumpMask = sessionBox.fillBitmask(into: bitmaskPtr)
+                if case .terminated = postJumpMask { break }
+                let applyMaskAfterJump = postJumpMask == .constrained
+
+                lastToken = try await withCheckedThrowingContinuation { cont in
+                    do {
+                        try _encodeStepForConstrainedGeneration(
+                            tokens: jumpTokens,
+                            gpuSampler: gpuSampler,
+                            applyBitmask: applyMaskAfterJump
+                        ) { token in
+                            cont.resume(returning: token)
+                        }
+                    } catch {
+                        cont.resume(throwing: error)
+                    }
+                }
+
+                // Yield the jump-forward tokens (deterministic) + the sampled token
+                for jt in jumpTokens {
+                    continuation.yield(jt)
+                }
+                continuation.yield(lastToken)
+                generated += jumpTokens.count + 1
+                continue
+            }
+
+            // Fill bitmask — may signal unconstrained (all tokens allowed) or terminated
+            let bitmaskPtr = bitmaskBuffer.contents().assumingMemoryBound(to: Int32.self)
+            let bitmaskResult = sessionBox.fillBitmask(into: bitmaskPtr)
+            if case .terminated = bitmaskResult { break }
+            let applyMask = bitmaskResult == .constrained
+
+            // Encode inference + sampling
+            lastToken = try await withCheckedThrowingContinuation { cont in
+                do {
+                    try _encodeStepForConstrainedGeneration(
+                        tokens: [],
+                        gpuSampler: gpuSampler,
+                        applyBitmask: applyMask
+                    ) { token in
+                        cont.resume(returning: token)
+                    }
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+
+            continuation.yield(lastToken)
+            generated += 1
+        }
+
+        // Drain: sentinel command buffer to ensure all GPU work completes
+        await withCheckedContinuation { (sentinelCont: CheckedContinuation<Void, Never>) in
+            do {
+                let queue = pipelineQueue
+                guard let cmdBuf = queue.makeCommandBuffer() else {
+                    sentinelCont.resume()
+                    return
+                }
+                cmdBuf.addCompletedHandler { _ in sentinelCont.resume() }
+                cmdBuf.commit()
+            }
+        }
+    }
+
+    /// Tokenize a jump-forward string and accept each token in the grammar.
+    ///
+    /// Returns the token IDs if ALL tokens are accepted by the grammar, or nil if
+    /// there's a tokenization disagreement (the host tokenizer produces tokens that
+    /// cross byte boundaries differently than xgrammar expects). On failure, rolls
+    /// back any partially-accepted tokens to restore grammar state.
+    private func tokenizeJumpForward(
+        _ string: String,
+        sessionBox: ConstrainedSessionHandle
+    ) -> [Int32]? {
+        let tokenIds = sessionBox.tokenizeForJumpForward(string)
+        guard !tokenIds.isEmpty else { return nil }
+
+        // Boundary-safety trim (MLX-style): only keep tokens whose cumulative
+        // decoded byte length is strictly less than the FF string's byte length.
+        // This prevents tokenization boundary disagreements where multi-byte
+        // tokens span grammar-forced character boundaries differently than the
+        // model's BPE tokenizer expects.
+        let ffByteLength = string.utf8.count
+        var safeCount = 0
+        for i in 1...tokenIds.count {
+            let prefixDecoded = sessionBox.decodeTokens(Array(tokenIds.prefix(i)))
+            if prefixDecoded.utf8.count < ffByteLength {
+                safeCount = i
+            } else {
+                break
+            }
+        }
+        guard safeCount > 0 else { return nil }
+
+        let safeTokens = Array(tokenIds.prefix(safeCount))
+
+        // Accept each safe token one-at-a-time; rollback on rejection.
+        var accepted = 0
+        for tokenId in safeTokens {
+            if !sessionBox.acceptToken(tokenId) {
+                if accepted > 0 {
+                    sessionBox.rollback(accepted)
+                }
+                return nil
+            }
+            accepted += 1
+        }
+
+        return safeTokens
+    }
+
+    /// Single encode step for constrained generation (prefill or decode).
+    /// Calls completion with the sampled token.
+    private mutating func _encodeStepForConstrainedGeneration(
+        tokens: [Int32],
+        gpuSampler: any MPSGraphSampler,
+        applyBitmask: Bool,
+        completion: @escaping (Int32) -> Void
+    ) throws {
+        let actualTokenCount = tokens.isEmpty ? 1 : tokens.count
+        let queryLength = actualTokenCount
+
+        defer {
+            processedTokenCount += actualTokenCount
+            step += 1
+        }
+
+        // Write tokens to input buffer
+        let tokenByteOffset = processedTokenCount * MemoryLayout<Int32>.size
+        if !tokens.isEmpty {
+            let ptr = inputTokensBuffer.contents().bindMemory(
+                to: Int32.self, capacity: processedTokenCount + queryLength)
+            for (i, token) in tokens.enumerated() {
+                ptr[processedTokenCount + i] = token
+            }
+        }
+
+        let cachePosBuffer = cachePositionBuffers[step % pipelineDepth]
+        let posLength = processedTokenCount + queryLength
+
+        let tokenShape = [1, queryLength]
+        let tokenStrides = try resolvedStrides(descriptor: inputIdsBaseDesc, shape: tokenShape)
+        let tokenValue = unsafe InferenceFunction.AsyncValue(
+            unsafeBuffer: inputTokensBuffer,
+            byteOffset: tokens.isEmpty ? 0 : tokenByteOffset,
+            scalarType: .int32,
+            shape: tokenShape,
+            strides: tokenStrides
+        )
+        let posShape = [1, posLength]
+        let posStrides = try resolvedStrides(descriptor: positionIdsBaseDesc, shape: posShape)
+        let posValue = unsafe InferenceFunction.AsyncValue(
+            unsafeBuffer: cachePosBuffer,
+            byteOffset: 0,
+            scalarType: .int32,
+            shape: posShape,
+            strides: posStrides
+        )
+
+        let asyncInputs: [String: InferenceFunction.AsyncValue] = [
+            inputIdsName: tokenValue,
+            positionIdsName: posValue,
+        ]
+
+        let keyBuffer = kvCache.keyBinding.metalBuffer
+        let keyShape = kvCache.keyBinding.layout.shape
+        let keyStrides = kvCache.keyBinding.layout.strides
+        var keyState = unsafe InferenceFunction.AsyncMutableValue(
+            unsafeBuffer: keyBuffer, byteOffset: 0,
+            scalarType: keyCacheScalarType, shape: keyShape, strides: keyStrides
+        )
+        let valBuffer = kvCache.valueBinding.metalBuffer
+        let valShape = kvCache.valueBinding.layout.shape
+        let valStrides = kvCache.valueBinding.layout.strides
+        var valState = unsafe InferenceFunction.AsyncMutableValue(
+            unsafeBuffer: valBuffer, byteOffset: 0,
+            scalarType: valueCacheScalarType, shape: valShape, strides: valStrides
+        )
+
+        var asyncStates = InferenceFunction.AsyncMutableViews()
+        asyncStates.insert(&keyState, for: keyCacheName)
+        asyncStates.insert(&valState, for: valueCacheName)
+
+        let logitsBuffer = logits.metalBuffer
+        let logitsShape = [1, queryLength, vocabSize]
+        let logitsStrides = try resolvedStrides(descriptor: logitsBaseDesc, shape: logitsShape)
+        var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
+            unsafeBuffer: logitsBuffer, byteOffset: 0,
+            scalarType: .float16, shape: logitsShape, strides: logitsStrides
+        )
+
+        var asyncOutputs = InferenceFunction.AsyncMutableViews()
+        asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
+
+        // Encode inference
+        let _ = try function.encode(
+            inputs: asyncInputs,
+            states: consume asyncStates,
+            outputViews: consume asyncOutputs,
+            to: computeStream
+        )
+
+        // GPU sampling
+        let outputBuffer = inputTokensBuffer
+        let queue = pipelineQueue
+
+        if queryLength == 1 {
+            if let compositeSampler = gpuSampler as? MPSGraphCompositeSampler {
+                compositeSampler.encode(
+                    to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    applyBitmask: applyBitmask, completion: completion
+                )
+            } else if let argmaxSampler = gpuSampler as? MPSGraphArgmaxSampler {
+                argmaxSampler.encode(
+                    to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    applyBitmask: applyBitmask, completion: completion
+                )
+            } else {
+                gpuSampler.encode(
+                    to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    completion: completion
+                )
+            }
+        } else {
+            if let compositeSampler = gpuSampler as? MPSGraphCompositeSampler {
+                compositeSampler.encodeWithSlice(
+                    to: queue, logitsBuffer: logitsBuffer, queryLength: actualTokenCount,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    applyBitmask: applyBitmask, completion: completion
+                )
+            } else if let argmaxSampler = gpuSampler as? MPSGraphArgmaxSampler {
+                argmaxSampler.encodeWithSlice(
+                    to: queue, logitsBuffer: logitsBuffer, queryLength: actualTokenCount,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    applyBitmask: applyBitmask, completion: completion
+                )
+            } else {
+                gpuSampler.encodeWithSlice(
+                    to: queue, logitsBuffer: logitsBuffer, queryLength: actualTokenCount,
+                    outputBuffer: outputBuffer, outputOffset: 0,
+                    completion: completion
+                )
             }
         }
     }

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -261,6 +261,11 @@ final class CoreAIPipelinedEngine: InferenceEngine, ConstrainedGenerationCapable
         maxTokens: Int,
         session: ConstrainedSessionHandle
     ) throws -> AsyncThrowingStream<TokenId, Error> {
+        precondition(
+            !engineInUse.load(ordering: .acquiring),
+            "generateConstrained called while a prior generation is still in flight — caller must drain first"
+        )
+
         let (stream, continuation) = AsyncThrowingStream<TokenId, Error>.makeStream()
 
         let sessionBox = session
@@ -1484,6 +1489,7 @@ private struct EngineImpl: ~Copyable {
         asyncStates.insert(&keyState, for: keyCacheName)
         asyncStates.insert(&valState, for: valueCacheName)
 
+        // Safe: constrained loop awaits each token before encoding the next step, so logits are consumed before overwrite.
         let logitsBuffer = logits.metalBuffer
         let logitsShape = [1, queryLength, vocabSize]
         let logitsStrides = try resolvedStrides(descriptor: logitsBaseDesc, shape: logitsShape)

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -261,10 +261,11 @@ final class CoreAIPipelinedEngine: InferenceEngine, ConstrainedGenerationCapable
         maxTokens: Int,
         session: ConstrainedSessionHandle
     ) throws -> AsyncThrowingStream<TokenId, Error> {
-        precondition(
-            !engineInUse.load(ordering: .acquiring),
-            "generateConstrained called while a prior generation is still in flight — caller must drain first"
-        )
+        if _generationTask.withLock({ $0 }) != nil || engineInUse.load(ordering: .acquiring) {
+            throw InferenceRuntimeError.invalidState(
+                "generateConstrained called while a prior generation is still in flight — caller must drain first"
+            )
+        }
 
         let (stream, continuation) = AsyncThrowingStream<TokenId, Error>.makeStream()
 
@@ -288,6 +289,7 @@ final class CoreAIPipelinedEngine: InferenceEngine, ConstrainedGenerationCapable
                 }
             }
             self.engine.reset()
+            self.history.clear()
             do {
                 try await self.engine.runConstrainedCompletion(
                     prompt: input,
@@ -432,60 +434,6 @@ extension CoreAIPipelinedEngine {
     }
 }
 
-// MARK: - Constrained Session Handle
-
-/// Thread-safe handle to a `ConstrainedGenerationSession`.
-///
-/// Access is serialized by the engine's `acquireEngine()`/`releaseEngine()` atomic
-/// gate — only one Task mutates the session at a time. The `@unchecked Sendable`
-/// conformance is justified by this single-writer guarantee.
-///
-/// The handle exposes only the operations the engine loop needs — no raw
-/// session access from outside.
-package final class ConstrainedSessionHandle: @unchecked Sendable {
-    /// Schema string is immutable after init — cached to avoid repeated access.
-    let schema: String
-
-    /// Tokenizer used for jump-forward string encoding.
-    private let tokenizer: any Tokenizer
-
-    private var _session: ConstrainedGenerationSession
-
-    init(session: consuming ConstrainedGenerationSession, tokenizer: any Tokenizer) {
-        self.schema = session.schema
-        self.tokenizer = tokenizer
-        self._session = session
-    }
-
-    var isTerminated: Bool { _session.isTerminated }
-
-    func acceptToken(_ token: Int32) -> Bool {
-        _session.acceptToken(token)
-    }
-
-    func fillBitmask(into ptr: UnsafeMutablePointer<Int32>) -> ConstrainedGenerationSession.BitmaskResult {
-        _session.fillBitmask(into: ptr)
-    }
-
-    func reset() { _session.reset() }
-
-    func rollback(_ numTokens: Int = 1) { _session.rollback(numTokens) }
-
-    func findJumpForwardString() -> String? {
-        _session.findJumpForwardString()
-    }
-
-    /// Decode a sequence of token IDs back into a string using the stored tokenizer.
-    func decodeTokens(_ tokens: [Int32]) -> String {
-        tokenizer.decode(tokens: tokens.map(Int.init))
-    }
-
-    /// Tokenize a string for jump-forward injection. Uses the stored tokenizer
-    /// without adding special tokens.
-    func tokenizeForJumpForward(_ string: String) -> [Int32] {
-        tokenizer.encode(text: string).map(Int32.init)
-    }
-}
 
 // MARK: - Pipeline Depth Gate
 
@@ -1239,9 +1187,9 @@ private struct EngineImpl: ~Copyable {
         // Get the bitmask buffer from whichever concrete sampler we have
         let bitmaskBuffer: MTLBuffer
         if let composite = gpuSampler as? MPSGraphCompositeSampler {
-            bitmaskBuffer = composite.bitmaskBuffer
+            bitmaskBuffer = try composite.bitmaskBuffer
         } else if let argmax = gpuSampler as? MPSGraphArgmaxSampler {
-            bitmaskBuffer = argmax.bitmaskBuffer
+            bitmaskBuffer = try argmax.bitmaskBuffer
         } else {
             throw InferenceRuntimeError.invalidArgument(
                 "Constrained generation requires MPSGraphArgmaxSampler or MPSGraphCompositeSampler")
@@ -1250,7 +1198,6 @@ private struct EngineImpl: ~Copyable {
         // Pre-grow KV cache
         let totalNeeded = prompt.count + maxTokens
         try kvCache.ensureCapacity(forContextLength: totalNeeded, queue: pipelineQueue)
-        try logits.ensureCapacity(forContextLength: 1)
 
         // Prefill prompt (unconstrained -- grammar doesn't constrain the prompt)
         let prefillTokens: [Int32]
@@ -1260,6 +1207,8 @@ private struct EngineImpl: ~Copyable {
         } else {
             prefillTokens = prompt
         }
+
+        try logits.ensureCapacity(forContextLength: max(1, prefillTokens.count))
 
         // Fill initial bitmask — the first generated token must also be constrained
         // (e.g. JSON schema requires '{' as first character, not '<think>')
@@ -1311,7 +1260,7 @@ private struct EngineImpl: ~Copyable {
                 lastToken = try await withCheckedThrowingContinuation { cont in
                     do {
                         try _encodeStepForConstrainedGeneration(
-                            tokens: jumpTokens,
+                            tokens: [lastToken] + jumpTokens,
                             gpuSampler: gpuSampler,
                             applyBitmask: applyMaskAfterJump
                         ) { token in
@@ -1398,7 +1347,7 @@ private struct EngineImpl: ~Copyable {
                 break
             }
         }
-        guard safeCount > 0 else { return nil }
+        guard safeCount > 0, safeCount <= 64 else { return nil }
 
         let safeTokens = Array(tokenIds.prefix(safeCount))
 

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -174,10 +174,12 @@ public struct CoreAILanguageModel: LanguageModel {
 
     /// Whether guided generation is available for this model.
     private var isGuidedGenerationSupported: Bool {
+        if let isConstrainedCapable = resources.loadedEngineIsConstrainedCapable {
+            return isConstrainedCapable
+        }
         if let supportsLogits = resources.loadedEngineSupportsLogits {
             return supportsLogits
         }
-        // Pipelined engine supports constrained generation via GPU bitmask path
         return true
     }
 

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/CoreAILanguageModel.swift
@@ -177,7 +177,8 @@ public struct CoreAILanguageModel: LanguageModel {
         if let supportsLogits = resources.loadedEngineSupportsLogits {
             return supportsLogits
         }
-        return variant != "coreai-pipelined"
+        // Pipelined engine supports constrained generation via GPU bitmask path
+        return true
     }
 
     // MARK: - Executor
@@ -311,7 +312,7 @@ public struct CoreAILanguageModel: LanguageModel {
 
                 // Check if guided generation is requested
                 if let schema = request.schema {
-                    guard engine.supportsLogits else {
+                    guard engine.supportsLogits || engine is any ConstrainedGenerationCapable else {
                         throw LanguageModelError.unsupportedCapability(
                             .init(
                                 capability: .guidedGeneration,
@@ -560,8 +561,14 @@ public struct CoreAILanguageModel: LanguageModel {
                 preconditionFailure("GenerationSchema JSON encoding produced invalid UTF-8")
             }
 
-            let strategy = ConstrainedDecodingStrategy(
-                jsonSchema: jsonSchema, vocabSize: model.bundle.vocabSize)
+            let strategy: any DecodingStrategy
+            if engine is any ConstrainedGenerationCapable {
+                strategy = PipelinedConstrainedDecodingStrategy(
+                    jsonSchema: jsonSchema, vocabSize: model.bundle.vocabSize)
+            } else {
+                strategy = ConstrainedDecodingStrategy(
+                    jsonSchema: jsonSchema, vocabSize: model.bundle.vocabSize)
+            }
             let stopSequences = StopSequences(
                 for: model.tokenizer,
                 additionalEosTokenIds: model.additionalEosTokenIds

--- a/swift/Sources/CoreAILanguageModels/LanguageModel/ModelResources.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/ModelResources.swift
@@ -42,6 +42,14 @@ final class ModelResources: ResourceManaging {
         state.withLock { $0.loaded?.supportsLogits }
     }
 
+    /// Whether the loaded engine supports GPU-side constrained generation, or `nil` when unloaded.
+    var loadedEngineIsConstrainedCapable: Bool? {
+        state.withLock { engine in
+            guard let loaded = engine.loaded else { return nil }
+            return loaded is any ConstrainedGenerationCapable
+        }
+    }
+
     /// Returns the engine, loading it on first use. Concurrent callers share one
     /// load; later callers get the warmed engine instantly.
     func engine() async throws -> any InferenceEngine {

--- a/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
+++ b/swift/Sources/Tools/llm-runner/LLMRunnerMain.swift
@@ -786,30 +786,52 @@ struct LLMRunner: AsyncParsableCommand, Sendable {
             throw ExitCode.failure
         }
 
-        let constrainedStrategy = ConstrainedDecodingStrategy(
-            jsonSchema: schema,
-            vocabSize: vocabSize
-        )
+        let constrainedStrategy: any DecodingStrategy
+        if inferenceEngine is any ConstrainedGenerationCapable {
+            constrainedStrategy = PipelinedConstrainedDecodingStrategy(
+                jsonSchema: schema,
+                vocabSize: vocabSize
+            )
+        } else {
+            constrainedStrategy = ConstrainedDecodingStrategy(
+                jsonSchema: schema,
+                vocabSize: vocabSize
+            )
+        }
 
         let inferenceID = InstrumentsProfiler.beginInference(
             promptTokens: actualInputTokens, maxTokens: maxTokens)
 
+        await PerformanceMetrics.shared.recordPromptTokens(actualInputTokens)
+
         var generatedText = ""
+        var generatedTokenCount = 0
+        var promptSpan: ProfileSpan? = InstrumentsProfiler.beginPrompt(
+            tokens: actualInputTokens, engine: "CoreAI-Constrained")
+        var extendSpan: ProfileSpan?
+
         let constrainedStream = try await constrainedStrategy.decode(
             from: input,
             tokenizer: tokenizer,
             inferenceEngine: inferenceEngine,
             samplingConfiguration: samplingConfiguration,
-            options: InferenceOptions(maxTokens: maxTokens, includeLogits: true),
+            options: InferenceOptions(maxTokens: maxTokens),
             stopSequences: stopSequences
         )
         for try await result in constrainedStream {
+            if promptSpan != nil {
+                promptSpan?.end()
+                promptSpan = nil
+                extendSpan = InstrumentsProfiler.beginExtend(step: 0, tokens: 1)
+            }
             generatedText += result.text
+            generatedTokenCount += 1
             print(result.text, terminator: "")
         }
+        extendSpan?.end()
         print()
 
-        let generatedTokenCount = tokenizer.encode(text: generatedText).count
+        await PerformanceMetrics.shared.recordGeneratedTokens(generatedTokenCount)
         InstrumentsProfiler.endInference(generatedTokens: generatedTokenCount, signpostID: inferenceID)
         await PerformanceMetrics.shared.endOverallTiming()
     }


### PR DESCRIPTION
  Summary

  - GPU-accelerated grammar-constrained generation for the pipelined engine
  - Applies xgrammar bitmasks directly in the MPSGraph sampler, eliminating per-token logit transfer to CPU
  - ConstrainedGenerationCapable protocol for capability-based routing
  - Session cache with checkout/checkin pattern for xgrammar reuse across calls

  ## Performance (Qwen3-4B, relative to unconstrained pipelined baseline)

  | Configuration | Relative | Notes |
  |---|---|---|
  | Pipelined unconstrained | 100% | roofline |
  | Sequential constrained | 75% | existing option |
  | **Pipelined constrained + jump-forward** | **82%** | new option, tested with long string responses  |

  ## Changes

  - **`ConstrainedGenerationCapable`** — Protocol for engines that support GPU-side bitmask application
  - **`ConstrainedSessionHandle`** — Encapsulated handle with narrow API, stores tokenizer for JF
  - **`PipelinedConstrainedDecodingStrategy`** — AsyncSequence-based strategy with single-use guard, early-stop on consumer drop
  - **`MPSGraphSamplers`** — Bitmask expansion graph, `applyBitmask` on encode paths
  - **`ConstrainedGenerationSession`** — `fillBitmask(into:)` with `BitmaskResult` enum, `rollback`, `findJumpForwardString`
  - **C bridge extensions** — `rollback`, `findJumpForwardString`, `isCompleted`
  - **`llm-runner`** — Routes to pipelined strategy, performance metrics for constrained path
  - **Integration tests** — Mock engine exercising cache reuse, schema invalidation, stop sequences, error paths



 ## Test plan
  
  - [x] Existing unit tests pass (sampler, session, pipeline gate)
  - [x] New GPU sampler tests: bitmask blocks dominant, all-ones matches unconstrained, only-allowed tokens
  - [x] Integration tests via MockConstrainedEngine (no Metal required)
  - [x] swift-format clean
  - [x] End-to-end on-device validation (greedy outputs match sequential path)
