### PR TITLE
Remove unneeded flux2 text encoder float cast before quantization

### DIFF
--- a/python/src/coreai_models/diffusion/pipeline.py
+++ b/python/src/coreai_models/diffusion/pipeline.py
@@ -162,8 +162,6 @@ def _load_hf_pipeline(model_id: str, pipeline_type: str, model_dtype: torch.dtyp
         from diffusers import Flux2KleinPipeline
 
         hf_pipe = Flux2KleinPipeline.from_pretrained(model_id, torch_dtype=model_dtype)
-        # Text encoder needs float32 for token embedding precision
-        hf_pipe.text_encoder = hf_pipe.text_encoder.float()
         return hf_pipe
 
     if pipeline_type == "sd3":


### PR DESCRIPTION
## Summary

In the FLUX2 export pipeline, we forced the text encoder to be float32 cast before compression/conversion. This was done to ensure text encoder parity during earlier seed builds, but it is no longer needed. We still get high parity and good image quality without this cast. 

## Motivation

Removing this allows the text encoder to default to float16 (like the other components) during this part of the export. This drastically reduces the memory pressure during model load/runtime. On a MacBook, the peak memory footprint dropped by almost 50%. On an iPhone/iPad, it also drops a significant amount.

## Validation

Text encoder parity looked good, and image quality remained high.

Before this PR:
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/3d1611ce-8faf-420b-9cf5-c733a9051f1f" />


With this PR:
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/b698383c-b93c-4969-b9e5-ff3193e565c6" />
