### PR TITLE
Add video generation infrastructure + LTX Video export

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,12 @@ let package = Package(
                 "CoreAIObjectDetector"
             ]
         ),
+        .library(
+            name: "CoreAIVideo",
+            targets: [
+                "CoreAIVideoPipeline"
+            ]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
@@ -115,6 +121,19 @@ let package = Package(
             ]
         ),
 
+        // Video Pipeline
+        .target(
+            name: "CoreAIVideoPipeline",
+            dependencies: [
+                "CoreAIDiffusionPipeline",
+                "CoreAIShared",
+            ],
+            path: "swift/Sources/CoreAIVideoPipeline",
+            swiftSettings: [
+                .enableUpcomingFeature("MemberImportVisibility")
+            ]
+        ),
+
         // CXGrammar C bridge
         .target(
             name: "CXGrammar",
@@ -171,6 +190,18 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "swift/Sources/Tools/diffusion-runner",
+            swiftSettings: [
+                .enableUpcomingFeature("MemberImportVisibility")
+            ]
+        ),
+        .executableTarget(
+            name: "video-runner",
+            dependencies: [
+                "CoreAIVideoPipeline",
+                "CoreAIShared",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "swift/Sources/Tools/video-runner",
             swiftSettings: [
                 .enableUpcomingFeature("MemberImportVisibility")
             ]

--- a/python/src/coreai_models/diffusion/components.py
+++ b/python/src/coreai_models/diffusion/components.py
@@ -32,6 +32,16 @@ from coreai_models.diffusion.flux2 import (
     dummy_flux2_vae_encoder,
     dummy_flux2_vae_encoder_half,
 )
+from coreai_models.diffusion.ltx_video import (
+    LTXVideoTextEncoderWrapper,
+    LTXVideoTransformerWrapper,
+    LTXVideoVAEDecoderWrapper,
+    LTXVideoVAEEncoderWrapper,
+    dummy_ltx_video_text_encoder,
+    dummy_ltx_video_transformer,
+    dummy_ltx_video_vae_decoder,
+    dummy_ltx_video_vae_encoder,
+)
 
 # ---------------------------------------------------------------------------
 # Torch wrappers — thin adapters that extract the tensor we need from the
@@ -362,6 +372,49 @@ FLUX2_COMPONENTS: dict[str, ComponentSpec] = {
 ALL_FLUX2_COMPONENTS: list[str] = list(FLUX2_COMPONENTS.keys())
 
 
+LTX_VIDEO_COMPONENTS: dict[str, ComponentSpec] = {
+    "transformer": ComponentSpec(
+        asset_name="Transformer",
+        input_names=(
+            "hidden_states",
+            "encoder_hidden_states",
+            "timestep",
+            "encoder_attention_mask",
+            "rotary_emb_cos",
+            "rotary_emb_sin",
+        ),
+        output_names=("output",),
+        wrapper_fn=lambda p: LTXVideoTransformerWrapper(p.transformer),
+        dummy_fn=dummy_ltx_video_transformer,
+        quantizable=True,
+    ),
+    "text_encoder": ComponentSpec(
+        asset_name="TextEncoder",
+        input_names=("input_ids", "attention_mask"),
+        output_names=("hidden_states",),
+        wrapper_fn=lambda p: LTXVideoTextEncoderWrapper(p.text_encoder),
+        dummy_fn=dummy_ltx_video_text_encoder,
+        quantizable=True,
+    ),
+    "vae_decoder": ComponentSpec(
+        asset_name="VAEDecoder",
+        input_names=("z",),
+        output_names=("video",),
+        wrapper_fn=lambda p: LTXVideoVAEDecoderWrapper(p.vae),
+        dummy_fn=dummy_ltx_video_vae_decoder,
+    ),
+    "vae_encoder": ComponentSpec(
+        asset_name="VAEEncoder",
+        input_names=("video",),
+        output_names=("latent",),
+        wrapper_fn=lambda p: LTXVideoVAEEncoderWrapper(p.vae),
+        dummy_fn=dummy_ltx_video_vae_encoder,
+    ),
+}
+
+ALL_LTX_VIDEO_COMPONENTS: list[str] = list(LTX_VIDEO_COMPONENTS.keys())
+
+
 SD3_COMPONENTS: dict[str, ComponentSpec] = {
     "text_encoder": ComponentSpec(
         asset_name="TextEncoder",
@@ -408,12 +461,14 @@ def get_component_registry(
     Args:
         hf_pipe: The loaded HuggingFace pipeline (unused for routing, but
             available for future introspection).
-        pipeline_type: One of "sd", "sd3", or "flux2".
+        pipeline_type: One of "sd", "sd3", "flux2", or "ltx_video".
     """
     if pipeline_type == "flux2":
         return FLUX2_COMPONENTS
     if pipeline_type == "sd3":
         return SD3_COMPONENTS
+    if pipeline_type == "ltx_video":
+        return LTX_VIDEO_COMPONENTS
     return SD_COMPONENTS
 
 
@@ -423,4 +478,6 @@ def get_valid_components(pipeline_type: str) -> list[str]:
         return ALL_FLUX2_COMPONENTS
     if pipeline_type == "sd3":
         return ALL_SD3_COMPONENTS
+    if pipeline_type == "ltx_video":
+        return ALL_LTX_VIDEO_COMPONENTS
     return ALL_SD_COMPONENTS

--- a/python/src/coreai_models/diffusion/ltx_video.py
+++ b/python/src/coreai_models/diffusion/ltx_video.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+LTX Video component specifications and torch wrappers for Core AI export.
+
+LTX Video is a video diffusion transformer from Lightricks that uses:
+- T5 text encoder (frozen, last hidden state)
+- N-block transformer with 3D RoPE (temporal + spatial)
+- AutoencoderKLLTXVideo 3D VAE for encode/decode of video latents
+
+Key design: like Flux2, the transformer uses pre-computed 3D RoPE embeddings
+passed as model inputs rather than computed in-graph, to avoid Core AI graph
+optimizer issues with RoPE frequency ops in deep transformers.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# 3D RoPE pre-computation (outside the exported graph)
+# ---------------------------------------------------------------------------
+
+
+def compute_ltx_video_rope(
+    num_frames: int,
+    height: int,
+    width: int,
+    dim: int,
+    patch_size: int = 1,
+    patch_size_t: int = 1,
+    base_num_frames: int = 20,
+    base_height: int = 2048,
+    base_width: int = 2048,
+    theta: float = 10000.0,
+    rope_interpolation_scale: tuple[float, float, float] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute 3D RoPE (cos, sin) embeddings for LTX Video transformer.
+
+    Replicates LTXVideoRotaryPosEmbed.forward() logic:
+      - Build a 3D grid of (frame, height, width) coordinates
+      - Scale each axis by interpolation scale and base resolution
+      - Compute frequency bands and apply to grid
+      - Return (cos, sin) each of shape [1, seq_len, dim]
+
+    Args:
+        num_frames: Number of temporal frames (after patchification).
+        height: Spatial height (after patchification).
+        width: Spatial width (after patchification).
+        dim: Inner dimension of the transformer (num_heads * head_dim).
+        patch_size: Spatial patch size.
+        patch_size_t: Temporal patch size.
+        base_num_frames: Base number of frames for interpolation scaling.
+        base_height: Base height for interpolation scaling.
+        base_width: Base width for interpolation scaling.
+        theta: RoPE theta parameter.
+        rope_interpolation_scale: Optional (t_scale, h_scale, w_scale) tuple.
+
+    Returns:
+        (rotary_emb_cos, rotary_emb_sin) each of shape [1, seq_len, dim].
+    """
+    # Build 3D coordinate grid
+    grid_f = torch.arange(num_frames, dtype=torch.float32)
+    grid_h = torch.arange(height, dtype=torch.float32)
+    grid_w = torch.arange(width, dtype=torch.float32)
+    grid = torch.stack(torch.meshgrid(grid_f, grid_h, grid_w, indexing="ij"), dim=0)
+    grid = grid.unsqueeze(0)  # [1, 3, F, H, W]
+
+    # Apply interpolation scaling
+    if rope_interpolation_scale is not None:
+        t_scale, h_scale, w_scale = rope_interpolation_scale
+    else:
+        t_scale, h_scale, w_scale = 1.0, 1.0, 1.0
+
+    grid[:, 0:1] = grid[:, 0:1] * t_scale * patch_size_t / base_num_frames
+    grid[:, 1:2] = grid[:, 1:2] * h_scale * patch_size / base_height
+    grid[:, 2:3] = grid[:, 2:3] * w_scale * patch_size / base_width
+
+    # Flatten spatial dims: [1, 3, F*H*W] -> transpose -> [1, F*H*W, 3]
+    grid = grid.flatten(2, 4).transpose(1, 2)
+
+    # Compute frequency bands
+    start = 1.0
+    end = theta
+    freqs = theta ** torch.linspace(
+        math.log(start, theta),
+        math.log(end, theta),
+        dim // 6,
+        dtype=torch.float32,
+    )
+    freqs = freqs * math.pi / 2.0
+
+    # Apply frequencies to grid coordinates
+    # grid: [1, S, 3], freqs: [dim//6]
+    # -> [1, S, 3, dim//6] -> transpose -> [1, S, dim//6, 3] -> flatten -> [1, S, dim//2]
+    freqs = freqs * (grid.unsqueeze(-1) * 2 - 1)
+    freqs = freqs.transpose(-1, -2).flatten(2)
+
+    cos_freqs = freqs.cos().repeat_interleave(2, dim=-1)
+    sin_freqs = freqs.sin().repeat_interleave(2, dim=-1)
+
+    # Handle non-divisible dimensions with padding
+    if dim % 6 != 0:
+        cos_padding = torch.ones_like(cos_freqs[:, :, : dim % 6])
+        sin_padding = torch.zeros_like(cos_freqs[:, :, : dim % 6])
+        cos_freqs = torch.cat([cos_padding, cos_freqs], dim=-1)
+        sin_freqs = torch.cat([sin_padding, sin_freqs], dim=-1)
+
+    return cos_freqs, sin_freqs
+
+
+# ---------------------------------------------------------------------------
+# Torch wrappers
+# ---------------------------------------------------------------------------
+
+
+class LTXVideoTransformerWrapper(torch.nn.Module):
+    """Wraps LTXVideoTransformer3DModel for export with pre-computed 3D RoPE.
+
+    Instead of computing RoPE internally via self.rope(), this wrapper accepts
+    (rotary_emb_cos, rotary_emb_sin) directly, removing all RoPE frequency
+    computation from the traced graph.
+    """
+
+    def __init__(self, transformer: torch.nn.Module) -> None:
+        super().__init__()
+        self.model: Any = transformer
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_attention_mask: torch.Tensor,
+        rotary_emb_cos: torch.Tensor,
+        rotary_emb_sin: torch.Tensor,
+    ) -> torch.Tensor:
+        model = self.model
+
+        image_rotary_emb = (rotary_emb_cos, rotary_emb_sin)
+
+        # Convert encoder_attention_mask to a bias
+        if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+            encoder_attention_mask = (
+                1 - encoder_attention_mask.to(hidden_states.dtype)
+            ) * -10000.0
+            encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+        batch_size = hidden_states.size(0)
+        hidden_states = model.proj_in(hidden_states)
+
+        temb, embedded_timestep = model.time_embed(
+            timestep.flatten(),
+            batch_size=batch_size,
+            hidden_dtype=hidden_states.dtype,
+        )
+
+        temb = temb.view(batch_size, -1, temb.size(-1))
+        embedded_timestep = embedded_timestep.view(
+            batch_size, -1, embedded_timestep.size(-1)
+        )
+
+        encoder_hidden_states = model.caption_projection(encoder_hidden_states)
+        encoder_hidden_states = encoder_hidden_states.view(
+            batch_size, -1, hidden_states.size(-1)
+        )
+
+        for block in model.transformer_blocks:
+            hidden_states = block(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+                encoder_attention_mask=encoder_attention_mask,
+            )
+
+        scale_shift_values = (
+            model.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+        )
+        shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
+
+        hidden_states = model.norm_out(hidden_states)
+        hidden_states = hidden_states * (1 + scale) + shift
+        return model.proj_out(hidden_states)
+
+
+class LTXVideoTextEncoderWrapper(torch.nn.Module):
+    """Wraps T5EncoderModel for LTX Video: (input_ids, attention_mask) -> hidden_states."""
+
+    def __init__(self, text_encoder: torch.nn.Module) -> None:
+        super().__init__()
+        self.model = text_encoder
+
+    def forward(
+        self, input_ids: torch.Tensor, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
+        return cast(
+            torch.Tensor,
+            self.model(input_ids=input_ids, attention_mask=attention_mask)[0],
+        )
+
+
+class LTXVideoVAEDecoderWrapper(torch.nn.Module):
+    """Wraps AutoencoderKLLTXVideo.decode: (latent) -> (video frames).
+
+    The 3D VAE decodes latents of shape [B, C, T, H, W] to pixel space.
+    """
+
+    def __init__(self, vae: torch.nn.Module) -> None:
+        super().__init__()
+        self.vae: Any = vae
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, self.vae.decode(z).sample)
+
+
+class LTXVideoVAEEncoderWrapper(torch.nn.Module):
+    """Wraps AutoencoderKLLTXVideo.encode: (video frames) -> (latent).
+
+    For image-to-video conditioning, encodes pixel-space video to latent space.
+    """
+
+    def __init__(self, vae: torch.nn.Module) -> None:
+        super().__init__()
+        self.vae: Any = vae
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, self.vae.encode(x).latent_dist.mode())
+
+
+# ---------------------------------------------------------------------------
+# Dummy-input factories
+# ---------------------------------------------------------------------------
+
+
+def _dummy_ltx_video_transformer_impl(
+    pipe: Any,
+    num_frames: int = 9,
+    height: int = 64,
+    width: int = 64,
+) -> tuple[torch.Tensor, ...]:
+    """Build dummy inputs for the LTX Video transformer at a given resolution.
+
+    Args:
+        pipe: The loaded HuggingFace LTXPipeline.
+        num_frames: Number of latent frames (after temporal compression).
+        height: Latent spatial height (after spatial compression).
+        width: Latent spatial width (after spatial compression).
+    """
+    cfg = pipe.transformer.config
+    dtype = next(pipe.transformer.parameters()).dtype
+    num_heads = cfg.num_attention_heads
+    head_dim = cfg.attention_head_dim
+    inner_dim = num_heads * head_dim
+    in_channels = cfg.in_channels
+    caption_channels = cfg.caption_channels
+    text_seq_len = 128
+
+    video_seq_len = num_frames * height * width
+
+    # Pre-compute 3D RoPE
+    rope_cos, rope_sin = compute_ltx_video_rope(
+        num_frames=num_frames,
+        height=height,
+        width=width,
+        dim=inner_dim,
+        patch_size=getattr(cfg, "patch_size", 1),
+        patch_size_t=getattr(cfg, "patch_size_t", 1),
+    )
+
+    return (
+        torch.randn(1, video_seq_len, in_channels, dtype=dtype),  # hidden_states
+        torch.randn(1, text_seq_len, caption_channels, dtype=dtype),  # encoder_hidden_states
+        torch.tensor([0.5], dtype=dtype),  # timestep
+        torch.ones(1, text_seq_len, dtype=dtype),  # encoder_attention_mask
+        rope_cos.to(dtype),  # rotary_emb_cos
+        rope_sin.to(dtype),  # rotary_emb_sin
+    )
+
+
+def dummy_ltx_video_transformer(pipe: Any) -> tuple[torch.Tensor, ...]:
+    """Default resolution: 9 latent frames, 64x64 spatial (512x320 output approx)."""
+    return _dummy_ltx_video_transformer_impl(pipe, num_frames=9, height=40, width=64)
+
+
+def dummy_ltx_video_text_encoder(pipe: Any) -> tuple[torch.Tensor, ...]:
+    text_seq_len = 128
+    return (
+        torch.zeros(1, text_seq_len, dtype=torch.long),  # input_ids
+        torch.ones(1, text_seq_len, dtype=torch.long),  # attention_mask
+    )
+
+
+def dummy_ltx_video_vae_decoder(pipe: Any) -> tuple[torch.Tensor, ...]:
+    latent_channels = pipe.vae.config.latent_channels
+    dtype = next(pipe.vae.parameters()).dtype
+    # 3D VAE: [B, C, T, H, W]
+    return (torch.randn(1, latent_channels, 9, 40, 64, dtype=dtype),)
+
+
+def dummy_ltx_video_vae_encoder(pipe: Any) -> tuple[torch.Tensor, ...]:
+    dtype = next(pipe.vae.parameters()).dtype
+    # Pixel space video: [B, C, T, H, W]
+    return (torch.randn(1, 3, 49, 320, 512, dtype=dtype),)

--- a/python/src/coreai_models/diffusion/models.py
+++ b/python/src/coreai_models/diffusion/models.py
@@ -16,6 +16,7 @@ SUPPORTED_MODELS: list[tuple[str, str, str]] = [
     ("stable-diffusion-2.x", "sd2-community/stable-diffusion-2-1", "sd"),
     ("stable-diffusion-3.x", "stabilityai/stable-diffusion-3.5-medium", "sd3"),
     ("flux2", "black-forest-labs/FLUX.2-klein-4B", "flux2"),
+    ("ltx-video", "Lightricks/LTX-Video", "ltx_video"),
 ]
 
 
@@ -27,7 +28,7 @@ def list_models() -> list[str]:
 def get_pipeline_type(model_id: str) -> str:
     """Determine the pipeline type for a given HF model ID.
 
-    Returns "sd", "sd3", or "flux2". Raises ValueError for unknown models.
+    Returns "sd", "sd3", "flux2", or "ltx_video". Raises ValueError for unknown models.
     """
     for _, known_id, ptype in SUPPORTED_MODELS:
         if model_id == known_id:

--- a/python/src/coreai_models/export/metadata.py
+++ b/python/src/coreai_models/export/metadata.py
@@ -171,6 +171,17 @@ _METADATA: dict[str, AIModelMetadataFields] = {
             "Source: https://huggingface.co/black-forest-labs/FLUX.2-klein-4B"
         ),
     ),
+    # ---- Video ----
+    "Lightricks/LTX-Video": AIModelMetadataFields(
+        author="Lightricks",
+        license="Apache-2.0",
+        model_description=(
+            "LTX-Video is a text-to-video diffusion transformer from Lightricks "
+            "that generates high-quality video clips from natural language prompts. "
+            "It uses a T5 text encoder and 3D VAE for spatio-temporal generation. "
+            "Source: https://huggingface.co/Lightricks/LTX-Video"
+        ),
+    ),
     # ---- Segmentation ----
     "facebook/sam3": AIModelMetadataFields(
         author="N. Carion et al.",

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -212,6 +212,17 @@ DIFFUSION_PRESETS: list[ModelPreset] = [
         None,
         notes="4bit recommended; use --compression none for full precision",
     ),
+    ModelPreset(
+        "ltx-video",
+        "Lightricks/LTX-Video",
+        "ltx-video",
+        "diffusion",
+        None,
+        "none",
+        "bfloat16",
+        None,
+        notes="Text-to-video generation; 49 frames at 24fps by default",
+    ),
 ]
 
 # ---------------------------------------------------------------------------

--- a/swift/Sources/CoreAIVideoPipeline/Output/VideoWriter.swift
+++ b/swift/Sources/CoreAIVideoPipeline/Output/VideoWriter.swift
@@ -1,0 +1,283 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import AVFoundation
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Utilities for writing video frames to MP4, GIF, or numbered PNG files.
+public enum VideoWriter {
+    // MARK: - MP4 (HEVC)
+
+    /// Write frames as an HEVC-encoded MP4 to the given file URL.
+    public static func writeMP4(frames: [CGImage], fps: Int, to url: URL) async throws {
+        guard let first = frames.first else {
+            throw VideoWriterError.noFrames
+        }
+
+        let width = first.width
+        let height = first.height
+
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ]
+        let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: writerInput,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32ARGB,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+
+        writer.add(writerInput)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        let frameDuration = CMTime(value: 1, timescale: CMTimeScale(fps))
+
+        for (index, cgImage) in frames.enumerated() {
+            while !writerInput.isReadyForMoreMediaData {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            guard let pixelBuffer = pixelBuffer(from: cgImage, width: width, height: height) else {
+                throw VideoWriterError.pixelBufferCreationFailed
+            }
+
+            let presentationTime = CMTime(
+                value: CMTimeValue(index), timescale: CMTimeScale(fps))
+            adaptor.append(pixelBuffer, withPresentationTime: presentationTime)
+        }
+
+        // Pad the last frame by one frame duration so the video has the expected length.
+        _ = frameDuration
+
+        writerInput.markAsFinished()
+        await writer.finishWriting()
+
+        if let error = writer.error {
+            throw error
+        }
+    }
+
+    // MARK: - GIF
+
+    /// Write frames as an animated GIF to the given file URL.
+    public static func writeGIF(frames: [CGImage], fps: Int, to url: URL) throws {
+        guard !frames.isEmpty else {
+            throw VideoWriterError.noFrames
+        }
+
+        guard
+            let destination = CGImageDestinationCreateWithURL(
+                url as CFURL,
+                UTType.gif.identifier as CFString,
+                frames.count,
+                nil
+            )
+        else {
+            throw VideoWriterError.destinationCreationFailed
+        }
+
+        let gifProperties: [String: Any] = [
+            kCGImagePropertyGIFDictionary as String: [
+                kCGImagePropertyGIFLoopCount as String: 0
+            ]
+        ]
+        CGImageDestinationSetProperties(destination, gifProperties as CFDictionary)
+
+        let frameDelay = 1.0 / Double(fps)
+        let frameProperties: [String: Any] = [
+            kCGImagePropertyGIFDictionary as String: [
+                kCGImagePropertyGIFDelayTime as String: frameDelay
+            ]
+        ]
+
+        for frame in frames {
+            CGImageDestinationAddImage(destination, frame, frameProperties as CFDictionary)
+        }
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw VideoWriterError.finalizationFailed
+        }
+    }
+
+    // MARK: - APNG (Animated PNG)
+
+    /// Write frames as an animated PNG file (full color, lossless).
+    public static func writeAPNG(frames: [CGImage], fps: Int, to url: URL) throws {
+        guard !frames.isEmpty else {
+            throw VideoWriterError.noFrames
+        }
+
+        guard
+            let destination = CGImageDestinationCreateWithURL(
+                url as CFURL,
+                UTType.png.identifier as CFString,
+                frames.count,
+                nil
+            )
+        else {
+            throw VideoWriterError.destinationCreationFailed
+        }
+
+        let pngProperties: [String: Any] = [
+            kCGImagePropertyPNGDictionary as String: [
+                kCGImagePropertyAPNGLoopCount as String: 0
+            ]
+        ]
+        CGImageDestinationSetProperties(destination, pngProperties as CFDictionary)
+
+        let frameDelay = 1.0 / Double(fps)
+        let frameProperties: [String: Any] = [
+            kCGImagePropertyPNGDictionary as String: [
+                kCGImagePropertyAPNGDelayTime as String: frameDelay
+            ]
+        ]
+
+        for frame in frames {
+            CGImageDestinationAddImage(destination, frame, frameProperties as CFDictionary)
+        }
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw VideoWriterError.finalizationFailed
+        }
+    }
+
+    // MARK: - WebP (Animated)
+
+    /// Write frames as an animated WebP file (lossy, small file size).
+    @available(macOS 14.0, iOS 17.0, *)
+    public static func writeWebP(frames: [CGImage], fps: Int, to url: URL) throws {
+        guard !frames.isEmpty else {
+            throw VideoWriterError.noFrames
+        }
+
+        guard
+            let destination = CGImageDestinationCreateWithURL(
+                url as CFURL,
+                UTType.webP.identifier as CFString,
+                frames.count,
+                nil
+            )
+        else {
+            throw VideoWriterError.destinationCreationFailed
+        }
+
+        let webPProperties: [String: Any] = [
+            kCGImagePropertyWebPDictionary as String: [
+                kCGImagePropertyWebPLoopCount as String: 0
+            ]
+        ]
+        CGImageDestinationSetProperties(destination, webPProperties as CFDictionary)
+
+        let frameDelay = 1.0 / Double(fps)
+        let frameProperties: [String: Any] = [
+            kCGImagePropertyWebPDictionary as String: [
+                kCGImagePropertyWebPDelayTime as String: frameDelay
+            ]
+        ]
+
+        for frame in frames {
+            CGImageDestinationAddImage(destination, frame, frameProperties as CFDictionary)
+        }
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw VideoWriterError.finalizationFailed
+        }
+    }
+
+    // MARK: - PNG Frames
+
+    /// Write each frame as a numbered PNG file in the given directory.
+    public static func writeFrames(frames: [CGImage], to directory: URL) throws {
+        guard !frames.isEmpty else {
+            throw VideoWriterError.noFrames
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let digitCount = String(frames.count - 1).count
+        for (index, frame) in frames.enumerated() {
+            let name = String(format: "frame_%0\(digitCount)d.png", index)
+            let fileURL = directory.appendingPathComponent(name)
+
+            guard
+                let dest = CGImageDestinationCreateWithURL(
+                    fileURL as CFURL, UTType.png.identifier as CFString, 1, nil)
+            else {
+                throw VideoWriterError.destinationCreationFailed
+            }
+            CGImageDestinationAddImage(dest, frame, nil)
+            guard CGImageDestinationFinalize(dest) else {
+                throw VideoWriterError.finalizationFailed
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func pixelBuffer(from image: CGImage, width: Int, height: Int) -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        let attrs: [String: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+        ]
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width, height,
+            kCVPixelFormatType_32ARGB,
+            attrs as CFDictionary,
+            &pixelBuffer
+        )
+        guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+            return nil
+        }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+        guard
+            let context = CGContext(
+                data: CVPixelBufferGetBaseAddress(buffer),
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
+            )
+        else {
+            return nil
+        }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return buffer
+    }
+}
+
+/// Errors specific to video output writing.
+public enum VideoWriterError: Error, CustomStringConvertible {
+    case noFrames
+    case pixelBufferCreationFailed
+    case destinationCreationFailed
+    case finalizationFailed
+
+    public var description: String {
+        switch self {
+        case .noFrames: "No frames provided for video output"
+        case .pixelBufferCreationFailed: "Failed to create pixel buffer from CGImage"
+        case .destinationCreationFailed: "Failed to create image destination"
+        case .finalizationFailed: "Failed to finalize image destination"
+        }
+    }
+}

--- a/swift/Sources/CoreAIVideoPipeline/Pipelines/VideoConfiguration.swift
+++ b/swift/Sources/CoreAIVideoPipeline/Pipelines/VideoConfiguration.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreGraphics
+
+/// Configuration for a video generation request.
+public struct VideoConfiguration: Sendable {
+    public var prompt: String
+    public var negativePrompt: String
+    public var seed: UInt32
+    public var stepCount: Int
+    public var guidanceScale: Float
+    public var numFrames: Int
+    public var fps: Int
+    public var width: Int
+    public var height: Int
+    public var conditioningImage: CGImage?
+
+    public init(
+        prompt: String,
+        negativePrompt: String = "",
+        seed: UInt32 = 42,
+        stepCount: Int = 50,
+        guidanceScale: Float = 7.5,
+        numFrames: Int = 49,
+        fps: Int = 24,
+        width: Int = 512,
+        height: Int = 320,
+        conditioningImage: CGImage? = nil
+    ) {
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.seed = seed
+        self.stepCount = stepCount
+        self.guidanceScale = guidanceScale
+        self.numFrames = numFrames
+        self.fps = fps
+        self.width = width
+        self.height = height
+        self.conditioningImage = conditioningImage
+    }
+}

--- a/swift/Sources/CoreAIVideoPipeline/Pipelines/VideoPipeline.swift
+++ b/swift/Sources/CoreAIVideoPipeline/Pipelines/VideoPipeline.swift
@@ -1,0 +1,55 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+import CoreGraphics
+
+/// Result of a video generation pipeline run, containing the decoded frames and target FPS.
+public struct VideoGenerationResult: Sendable {
+    public let frames: [CGImage]
+    public let fps: Int
+    public init(frames: [CGImage], fps: Int) {
+        self.frames = frames
+        self.fps = fps
+    }
+}
+
+/// Progress update emitted during video generation.
+public struct VideoProgress: Sendable {
+    public let step: Int
+    public let totalSteps: Int
+    public let phase: Phase
+
+    public enum Phase: String, Sendable {
+        case encoding
+        case denoising
+        case decoding
+        case assembling
+    }
+
+    public init(step: Int, totalSteps: Int, phase: Phase = .denoising) {
+        self.step = step
+        self.totalSteps = totalSteps
+        self.phase = phase
+    }
+}
+
+/// A video generation pipeline that produces frames from a text prompt.
+public protocol VideoPipeline {
+    /// Default output resolution for this pipeline's model.
+    var defaultVideoSize: (width: Int, height: Int) { get }
+
+    /// Default number of frames the pipeline produces.
+    var defaultFrameCount: Int { get }
+
+    /// Generate video frames from the given configuration.
+    ///
+    /// The progress handler is called periodically and may return `false` to cancel.
+    func generateVideo(
+        configuration: VideoConfiguration,
+        progressHandler: @Sendable (VideoProgress) -> Bool
+    ) async throws -> VideoGenerationResult
+}

--- a/swift/Sources/Tools/video-runner/VideoRunnerMain.swift
+++ b/swift/Sources/Tools/video-runner/VideoRunnerMain.swift
@@ -1,0 +1,87 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import ArgumentParser
+import CoreAIShared
+import CoreAIVideoPipeline
+import Foundation
+
+@main
+struct VideoRunner: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "video-runner",
+        abstract: "Generate videos using text-to-video diffusion models"
+    )
+
+    @Option(help: "Path to model directory containing .aimodel components")
+    var model: String
+
+    @Option(help: "Text prompt for video generation")
+    var prompt: String
+
+    @Option(help: "Number of output frames (default: model default)")
+    var numFrames: Int?
+
+    @Option(help: "Output FPS")
+    var fps: Int = 24
+
+    @Option(help: "Output resolution as WxH, e.g. 512x320")
+    var resolution: String?
+
+    @Option(help: "Number of denoising steps")
+    var steps: Int = 50
+
+    @Option(name: .customLong("guidance-scale"), help: "Classifier-free guidance scale")
+    var guidanceScale: Float = 7.5
+
+    @Option(help: "Random seed")
+    var seed: UInt32 = 42
+
+    @Option(help: "Output file path")
+    var output: String = "output.mp4"
+
+    @Option(
+        name: .customLong("output-format"),
+        help: "Output format: mp4, gif, apng, webp, or frames")
+    var outputFormat: String = "mp4"
+
+    @Flag(help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    func run() async throws {
+        let parsedWidth: Int?
+        let parsedHeight: Int?
+        if let resolution {
+            let parts = resolution.split(separator: "x")
+            guard parts.count == 2,
+                let w = Int(parts[0]),
+                let h = Int(parts[1])
+            else {
+                print("Error: --resolution must be in WxH format (e.g. 512x320)")
+                throw ExitCode.failure
+            }
+            parsedWidth = w
+            parsedHeight = h
+        } else {
+            parsedWidth = nil
+            parsedHeight = nil
+        }
+
+        print("Video Generation Configuration")
+        print("  Model:          \(model)")
+        print("  Prompt:         \(prompt)")
+        print("  Frames:         \(numFrames.map(String.init) ?? "model default")")
+        print("  FPS:            \(fps)")
+        print(
+            "  Resolution:     \(parsedWidth.map { "\($0)x\(parsedHeight!)" } ?? "model default")")
+        print("  Steps:          \(steps)")
+        print("  Guidance Scale: \(guidanceScale)")
+        print("  Seed:           \(seed)")
+        print("  Output:         \(output)")
+        print("  Format:         \(outputFormat)")
+        print()
+        print("Video pipeline not yet connected \u{2014} model loading coming soon")
+    }
+}


### PR DESCRIPTION
## Summary

Shared video generation infrastructure + LTX Video as the first video model.

### Swift: CoreAIVideoPipeline library + video-runner CLI
- `VideoPipeline` protocol with `generateVideo(configuration:progressHandler:)`
- `VideoConfiguration` (prompt, frames, fps, resolution, seed, guidance)
- `VideoWriter` — MP4 (AVAssetWriter/HEVC), GIF (ImageIO), PNG frames
- `video-runner` CLI skeleton (model loading coming next)

### Python: LTX Video export
- `LTXVideoTransformerWrapper` with pre-computed 3D RoPE
- T5 text encoder, 3D VAE encoder/decoder wrappers
- `compute_ltx_video_rope()` for temporal+spatial position embeddings
- Registry preset, metadata entry, component specs

### Why LTX Video first
- Apache 2.0, ~2B params
- 32x spatial + 8x temporal VAE = only ~1024 tokens for 5s 512x512 video
- FlowMatchEuler scheduler (same as Flux2)
- Conv3d validated in coreai_torch ✅

## Test plan
- [ ] `swift build --target CoreAIVideoPipeline` compiles
- [ ] `swift build --target video-runner` compiles
- [ ] `video-runner --help` shows clean options
- [ ] Python: `from coreai_models.diffusion.ltx_video import *` imports
- [ ] Python: `compute_ltx_video_rope()` produces correct shapes
- [ ] Export: `uv run coreai.diffusion.export ltx-video` (after model download)