### PR TITLE
Add bind(into:) for zero-copy state binding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,7 @@ let package = Package(
             swiftSettings: [
                 .define("CXGRAMMAR_IMPORT"),
                 .enableUpcomingFeature("MemberImportVisibility"),
+                .enableExperimentalFeature("Lifetimes"),
             ],
             linkerSettings: [
                 .linkedLibrary("c++")
@@ -224,6 +225,9 @@ let package = Package(
             path: "swift/Tests/LanguageModelsTests",
             resources: [
                 .copy("Resources/MinimalTokenizer")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("Lifetimes"),
             ],
             linkerSettings: [
                 .linkedLibrary("c++")

--- a/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+Encode.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+Encode.swift
@@ -1,0 +1,38 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import Metal
+
+/// Encode an inference step with KV cache states, optional additional MTLBuffer
+/// states, and logits output.
+func encodeWithStates(
+    function: InferenceFunction,
+    inputs: [String: InferenceFunction.AsyncValue],
+    keyState: inout InferenceFunction.AsyncMutableValue,
+    keyCacheName: String,
+    valState: inout InferenceFunction.AsyncMutableValue,
+    valueCacheName: String,
+    additionalStates: FixedMTLBufferState?,
+    logitsBuffer: MTLBuffer,
+    logitsName: String,
+    logitsShape: [Int],
+    logitsStrides: [Int],
+    computeStream: ComputeStream
+) throws {
+    var asyncStates = InferenceFunction.AsyncMutableViews()
+    asyncStates.insert(&keyState, for: keyCacheName)
+    asyncStates.insert(&valState, for: valueCacheName)
+    additionalStates?.bind(into: &asyncStates)
+
+    var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
+        unsafeBuffer: logitsBuffer, byteOffset: 0,
+        scalarType: .float16, shape: logitsShape, strides: logitsStrides)
+    var asyncOutputs = InferenceFunction.AsyncMutableViews()
+    asyncOutputs.insert(&logitsOutput, for: logitsName)
+    let _ = try function.encode(
+        inputs: inputs, states: consume asyncStates,
+        outputViews: consume asyncOutputs, to: computeStream)
+}

--- a/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+MTLBuffer.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+MTLBuffer.swift
@@ -7,9 +7,9 @@ import CoreAI
 import CoreAIShared
 import Metal
 
-/// Fixed-size MTLBuffer state for non-truncatable persistent states.
+/// Fixed-size MTLBuffer state for non-truncatable persistent states (pipelined engine).
 /// Allocated once at init, zero-initialized, never grows.
-public struct FixedMTLBufferState {
+public final class FixedMTLBufferState {
     public let stateNames: [String]
     public var stateCount: Int { bindings.count }
 
@@ -29,7 +29,8 @@ public struct FixedMTLBufferState {
             let resolved = desc.resolvingDynamicDimensions(desc.shape)
             let strides = resolved.preferredStrides
             let byteCount = resolved.minimumByteCount
-            guard let buffer = device.makeBuffer(length: max(byteCount, 64), options: .storageModeShared) else {
+            guard let buffer = device.makeBuffer(length: max(byteCount, 64), options: .storageModeShared)
+            else {
                 throw InferenceRuntimeError.bufferAllocationFailed("\(name) (\(byteCount) bytes)")
             }
             memset(buffer.contents(), 0, buffer.length)
@@ -39,17 +40,21 @@ public struct FixedMTLBufferState {
         self.stateNames = states.map(\.name)
     }
 
-    /// Access a state binding by index for AsyncMutableValue construction.
-    /// The engine builds AsyncMutableValue views from these in the same scope as encode().
-    /// Note: MTLBuffer is a reference type — the returned buffer is shared, not copied.
-    public subscript(stateIndex index: Int) -> (
-        name: String, buffer: MTLBuffer, scalarType: NDArray.ScalarType, shape: [Int], strides: [Int]
-    ) {
-        get { bindings[index] }
+    /// Insert all managed states into async mutable views. MTLBuffer is a reference
+    /// type (no COW). Uses _overrideLifetime for disjoint element access in the loop.
+    @_lifetime(views: borrow self)
+    public func bind(into views: inout InferenceFunction.AsyncMutableViews) {
+        for binding in bindings {
+            var value = unsafe InferenceFunction.AsyncMutableValue(
+                unsafeBuffer: binding.buffer, byteOffset: 0,
+                scalarType: binding.scalarType, shape: binding.shape, strides: binding.strides)
+            views.insert(&value, for: binding.name)
+            views = unsafe _overrideLifetime(consume views, borrowing: self)
+        }
     }
 
     /// Zero all state buffers. Caller must ensure no in-flight GPU work references these.
-    public mutating func reset() {
+    public func reset() {
         for (_, buffer, _, _, _) in bindings {
             memset(buffer.contents(), 0, buffer.length)
         }

--- a/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+NDArray.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+NDArray.swift
@@ -11,56 +11,63 @@ import Darwin
 
 /// Fixed-size state for non-truncatable persistent states.
 /// Allocated at full size on init, zero-initialized. No capacity management needed.
-public struct FixedNDArrayState: SyncStateHandler {
+public final class FixedNDArrayState: SyncStateHandler {
     public let stateNames: [String]
     public let supportsTruncation: Bool = false
     public let currentCapacity: Int = .max
     public var stateCount: Int { arrays.count }
 
-    private var arrays: [(name: String, array: NDArray)]
+    private var arrays: [String: NDArray]
 
     public init(states: [(name: String, descriptor: NDArrayDescriptor)]) {
-        var arrays: [(String, NDArray)] = []
+        var arrays: [String: NDArray] = [:]
         for (name, desc) in states {
             var array = NDArray(descriptor: desc)
             zeroFillNDArray(&array)
-            arrays.append((name, array))
+            arrays[name] = array
         }
         self.arrays = arrays
         self.stateNames = states.map(\.name)
     }
 
-    public mutating func ensureCapacity(forContextLength contextLength: Int) throws -> Bool {
+    public func ensureCapacity(forContextLength contextLength: Int) throws -> Bool {
         false
     }
 
     public subscript(stateIndex index: Int) -> (name: String, array: NDArray) {
-        get { arrays[index] }
-        set { arrays[index] = newValue }
+        get { (stateNames[index], arrays[stateNames[index]]!) }
+        set { arrays[stateNames[index]] = newValue.array }
     }
 
-    public mutating func reset() {
-        for i in arrays.indices {
-            zeroFillNDArray(&arrays[i].array)
+    @_lifetime(views: borrow self)
+    public func bind(into views: inout InferenceFunction.MutableViews) {
+        for name in stateNames {
+            let view = _overrideLifetime(arrays[name]!.mutableRawView(), borrowing: Void())
+            views.insert(view, for: name)
         }
     }
 
-    public mutating func truncate(to tokenCount: Int) {
+    public func reset() {
+        for name in stateNames {
+            zeroFillNDArray(&arrays[name]!)
+        }
+    }
+
+    public func truncate(to tokenCount: Int) {
         preconditionFailure("truncate(to:) called on non-truncatable FixedNDArrayState")
     }
 }
 
 // MARK: - Growing NDArray State
 
-/// Dynamically-growing KV cache state. Starts small and doubles capacity
-/// when more context is needed.
-public struct GrowingNDArrayState: SyncStateHandler {
+/// Dynamically-growing KV cache state. Starts small and doubles capacity.
+public final class GrowingNDArrayState: SyncStateHandler {
     public let stateNames: [String]
     public let supportsTruncation: Bool = true
     public private(set) var currentCapacity: Int
     public var stateCount: Int { arrays.count }
 
-    private var arrays: [(name: String, array: NDArray)]
+    private var arrays: [String: NDArray]
     private let descriptors: [NDArrayDescriptor]
     private let maxCapacity: Int
     private let sequenceDimIndex: Int
@@ -80,16 +87,16 @@ public struct GrowingNDArrayState: SyncStateHandler {
         let capacity = min(initialCapacity, maxCapacity)
         self.currentCapacity = capacity
 
-        var arrays: [(String, NDArray)] = []
+        var arrays: [String: NDArray] = [:]
         for (name, desc) in states {
             let resolved = desc.resolvingDynamicDimensions(
                 desc.shape.map { $0 < 0 ? capacity : $0 })
-            arrays.append((name, NDArray(descriptor: resolved)))
+            arrays[name] = NDArray(descriptor: resolved)
         }
         self.arrays = arrays
     }
 
-    public mutating func ensureCapacity(forContextLength contextLength: Int) throws -> Bool {
+    public func ensureCapacity(forContextLength contextLength: Int) throws -> Bool {
         guard contextLength > currentCapacity else { return false }
         guard contextLength <= maxCapacity else {
             throw InferenceRuntimeError.invalidState(
@@ -101,16 +108,14 @@ public struct GrowingNDArrayState: SyncStateHandler {
             newCapacity = min(newCapacity * 2, maxCapacity)
         }
 
-        for i in arrays.indices {
+        for (i, name) in stateNames.enumerated() {
             let desc = descriptors[i]
             let newShape = desc.shape.map { $0 < 0 ? newCapacity : $0 }
             let resolvedDesc = desc.resolvingDynamicDimensions(newShape)
             var newArray = NDArray(descriptor: resolvedDesc)
-            // Force backing allocation before copy
             _ = newArray.mutableRawView()
-
-            copyCache(from: arrays[i].array, to: &newArray, sequenceDim: sequenceDimIndex)
-            arrays[i].array = newArray
+            copyCache(from: arrays[name]!, to: &newArray, sequenceDim: sequenceDimIndex)
+            arrays[name] = newArray
         }
 
         currentCapacity = newCapacity
@@ -118,20 +123,25 @@ public struct GrowingNDArrayState: SyncStateHandler {
     }
 
     public subscript(stateIndex index: Int) -> (name: String, array: NDArray) {
-        get { arrays[index] }
-        set { arrays[index] = newValue }
+        get { (stateNames[index], arrays[stateNames[index]]!) }
+        set { arrays[stateNames[index]] = newValue.array }
     }
 
-    public mutating func reset() {
-        for i in arrays.indices {
-            zeroFillNDArray(&arrays[i].array)
+    @_lifetime(views: borrow self)
+    public func bind(into views: inout InferenceFunction.MutableViews) {
+        for name in stateNames {
+            let view = _overrideLifetime(arrays[name]!.mutableRawView(), borrowing: Void())
+            views.insert(view, for: name)
         }
     }
 
-    public mutating func truncate(to tokenCount: Int) {
-        // KV cache truncation is a no-op on the backing storage.
-        // The causal mask hides positions beyond processedTokenCount.
+    public func reset() {
+        for name in stateNames {
+            zeroFillNDArray(&arrays[name]!)
+        }
     }
+
+    public func truncate(to tokenCount: Int) {}
 
     // MARK: - Private
 
@@ -175,7 +185,6 @@ public struct GrowingNDArrayState: SyncStateHandler {
 
 // MARK: - Shared Utilities
 
-/// Zero-initialize an NDArray, dispatching on scalar type.
 func zeroFillNDArray(_ array: inout NDArray) {
     let count = array.shape.reduce(1, *)
     switch array.scalarType {

--- a/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+Run.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/StateHandler+Run.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+
+/// Run an inference step with combined primary + secondary states and output.
+/// Zero-copy: bind(into:) uses reference-backed storage and _overrideLifetime.
+func runWithStates(
+    function: InferenceFunction,
+    inputs: [String: NDArray],
+    primary: any SyncStateHandler,
+    secondary: FixedNDArrayState?,
+    outputArray: inout NDArray,
+    outputName: String
+) async throws {
+    var states = InferenceFunction.MutableViews()
+    primary.bind(into: &states)
+    secondary?.bind(into: &states)
+
+    var outputViews = InferenceFunction.MutableViews()
+    outputViews.insert(&outputArray, for: outputName)
+
+    _ = try await function.run(
+        inputs: inputs,
+        states: _unsafeEscapeMutableViews(consume states),
+        outputViews: consume outputViews)
+}

--- a/swift/Sources/CoreAILanguageModels/Handlers/StateHandler.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/StateHandler.swift
@@ -8,16 +8,13 @@ import CoreAI
 /// Persistent model state that the engine carries across inference steps.
 ///
 /// Each handler manages one or more named state tensors (e.g., key_cache + value_cache,
-/// or a single convolution_state). The engine owns an array of handlers and delegates
-/// all state lifecycle to them — allocation, growth, and reset.
+/// or a single convolution_state). The engine owns handlers and delegates all state
+/// lifecycle to them — allocation, growth, and reset.
 ///
-/// ## MutableViews Lifetime Constraint
-///
-/// `InferenceFunction.MutableViews.insert` creates a lifetime dependency on each `inout`
-/// variable. This means state binding CANNOT be abstracted into a method that takes
-/// `inout MutableViews` — the inserts must happen in the same scope as `function.run()`.
-/// Handlers therefore expose their arrays directly via subscript for the engine to bind.
-public protocol SyncStateHandler {
+/// Handlers are classes (AnyObject) so they own their NDArrays at refcount 1 —
+/// `bind(into:)` calls `mutableRawView()` without triggering COW. The loop uses
+/// `_overrideLifetime` to express disjoint element access to the compiler.
+public protocol SyncStateHandler: AnyObject {
     /// Names of the states managed by this handler.
     var stateNames: [String] { get }
 
@@ -35,18 +32,32 @@ public protocol SyncStateHandler {
 
     /// Ensure the state can accommodate `contextLength` tokens.
     /// Returns true if reallocation occurred.
-    mutating func ensureCapacity(forContextLength contextLength: Int) throws -> Bool
+    func ensureCapacity(forContextLength contextLength: Int) throws -> Bool
 
-    /// Access a state array by index for binding into MutableViews.
-    /// The engine calls this to get name + array pairs for insert.
+    /// Access a state array by name+index (value copy — use bind(into:) on hot paths).
     subscript(stateIndex index: Int) -> (name: String, array: NDArray) { get set }
 
+    /// Insert all managed states into `views`. Zero-copy: uses reference-backed
+    /// storage internally, so mutableRawView() never triggers COW.
+    @_lifetime(views: borrow self)
+    func bind(into views: inout InferenceFunction.MutableViews)
+
     /// Full reset — zero all backing storage, rewind to position 0.
-    mutating func reset()
+    func reset()
 
     /// Truncate to a given token position.
-    /// Only valid when `supportsTruncation == true`. For KV cache, this is a no-op
-    /// on the backing storage (causal mask handles visibility); the engine just
-    /// updates its processedTokenCount.
-    mutating func truncate(to tokenCount: Int)
+    func truncate(to tokenCount: Int)
+}
+
+// MARK: - Lifetime Helpers
+
+/// Detach lifetime dependencies from MutableViews so it can cross scope
+/// boundaries (closures, await). Caller must ensure inserted arrays remain valid.
+@inline(__always)
+@_unsafeNonescapableResult
+@_lifetime(immortal)
+func _unsafeEscapeMutableViews(
+    _ views: consuming InferenceFunction.MutableViews
+) -> InferenceFunction.MutableViews {
+    views
 }

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -845,70 +845,14 @@ private struct EngineImpl: ~Copyable {
 
         // Swift 6 lifetime safety: AsyncMutableViews uses @lifetime(self: &mutableValue)
         // on insert(), so all inserts + consume must be in the same scope without branching.
-        // We switch on state count to avoid the optional-chain branch that the checker rejects.
-        switch additionalStates?.stateCount ?? 0 {
-        case 1:
-            let extra0 = additionalStates![stateIndex: 0]
-            var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra0.buffer, byteOffset: 0,
-                scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            asyncStates.insert(&extraState0, for: extra0.name)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logitsOutputBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        case 2:
-            let extra0 = additionalStates![stateIndex: 0]
-            let extra1 = additionalStates![stateIndex: 1]
-            var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra0.buffer, byteOffset: 0,
-                scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-            var extraState1 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra1.buffer, byteOffset: 0,
-                scalarType: extra1.scalarType, shape: extra1.shape, strides: extra1.strides)
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            asyncStates.insert(&extraState0, for: extra0.name)
-            asyncStates.insert(&extraState1, for: extra1.name)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logitsOutputBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        default:
-            // case 0: no additional states
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logitsOutputBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        }
+        try encodeWithStates(
+            function: function, inputs: asyncInputs,
+            keyState: &keyState, keyCacheName: keyCacheName,
+            valState: &valState, valueCacheName: valueCacheName,
+            additionalStates: additionalStates,
+            logitsBuffer: logitsOutputBuffer, logitsName: logitsOutputName,
+            logitsShape: logitsShape, logitsStrides: logitsStrides,
+            computeStream: computeStream)
         logitsSpan.end()
 
         // GPU sampling via Metal queue
@@ -1188,68 +1132,14 @@ private struct EngineImpl: ~Copyable {
         let logitsShape = [1, queryLength, vocabSize]
         let logitsStrides = try resolvedStrides(descriptor: logitsBaseDesc, shape: logitsShape)
 
-        switch additionalStates?.stateCount ?? 0 {
-        case 1:
-            let extra0 = additionalStates![stateIndex: 0]
-            var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra0.buffer, byteOffset: 0,
-                scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            asyncStates.insert(&extraState0, for: extra0.name)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        case 2:
-            let extra0 = additionalStates![stateIndex: 0]
-            let extra1 = additionalStates![stateIndex: 1]
-            var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra0.buffer, byteOffset: 0,
-                scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-            var extraState1 = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: extra1.buffer, byteOffset: 0,
-                scalarType: extra1.scalarType, shape: extra1.shape, strides: extra1.strides)
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            asyncStates.insert(&extraState0, for: extra0.name)
-            asyncStates.insert(&extraState1, for: extra1.name)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        default:
-            var asyncStates = InferenceFunction.AsyncMutableViews()
-            asyncStates.insert(&keyState, for: keyCacheName)
-            asyncStates.insert(&valState, for: valueCacheName)
-            var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                scalarType: .float16, shape: logitsShape, strides: logitsStrides)
-            var asyncOutputs = InferenceFunction.AsyncMutableViews()
-            asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-            let _ = try function.encode(
-                inputs: asyncInputs,
-                states: consume asyncStates,
-                outputViews: consume asyncOutputs,
-                to: computeStream
-            )
-        }
+        try encodeWithStates(
+            function: function, inputs: asyncInputs,
+            keyState: &keyState, keyCacheName: keyCacheName,
+            valState: &valState, valueCacheName: valueCacheName,
+            additionalStates: additionalStates,
+            logitsBuffer: logits.metalBuffer, logitsName: logitsOutputName,
+            logitsShape: logitsShape, logitsStrides: logitsStrides,
+            computeStream: computeStream)
 
         processedTokenCount += queryLength
         step += 1
@@ -1341,68 +1231,14 @@ private struct EngineImpl: ~Copyable {
             let lShape = [1, shape, vocabSize]
             let lStrides = try resolvedStrides(descriptor: logitsBaseDesc, shape: lShape)
 
-            switch additionalStates?.stateCount ?? 0 {
-            case 1:
-                let extra0 = additionalStates![stateIndex: 0]
-                var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: extra0.buffer, byteOffset: 0,
-                    scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-                var asyncStates = InferenceFunction.AsyncMutableViews()
-                asyncStates.insert(&keyState, for: keyCacheName)
-                asyncStates.insert(&valState, for: valueCacheName)
-                asyncStates.insert(&extraState0, for: extra0.name)
-                var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                    scalarType: .float16, shape: lShape, strides: lStrides)
-                var asyncOutputs = InferenceFunction.AsyncMutableViews()
-                asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-                let _ = try function.encode(
-                    inputs: asyncInputs,
-                    states: consume asyncStates,
-                    outputViews: consume asyncOutputs,
-                    to: computeStream
-                )
-            case 2:
-                let extra0 = additionalStates![stateIndex: 0]
-                let extra1 = additionalStates![stateIndex: 1]
-                var extraState0 = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: extra0.buffer, byteOffset: 0,
-                    scalarType: extra0.scalarType, shape: extra0.shape, strides: extra0.strides)
-                var extraState1 = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: extra1.buffer, byteOffset: 0,
-                    scalarType: extra1.scalarType, shape: extra1.shape, strides: extra1.strides)
-                var asyncStates = InferenceFunction.AsyncMutableViews()
-                asyncStates.insert(&keyState, for: keyCacheName)
-                asyncStates.insert(&valState, for: valueCacheName)
-                asyncStates.insert(&extraState0, for: extra0.name)
-                asyncStates.insert(&extraState1, for: extra1.name)
-                var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                    scalarType: .float16, shape: lShape, strides: lStrides)
-                var asyncOutputs = InferenceFunction.AsyncMutableViews()
-                asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-                let _ = try function.encode(
-                    inputs: asyncInputs,
-                    states: consume asyncStates,
-                    outputViews: consume asyncOutputs,
-                    to: computeStream
-                )
-            default:
-                var asyncStates = InferenceFunction.AsyncMutableViews()
-                asyncStates.insert(&keyState, for: keyCacheName)
-                asyncStates.insert(&valState, for: valueCacheName)
-                var logitsOutput = unsafe InferenceFunction.AsyncMutableValue(
-                    unsafeBuffer: logits.metalBuffer, byteOffset: 0,
-                    scalarType: .float16, shape: lShape, strides: lStrides)
-                var asyncOutputs = InferenceFunction.AsyncMutableViews()
-                asyncOutputs.insert(&logitsOutput, for: logitsOutputName)
-                let _ = try function.encode(
-                    inputs: asyncInputs,
-                    states: consume asyncStates,
-                    outputViews: consume asyncOutputs,
-                    to: computeStream
-                )
-            }
+            try encodeWithStates(
+                function: function, inputs: asyncInputs,
+                keyState: &keyState, keyCacheName: keyCacheName,
+                valState: &valState, valueCacheName: valueCacheName,
+                additionalStates: additionalStates,
+                logitsBuffer: logits.metalBuffer, logitsName: logitsOutputName,
+                logitsShape: lShape, logitsStrides: lStrides,
+                computeStream: computeStream)
 
             // Warm up argmax kernel using pipeline-matched decode buffers
             let warmupLogitsBuffer = decodeLogitsBuffers[step % pipelineDepth]

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAISequentialEngine.swift
@@ -256,61 +256,15 @@ public final class CoreAISequentialEngine: InferenceEngine, @unchecked Sendable 
             cachedLogitsBatchSize = batchSize
         }
 
-        // Build output backings (logits — written in-place)
-        var outputViews = InferenceFunction.MutableViews()
-        outputViews.insert(&logitsArray, for: logitsName)
-
-        // Build states and execute. MutableViews lifetime requires explicit local
-        // bindings — see StateHandler.swift for why this can't be abstracted.
-        var kv0 = kvCache[stateIndex: 0]
-        var kv1 = kvCache[stateIndex: 1]
-        if var handler = additionalStates {
-            switch handler.stateCount {
-            case 1:
-                var s0 = handler[stateIndex: 0]
-                var states = InferenceFunction.MutableViews()
-                states.insert(&kv0.array, for: kv0.name)
-                states.insert(&kv1.array, for: kv1.name)
-                states.insert(&s0.array, for: s0.name)
-                _ = try await function.run(
-                    inputs: [inputIdsName: inputIdsArray, positionIdsName: positionIds],
-                    states: consume states,
-                    outputViews: consume outputViews
-                )
-                handler[stateIndex: 0] = s0
-            case 2:
-                var s0 = handler[stateIndex: 0]
-                var s1 = handler[stateIndex: 1]
-                var states = InferenceFunction.MutableViews()
-                states.insert(&kv0.array, for: kv0.name)
-                states.insert(&kv1.array, for: kv1.name)
-                states.insert(&s0.array, for: s0.name)
-                states.insert(&s1.array, for: s1.name)
-                _ = try await function.run(
-                    inputs: [inputIdsName: inputIdsArray, positionIdsName: positionIds],
-                    states: consume states,
-                    outputViews: consume outputViews
-                )
-                handler[stateIndex: 0] = s0
-                handler[stateIndex: 1] = s1
-            default:
-                preconditionFailure(
-                    "Unsupported additional state count \(handler.stateCount). "
-                        + "Add a new case to handle \(handler.stateCount) states.")
-            }
-            additionalStates = handler
-        } else {
-            var states = InferenceFunction.MutableViews()
-            states.insert(&kv0.array, for: kv0.name)
-            states.insert(&kv1.array, for: kv1.name)
-            _ = try await function.run(
-                inputs: [inputIdsName: inputIdsArray, positionIdsName: positionIds],
-                states: consume states,
-                outputViews: consume outputViews
-            )
-        }
-        kvCache[stateIndex: 0] = kv0
-        kvCache[stateIndex: 1] = kv1
+        // Bind states, build output views, and execute
+        try await runWithStates(
+            function: function,
+            inputs: [inputIdsName: inputIdsArray, positionIdsName: positionIds],
+            primary: kvCache,
+            secondary: additionalStates,
+            outputArray: &logitsArray,
+            outputName: logitsName
+        )
 
         // Read logits from NDArray
         let totalLogits = batchSize * config.vocabSize

--- a/swift/Tests/LanguageModelsTests/StateHandlerTests.swift
+++ b/swift/Tests/LanguageModelsTests/StateHandlerTests.swift
@@ -88,3 +88,75 @@ struct StateHandlerConformanceTests {
         let _: any SyncStateHandler.Type = FixedNDArrayState.self
     }
 }
+
+// MARK: - withBoundStates Tests
+
+/// Minimal state handler for testing the binding API.
+final class MockStateHandler: SyncStateHandler {
+    var stateNames: [String]
+    var stateCount: Int { arrays.count }
+    let currentCapacity: Int = .max
+    let supportsTruncation: Bool = false
+
+    private var arrays: [String: NDArray]
+
+    init(names: [String], shape: [Int], scalarType: NDArray.ScalarType = .float16) {
+        self.stateNames = names
+        self.arrays = Dictionary(
+            uniqueKeysWithValues: names.map { ($0, NDArray(shape: shape, scalarType: scalarType)) })
+    }
+
+    func ensureCapacity(forContextLength contextLength: Int) throws -> Bool { false }
+
+    subscript(stateIndex index: Int) -> (name: String, array: NDArray) {
+        get { (stateNames[index], arrays[stateNames[index]]!) }
+        set { arrays[stateNames[index]] = newValue.array }
+    }
+
+    @_lifetime(views: borrow self)
+    func bind(into views: inout InferenceFunction.MutableViews) {
+        for name in stateNames {
+            let view = _overrideLifetime(arrays[name]!.mutableRawView(), borrowing: Void())
+            views.insert(view, for: name)
+        }
+    }
+
+    func reset() {}
+    func truncate(to tokenCount: Int) {}
+}
+
+@Suite("bind(into:) Tests")
+struct BindTests {
+    @Test("binds 1 through 4 states into MutableViews")
+    func bindsVariousCounts() {
+        for count in 1...4 {
+            let names = (0..<count).map { "state_\($0)" }
+            let handler = MockStateHandler(names: names, shape: [1, 4])
+            var views = InferenceFunction.MutableViews()
+            handler.bind(into: &views)
+        }
+    }
+
+    @Test("preserves state data through bind")
+    func preservesData() {
+        let handler = MockStateHandler(names: ["s0"], shape: [1, 4], scalarType: .float32)
+        var state = handler[stateIndex: 0]
+        fillNDArray(&state.array, as: Float.self, count: 4) { Float($0 + 1) }
+        handler[stateIndex: 0] = state
+
+        var views = InferenceFunction.MutableViews()
+        handler.bind(into: &views)
+
+        let values = readNDArray(handler[stateIndex: 0].array, as: Float.self, count: 4)
+        #expect(values == [1.0, 2.0, 3.0, 4.0])
+    }
+
+    @Test("multiple handlers compose into single MutableViews")
+    func composesHandlers() {
+        let primary = MockStateHandler(names: ["kv0", "kv1"], shape: [1, 4])
+        let secondary = MockStateHandler(names: ["conv"], shape: [1, 4])
+        var views = InferenceFunction.MutableViews()
+        primary.bind(into: &views)
+        secondary.bind(into: &views)
+    }
+}


### PR DESCRIPTION
State handlers are now classes that own their NDArrays at refcount 1.

`bind(into:)` inserts all states into `MutableViews` in a loop using stdlib `_overrideLifetime` to express disjoint
element access. Same pattern for `AsyncMutableViews` on the pipelined engine's `FixedMTLBufferState`.

## Changes

- `SyncStateHandler` protocol: add `bind(into:)`, constrain to `AnyObject`
- `FixedNDArrayState`, `GrowingNDArrayState`: struct → class, dictionary-backed
- `FixedMTLBufferState`: struct → class, add `bind(into:)` for `AsyncMutableViews`
- `runWithStates()`: sequential engine helper
- `encodeWithStates()`: pipelined engine helper
- Sequential engine: replace inline state binding with `runWithStates()`
- Pipelined engine: replace 3 inline state binding blocks with `encodeWithStates()`

Requires `Lifetimes` experimental Swift feature.
Tested with 2 state and 4 state hybrid models.