### PR TITLE
Add SyncInputHandler protocol for engine extensibility

### DIFF
--- a/swift/Sources/CoreAILanguageModels/Handlers/InputHandler+Pipelined.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/InputHandler+Pipelined.swift
@@ -1,0 +1,107 @@
+// Asynchronous token input handler for the Pipelined engine (MTLBuffer-based).
+//
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+import Metal
+
+/// Input handler for the pipelined engine. Owns the token and position MTLBuffers,
+/// handles buffer rotation, and the prefill/decode source split.
+///
+/// `decodeOutputBuffers` is shared with the engine (GPU sampler writes next token
+/// there; this handler reads the previous step's token during decode).
+struct PipelinedTokenInputHandler {
+    let inputIdsName: String
+    let positionIdsName: String
+    let inputIdsDescriptor: NDArrayDescriptor
+    let positionIdsDescriptor: NDArrayDescriptor
+
+    let inputTokensBuffer: MTLBuffer
+    let cachePositionBuffers: [MTLBuffer]
+    let decodeOutputBuffers: [MTLBuffer]
+    let pipelineDepth: Int
+
+    /// Build async input values for one encode step.
+    ///
+    /// - Prefill (`!tokens.isEmpty`): writes tokens to `inputTokensBuffer` at their
+    ///   natural position (disjoint from prior chunks still in-flight on GPU).
+    /// - Decode (`tokens.isEmpty`): reads from previous step's `decodeOutputBuffer`.
+    func prepare(
+        tokens: some Collection<Int32>,
+        processedTokenCount: Int,
+        step: Int
+    ) throws -> [String: InferenceFunction.AsyncValue] {
+        let queryLength = tokens.isEmpty ? 1 : tokens.count
+
+        // Write tokens (prefill only — decode reads from GPU sampler output)
+        if !tokens.isEmpty {
+            let dst = inputTokensBuffer.contents()
+                .assumingMemoryBound(to: Int32.self)
+                .advanced(by: processedTokenCount)
+            let tokenArray = Array(tokens)
+            tokenArray.withUnsafeBufferPointer { src in
+                memcpy(dst, src.baseAddress!, tokenArray.count * MemoryLayout<Int32>.size)
+            }
+        }
+
+        // Token input
+        let tokenShape = [1, queryLength]
+        let tokenStrides = try resolvedStrides(descriptor: inputIdsDescriptor, shape: tokenShape)
+        let tokenValue: InferenceFunction.AsyncValue
+        if tokens.isEmpty {
+            tokenValue = unsafe InferenceFunction.AsyncValue(
+                unsafeBuffer: decodeOutputBuffers[(step + pipelineDepth - 1) % pipelineDepth],
+                byteOffset: 0, scalarType: .int32, shape: tokenShape, strides: tokenStrides)
+        } else {
+            tokenValue = unsafe InferenceFunction.AsyncValue(
+                unsafeBuffer: inputTokensBuffer,
+                byteOffset: processedTokenCount * MemoryLayout<Int32>.size,
+                scalarType: .int32, shape: tokenShape, strides: tokenStrides)
+        }
+
+        // Position input (rotating buffer)
+        let posLength = processedTokenCount + queryLength
+        let posShape = [1, posLength]
+        let posStrides = try resolvedStrides(descriptor: positionIdsDescriptor, shape: posShape)
+        let posValue = unsafe InferenceFunction.AsyncValue(
+            unsafeBuffer: cachePositionBuffers[step % pipelineDepth],
+            byteOffset: 0, scalarType: .int32, shape: posShape, strides: posStrides)
+
+        return [
+            inputIdsName: tokenValue,
+            positionIdsName: posValue,
+        ]
+    }
+
+    /// Prepare inputs for warmup (always prefill mode, writes dummy tokens).
+    func prepareWarmup(
+        shape: Int,
+        processedTokenCount: Int,
+        step: Int
+    ) throws -> [String: InferenceFunction.AsyncValue] {
+        let ptr = inputTokensBuffer.contents().assumingMemoryBound(to: Int32.self)
+        for i in 0..<shape { ptr[i] = 1 }
+
+        let tokenShape = [1, shape]
+        let tokenStrides = try resolvedStrides(descriptor: inputIdsDescriptor, shape: tokenShape)
+        let tokenValue = unsafe InferenceFunction.AsyncValue(
+            unsafeBuffer: inputTokensBuffer, byteOffset: 0,
+            scalarType: .int32, shape: tokenShape, strides: tokenStrides)
+
+        let posLength = processedTokenCount + shape
+        let posShape = [1, posLength]
+        let posStrides = try resolvedStrides(descriptor: positionIdsDescriptor, shape: posShape)
+        let posValue = unsafe InferenceFunction.AsyncValue(
+            unsafeBuffer: cachePositionBuffers[step % pipelineDepth],
+            byteOffset: 0, scalarType: .int32, shape: posShape, strides: posStrides)
+
+        return [
+            inputIdsName: tokenValue,
+            positionIdsName: posValue,
+        ]
+    }
+}

--- a/swift/Sources/CoreAILanguageModels/Handlers/InputHandler+Token.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/InputHandler+Token.swift
@@ -1,0 +1,99 @@
+// Synchronous token input handler for Sequential and StaticShape engines.
+//
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+
+/// Standard input handler for text LLMs: `input_ids` (Int32) + `position_ids` (Int32).
+///
+/// Pre-allocates the `input_ids` NDArray and reuses it when batch size is unchanged.
+public struct TokenInputHandler: SyncInputHandler {
+    public let inputNames: [String]
+
+    private let inputIdsName: String
+    private let positionIdsName: String
+    private let inputIdsDescriptor: NDArrayDescriptor
+    private let positionIdsDescriptor: NDArrayDescriptor
+
+    private var inputIdsArray: NDArray
+    private var cachedBatchSize: Int
+
+    public init(
+        inputIdsName: String,
+        positionIdsName: String,
+        inputIdsDescriptor: NDArrayDescriptor,
+        positionIdsDescriptor: NDArrayDescriptor
+    ) {
+        self.inputIdsName = inputIdsName
+        self.positionIdsName = positionIdsName
+        self.inputIdsDescriptor = inputIdsDescriptor
+        self.positionIdsDescriptor = positionIdsDescriptor
+        self.inputNames = [inputIdsName, positionIdsName]
+
+        let initDesc = inputIdsDescriptor.resolvingDynamicDimensions([1, 1])
+        self.inputIdsArray = NDArray(descriptor: initDesc)
+        self.cachedBatchSize = 1
+    }
+
+    public mutating func prepare(_ context: InputContext) async throws -> [String: NDArray] {
+        let tokens = context.tokens
+        let batchSize = tokens.count
+        precondition(batchSize > 0, "TokenInputHandler: empty token batch")
+
+        if cachedBatchSize != batchSize {
+            let resolved = inputIdsDescriptor.resolvingDynamicDimensions([1, batchSize])
+            inputIdsArray = NDArray(descriptor: resolved)
+            cachedBatchSize = batchSize
+        }
+        fillNDArray(&inputIdsArray, as: Int32.self, with: tokens)
+
+        let totalPositions = context.processedTokenCount + batchSize
+        let resolvedPosDesc = positionIdsDescriptor.resolvingDynamicDimensions([1, totalPositions])
+        var positionIds = NDArray(descriptor: resolvedPosDesc)
+        fillNDArray(&positionIds, as: Int32.self, count: totalPositions) { Int32($0) }
+
+        return [
+            inputIdsName: inputIdsArray,
+            positionIdsName: positionIds,
+        ]
+    }
+}
+
+/// Wraps a base input handler and appends model-specific extra inputs.
+///
+/// Use for any input that needs per-step computation beyond standard token/position IDs.
+public struct CompositeInputHandler<Base: SyncInputHandler>: SyncInputHandler {
+    public var inputNames: [String] {
+        base.inputNames + extras.map(\.name)
+    }
+
+    private var base: Base
+    private let extras: [ExtraInput]
+
+    public struct ExtraInput: Sendable {
+        public let name: String
+        public let prepare: @Sendable (InputContext) throws -> NDArray
+
+        public init(name: String, prepare: @Sendable @escaping (InputContext) throws -> NDArray) {
+            self.name = name
+            self.prepare = prepare
+        }
+    }
+
+    public init(base: Base, extras: [ExtraInput]) {
+        self.base = base
+        self.extras = extras
+    }
+
+    public mutating func prepare(_ context: InputContext) async throws -> [String: NDArray] {
+        var inputs = try await base.prepare(context)
+        for extra in extras {
+            inputs[extra.name] = try extra.prepare(context)
+        }
+        return inputs
+    }
+}

--- a/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
@@ -1,0 +1,90 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+
+/// Context for each inference step, used by both dynamic (GPU) and static (ANE) engines.
+public struct InputContext: Sendable {
+    /// Tokens to process in this step.
+    public let tokens: ArraySlice<Int32>
+    /// Number of tokens already processed before this step.
+    public let processedTokenCount: Int
+    /// Batch-aligned start position.
+    public let alignedStep: Int
+    /// Total batch slot count (may exceed tokens.count for static-shape padding).
+    public let batchSize: Int
+    /// Sliding window size (nil for models without sliding attention).
+    public let slidingWindow: Int?
+
+    /// For dynamic-shape engines (Sequential, Pipelined).
+    /// alignedStep = processedTokenCount, batchSize = tokens.count.
+    public static func dynamic(
+        tokens: ArraySlice<Int32>,
+        processedTokenCount: Int
+    ) -> InputContext {
+        InputContext(
+            tokens: tokens,
+            processedTokenCount: processedTokenCount,
+            alignedStep: processedTokenCount,
+            batchSize: tokens.count,
+            slidingWindow: nil)
+    }
+
+    /// For static-shape engines. Batch is fixed-size and aligned.
+    public static func `static`(
+        tokens: ArraySlice<Int32>,
+        alignedStep: Int,
+        batchSize: Int,
+        slidingWindow: Int?
+    ) -> InputContext {
+        InputContext(
+            tokens: tokens,
+            processedTokenCount: alignedStep,
+            alignedStep: alignedStep,
+            batchSize: batchSize,
+            slidingWindow: slidingWindow)
+    }
+}
+
+/// Prepares model inputs for each inference step.
+///
+/// The engine calls `prepare(...)` each step and passes the result to `function.run()`.
+/// Standard models use `TokenInputHandler`; models with extra inputs (RoPE,
+/// sliding step, PLE) wrap it with `CompositeInputHandler`.
+public protocol SyncInputHandler {
+    /// Input names this handler produces.
+    var inputNames: [String] { get }
+
+    /// Prepare inputs for the current step.
+    mutating func prepare(_ context: InputContext) async throws -> [String: NDArray]
+}
+
+// MARK: - Load-time Coverage Check
+
+public enum InputCoverage {
+    /// Verify that a set of handlers covers all required inputs declared by the model descriptor.
+    /// Call at engine init to fail fast on missing handlers rather than producing NaN at runtime.
+    ///
+    /// - Parameters:
+    ///   - handlers: All input handlers the engine will use.
+    ///   - descriptor: The model function's descriptor declaring required inputs.
+    ///   - ignoring: Input names to exclude from the check (e.g. "embedding_table" passed directly).
+    /// - Throws: If any declared input is not produced by any handler.
+    public static func verify(
+        handlers: [any SyncInputHandler],
+        descriptor: InferenceFunctionDescriptor,
+        ignoring: Set<String> = []
+    ) throws {
+        let produced = handlers.reduce(into: Set<String>()) { $0.formUnion($1.inputNames) }
+        let declared = Set(descriptor.inputNames).subtracting(ignoring)
+        let uncovered = declared.subtracting(produced)
+        guard uncovered.isEmpty else {
+            throw InferenceRuntimeError.invalidState(
+                "No input handler produces required input(s): \(uncovered.sorted()). "
+                    + "Produced: \(produced.sorted())")
+        }
+    }
+}

--- a/swift/Sources/CoreAIShared/Runtime/NDArray+Helpers.swift
+++ b/swift/Sources/CoreAIShared/Runtime/NDArray+Helpers.swift
@@ -32,6 +32,17 @@ extension Span where Element == Int {
     }
 }
 
+/// Check whether a shape+strides pair represents a contiguous row-major layout.
+public func isContiguousRowMajor(shape: Span<Int>, strides: Span<Int>) -> Bool {
+    let rank = shape.count
+    var expectedStride = 1
+    for d in (0..<rank).reversed() {
+        if strides[d] != expectedStride { return false }
+        expectedStride *= shape[d]
+    }
+    return true
+}
+
 // MARK: - NDArray Fill / Read Helpers
 
 /// Fill an NDArray from a collection of elements.
@@ -44,34 +55,68 @@ public func fillNDArray<T: BitwiseCopyable>(
 
 /// Fill an NDArray using a closure that maps index → value.
 ///
-/// - Precondition: `count` must not exceed the number of elements in the
-///   array (derived from the shape).
+/// Uses stride-aware indexing to handle GPU-aligned padding in 4D+ tensors.
+/// - Precondition: `count` must not exceed the logical element count of the array.
 public func fillNDArray<T: BitwiseCopyable>(
     _ array: inout NDArray, as type: T.Type, count: Int, using generator: (Int) -> T
 ) {
     let view = array.mutableView(as: type)
-    view.withUnsafeMutablePointer { ptr, shape, _ in
+    view.withUnsafeMutablePointer { ptr, shape, strides in
         let capacity = shape.product
         precondition(count <= capacity, "fillNDArray: count \(count) exceeds array capacity \(capacity)")
-        for i in 0..<count {
-            ptr[i] = generator(i)
+
+        if isContiguousRowMajor(shape: shape, strides: strides) {
+            for i in 0..<count { ptr[i] = generator(i) }
+        } else {
+            let rank = shape.count
+            var indices = [Int](repeating: 0, count: rank)
+            for i in 0..<count {
+                var offset = 0
+                for d in 0..<rank { offset += indices[d] * strides[d] }
+                ptr[offset] = generator(i)
+                var dim = rank - 1
+                while dim >= 0 {
+                    indices[dim] += 1
+                    if indices[dim] < shape[dim] { break }
+                    indices[dim] = 0
+                    dim -= 1
+                }
+            }
         }
     }
 }
 
 /// Read elements from an NDArray into a new Array.
 ///
-/// - Precondition: `count` must not exceed the number of elements in the
-///   array (derived from the shape).
+/// Uses stride-aware indexing to handle non-contiguous layouts.
+/// - Precondition: `count` must not exceed the logical element count.
 public func readNDArray<T: BitwiseCopyable>(
     _ array: NDArray, as type: T.Type, count: Int
 ) -> [T] {
-    array.view(as: type).withUnsafePointer { ptr, shape, _ in
+    array.view(as: type).withUnsafePointer { ptr, shape, strides in
         let capacity = shape.product
         precondition(count <= capacity, "readNDArray: count \(count) exceeds array capacity \(capacity)")
+
+        if isContiguousRowMajor(shape: shape, strides: strides) {
+            return Array(UnsafeBufferPointer(start: ptr, count: count))
+        }
+
+        let rank = shape.count
         var result = [T]()
         result.reserveCapacity(count)
-        result.append(contentsOf: UnsafeBufferPointer(start: ptr, count: count))
+        var indices = [Int](repeating: 0, count: rank)
+        for _ in 0..<count {
+            var offset = 0
+            for d in 0..<rank { offset += indices[d] * strides[d] }
+            result.append(ptr[offset])
+            var dim = rank - 1
+            while dim >= 0 {
+                indices[dim] += 1
+                if indices[dim] < shape[dim] { break }
+                indices[dim] = 0
+                dim -= 1
+            }
+        }
         return result
     }
 }
@@ -102,25 +147,14 @@ public func flattenNDArray<T: BinaryFloatingPoint & BitwiseCopyable>(
     _ array: NDArray, as type: T.Type
 ) -> [Float] {
     let outerShape = array.shape
-    let rank = outerShape.count
     let total = outerShape.reduce(1, *)
     var result = [Float](repeating: 0, count: total)
     array.view(as: type).withUnsafePointer { ptr, shape, strides in
-        // Fast path: row-major contiguous layout — avoids per-element stride arithmetic.
-        var expectedStride = 1
-        var isContiguous = true
-        for d in (0..<rank).reversed() {
-            if strides[d] != expectedStride {
-                isContiguous = false
-                break
-            }
-            expectedStride *= shape[d]
-        }
-        if isContiguous {
+        if isContiguousRowMajor(shape: shape, strides: strides) {
             for i in 0..<total { result[i] = Float(ptr[i]) }
             return
         }
-        // Slow path: non-contiguous strides.
+        let rank = shape.count
         var indices = [Int](repeating: 0, count: rank)
         for i in 0..<total {
             var offset = 0

--- a/swift/Tests/LanguageModelsTests/InputHandlerTests.swift
+++ b/swift/Tests/LanguageModelsTests/InputHandlerTests.swift
@@ -1,0 +1,46 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import Testing
+
+@testable import CoreAILanguageModels
+
+@Suite("InputHandler Tests")
+struct InputHandlerTests {
+    @Test("TokenInputHandler conforms to SyncInputHandler")
+    func tokenConformance() {
+        let _: any SyncInputHandler.Type = TokenInputHandler.self
+    }
+
+    @Test("InputContext.dynamic creates correct context")
+    func dynamicContext() {
+        let tokens: ArraySlice<Int32> = [10, 20, 30][...]
+        let ctx = InputContext.dynamic(tokens: tokens, processedTokenCount: 5)
+        #expect(ctx.tokens.count == 3)
+        #expect(ctx.processedTokenCount == 5)
+        #expect(ctx.alignedStep == 5)
+        #expect(ctx.batchSize == 3)
+        #expect(ctx.slidingWindow == nil)
+    }
+
+    @Test("InputContext.static creates correct context")
+    func staticContext() {
+        let tokens: ArraySlice<Int32> = [10, 20][...]
+        let ctx = InputContext.static(tokens: tokens, alignedStep: 10, batchSize: 4, slidingWindow: 256)
+        #expect(ctx.tokens.count == 2)
+        #expect(ctx.processedTokenCount == 10)
+        #expect(ctx.alignedStep == 10)
+        #expect(ctx.batchSize == 4)
+        #expect(ctx.slidingWindow == 256)
+    }
+
+    @Test("InputCoverage.verify passes when all inputs covered")
+    func coveragePass() throws {
+        // This is a compile-time API check — we can't easily construct a descriptor
+        // in tests without a model, so just verify the type exists
+        let _: InputCoverage.Type = InputCoverage.self
+    }
+}


### PR DESCRIPTION
## Summary

Composable input preparation layer for inference engines, enabling model-specific inputs (RoPE, PLE, sliding window masks) without engine modifications.

- **SyncInputHandler** protocol with `prepare(_ context:) -> [String: NDArray]`
- **InputContext** with `.dynamic()` and `.static()` builders
- **TokenInputHandler** — standard token/position ID preparation with batch caching
- **CompositeInputHandler** — wraps base handler with extra model-specific inputs
- **PipelinedTokenInputHandler** — MTLBuffer-based for pipelined engine
- **InputCoverage.verify()** — fail-fast at engine init if inputs are uncovered

Also hardens `NDArray+Helpers`:
- `fillNDArray(count:using:)` and `readNDArray` now check contiguity and fall back to stride-aware indexing for tensors with GPU alignment padding

## Test plan

- [x] InputHandler Tests: 4 tests pass (context builders, type conformance, coverage API)
- [x] CoreAIShared Tests: 24 tests pass (no regressions)
- [x] Full package builds cleanly