### PR TITLE
Normalize topK=1 to greedy at engine entry points

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -688,6 +688,7 @@ private struct EngineImpl: ~Copyable {
     // MARK: - Sampler
 
     private mutating func getOrCreateSampler(for config: SamplingConfiguration) throws -> any MPSGraphSampler {
+        let config = config.normalized()
         let temperature = config.temperature
 
         if let existingSampler = cachedSampler, let existingTemp = cachedSamplerTemperature {

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
@@ -538,7 +538,7 @@ extension CoreAISequentialEngine.GenerationSequence {
             generationToken: GenerationToken
         ) {
             self.engine = engine
-            self.samplingConfiguration = samplingConfiguration
+            self.samplingConfiguration = samplingConfiguration.normalized()
             self.returnsLogits = inferenceOptions.includeLogits
             self.forcedContinuation = inferenceOptions.forcedContinuation
             self.stopReasonStore = stopReasonStore

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialVLMEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialVLMEngine.swift
@@ -1009,7 +1009,7 @@ extension CoreAISequentialVLMEngine.GenerationSequence {
             generationToken: GenerationToken
         ) {
             self.engine = engine
-            self.samplingConfiguration = samplingConfiguration
+            self.samplingConfiguration = samplingConfiguration.normalized()
             self.returnsLogits = inferenceOptions.includeLogits
             self.forcedContinuation = inferenceOptions.forcedContinuation
             self.stopReasonStore = stopReasonStore

--- a/swift/Sources/CoreAILanguageModels/Samplers/SamplingConfiguration.swift
+++ b/swift/Sources/CoreAILanguageModels/Samplers/SamplingConfiguration.swift
@@ -226,6 +226,14 @@ public struct SamplingConfiguration: Sendable, Equatable, Hashable {
     ///
     /// - Returns: A new configuration with redundant settings removed.
     public func normalized() -> SamplingConfiguration {
+        // topK=1 with temperature>0 is equivalent to greedy — promote it
+        if let k = topK, k == 1, temperature > 0 {
+            CLILogger.log(
+                "⚠️ SamplingConfiguration: topK=1 normalized to greedy (temperature=0)",
+                component: "Sampling")
+            return .greedy
+        }
+
         let effectiveTopK: Int?
         let effectiveTopP: Double?
         let effectiveMinP: Double?


### PR DESCRIPTION
Presents a warning in case a user actually wants to exercise this path (which will be optimized out)