### PR TITLE
Fix Flux quality: don't quantize text encoder

### DIFF
--- a/python/src/coreai_models/diffusion/components.py
+++ b/python/src/coreai_models/diffusion/components.py
@@ -327,7 +327,7 @@ FLUX2_COMPONENTS: dict[str, ComponentSpec] = {
         output_names=("hidden_states",),
         wrapper_fn=lambda p: Flux2TextEncoderWrapper(p.text_encoder),
         dummy_fn=dummy_flux2_text_encoder,
-        quantizable=True,
+        quantizable=False,
     ),
     "vae_decoder": ComponentSpec(
         asset_name="VAEDecoder",


### PR DESCRIPTION
The Flux text encoder (Qwen-based, 3B) was marked quantizable=True, causing it to be exported at INT4 when --compression 4bit is used. This degrades prompt adherence (cosine 0.9655 vs reference) because the conditioning signal loses semantic precision at 4-bit.

Set quantizable=False for the Flux text encoder so it stays at f16 regardless of global compression setting. The transformer (4B) remains INT4 — it's quality-insensitive since it just predicts noise.

Fixes #111.