### PR TITLE
Fix guided generation: include <|endoftext|> as stop token

### DIFF
--- a/swift/Sources/CoreAILanguageModels/Bundle/LanguageConfig.swift
+++ b/swift/Sources/CoreAILanguageModels/Bundle/LanguageConfig.swift
@@ -126,7 +126,7 @@ public struct LanguageConfig: Codable, Sendable, Equatable {
         // 3. Check added_tokens_decoder for turn-ending special tokens
         //    (e.g. Gemma's <end_of_turn> ID 106, Qwen's <|im_end|>)
         //    Only include tokens whose content matches known turn-ending patterns.
-        let turnEndPatterns = ["end_of_turn", "im_end", "eot_id"]
+        let turnEndPatterns = ["end_of_turn", "im_end", "eot_id", "endoftext"]
         if let addedTokens = json["added_tokens_decoder"] as? [String: Any] {
             for (idString, value) in addedTokens {
                 guard let dict = value as? [String: Any],

--- a/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedDecodingStrategy.swift
+++ b/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedDecodingStrategy.swift
@@ -324,16 +324,17 @@ extension ConstrainedDecodingStrategy.ConstrainedDecodedSequence {
                 generatedTokens.append(bestToken)
                 tokenStep += 1
 
+                if terminatedAfterAccept {
+                    finished = true
+                    return nil
+                }
+
                 let delta = ConstrainedDecodingStrategy.computeTextDelta(
                     generatedTokens: generatedTokens,
                     previousDecodedText: &previousDecodedText,
                     tokenizer: tokenizer,
                     tokenStep: tokenStep
                 )
-
-                if terminatedAfterAccept {
-                    finished = true
-                }
 
                 return GenerationResult(text: delta, tokenId: bestToken, rawLogits: logits)
             }


### PR DESCRIPTION
Qwen3 models declare `eos_token` as `<|im_end|>` (151645) but the grammar (`xgrammar`) can also produce `<|endoftext|>` (151643) as a valid terminal. Since 151643 wasn't in the stop sequences, it passed through to the output as literal text, corrupting structured generation results.

Add 'endoftext' to the turnEndPatterns so it's picked up from `added_tokens_decoder` alongside `im_end`, `end_of_turn`, and `eot_id`.