### PR TITLE
Remove Deprecated LLMAsset Terminology

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -102,7 +102,7 @@ uv run coreai.vlm.export --list-models   # list supported VLMs
 uv run coreai.vlm.export qwen3-vl        # text decoder + token embedding + vision encoder
 ```
 
-This produces a single `<name>.llmasset/` bundle (`kind=vlm`) holding the text
+This produces a single `<name>/` bundle (`kind=vlm`) holding the text
 decoder (`main`), token-embedding lookup (`embedding`), vision encoder
 (`vision`), tokenizer, and `metadata.json`. Pass `--skip-vision` to export the
 text portion only.

--- a/models/vlm/README.md
+++ b/models/vlm/README.md
@@ -62,7 +62,7 @@ The strategy is inferred from the model's `preprocessor_config.json` at export
 time and written into the bundle's `metadata.json`. Override at runtime:
 
 ```bash
-llm-runner --model vlm_bundle --image photo.jpg --image-strategy center_crop
+swift run -c release llm-runner --model vlm_bundle --image photo.jpg --image-strategy center_crop --prompt "your prompt"
 ```
 
 ### Original resolution in prompt

--- a/models/vlm/README.md
+++ b/models/vlm/README.md
@@ -28,7 +28,7 @@ Options:
 
 ## Bundle layout
 
-The export produces a `<name>.llmasset/` directory (`metadata.json` `kind=vlm`)
+The export produces a `<name>/` directory (`metadata.json` `kind=vlm`)
 with asset roles consumed by the Swift runner's `ModelBundle`:
 
 | Asset       | File             | Role                                            |

--- a/python/src/coreai_models/vlm/export.py
+++ b/python/src/coreai_models/vlm/export.py
@@ -6,7 +6,7 @@
 """CLI entry point for ``coreai.vlm.export``.
 
 Exports a vision-language model to Core AI format as a multi-asset bundle
-(``<name>.llmasset/``):
+(``<name>/``):
 
   - ``<name>.aimodel``   text decoder (asset role ``main``, inputs_embeds, stateful KV)
   - ``embed.aimodel``    token-embedding lookup (asset role ``embedding``)
@@ -332,7 +332,7 @@ async def export_text_bundle(
     program.optimize()
 
     # ---- 5. Save bundle ----
-    bundle_path = output_dir / (output_name + ".llmasset")
+    bundle_path = output_dir / output_name
     bundle_path.mkdir(parents=True, exist_ok=True)
     aimodel_path = bundle_path / f"{output_name}.aimodel"
 

--- a/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedDecodingStrategy.swift
+++ b/swift/Sources/CoreAILanguageModels/DecodingStrategies/ConstrainedDecodingStrategy.swift
@@ -88,7 +88,7 @@ public struct ConstrainedDecodingStrategy: DecodingStrategy {
         guard let vocabSize = vocabSizeOverride ?? Self.deriveVocabSize(from: tokenizer) else {
             throw InferenceRuntimeError.invalidArgument(
                 "Cannot determine vocabulary size from tokenizer. "
-                    + "Pass vocabSize explicitly via CoreAIRunner or LLMAsset metadata."
+                    + "Pass vocabSize explicitly via CoreAIRunner or ModelBundle metadata."
             )
         }
 


### PR DESCRIPTION
## Summary

To keep all models consistent, this PR removes `LLMAsset` from a couple places that still had it. There is no change in functionality as a result of this PR.

## Testing
```bash
uv run coreai.vlm.export qwen3-vl
swift run -c release llm-runner --model exports/qwen3_vl_2b --image <image> --image-strategy center_crop --verbose --max-tokens 1024 --prompt "describe this image"
```