### PR TITLE
State handling for static-shape inference engine

### DIFF
--- a/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
@@ -18,6 +18,9 @@ public struct InputContext: Sendable {
     public let batchSize: Int
     /// Sliding window size (nil for models without sliding attention).
     public let slidingWindow: Int?
+    /// The active graph's input descriptors, keyed by input name. Lets a handler size its
+    /// own output buffer to the running bucket. Empty for engines that don't vary by bucket.
+    public let descriptors: [String: NDArrayDescriptor]
 
     /// For dynamic-shape engines (Sequential, Pipelined).
     /// alignedStep = processedTokenCount, batchSize = tokens.count.
@@ -30,7 +33,8 @@ public struct InputContext: Sendable {
             processedTokenCount: processedTokenCount,
             alignedStep: processedTokenCount,
             batchSize: tokens.count,
-            slidingWindow: nil)
+            slidingWindow: nil,
+            descriptors: [:])
     }
 
     /// For static-shape engines. Batch is fixed-size and aligned.
@@ -38,14 +42,16 @@ public struct InputContext: Sendable {
         tokens: ArraySlice<Int32>,
         alignedStep: Int,
         batchSize: Int,
-        slidingWindow: Int?
+        slidingWindow: Int?,
+        descriptors: [String: NDArrayDescriptor] = [:]
     ) -> InputContext {
         InputContext(
             tokens: tokens,
             processedTokenCount: alignedStep,
             alignedStep: alignedStep,
             batchSize: batchSize,
-            slidingWindow: slidingWindow)
+            slidingWindow: slidingWindow,
+            descriptors: descriptors)
     }
 }
 

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -41,9 +41,34 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     // Largest query length across all extend functions — used as prefill threshold.
     private let maxQueryLength: Int
 
-    // Fixed size caches shared across all decoding functions.
-    private var keyCache: NDArray
-    private var valueCache: NDArray
+    // Generic persistent state (KV + any hybrid/sliding states), discovered by name from the
+    // descriptor and zero-initialized. No hardcoded KV contract, no per-model state properties.
+    //
+    // Each static graph is compiled with its own per-ctx sequence strides, so a state buffer
+    // MUST be physically laid out for the exact bucket the running graph expects — a max-ctx
+    // allocation viewed through a slice hands the smaller-bucket graph the wrong stride and
+    // corrupts the cache. We therefore RIGHT-SIZE the ctx-scaled states (e.g. the global KV
+    // cache) to the running bucket and grow+re-lay-out on a bucket crossing (`ensureStateCtx`).
+    // States whose descriptor is constant across buckets (e.g. a fixed sliding-window ring)
+    // are allocated once and never re-laid-out.
+    private var stateHandler: FixedNDArrayState
+    private let stateNames: [String]
+    // ctx bucket -> that bucket's (name, descriptor) list, for re-allocation on crossing.
+    private let stateDescriptorsByCtx: [Int: [(name: String, descriptor: NDArrayDescriptor)]]
+    // States whose sequence extent scales with the ctx bucket (must be re-laid-out on grow).
+    private let ctxScaledStateNames: Set<String>
+    // The ctx bucket the state buffers are currently laid out for.
+    private var currentStateCtx: Int
+    // Sorted ascending ctx buckets available in the model.
+    private let stateCtxLadder: [Int]
+
+    // Model-specific input preparation (embedding gather, position ids, causal mask, step, and
+    // profile extras like PLE / dual-RoPE / sliding-ring). The engine never learns an input name.
+    private let providers: [any SyncInputHandler]
+    private let profileName: String
+
+    // Bundle location (for the model profile to find sidecar resources, e.g. the PLE table).
+    private let bundleURL: URL
 
     // Number of tokens already processed in the current sequence.
     public private(set) var processedTokenCount: Int = 0
@@ -64,10 +89,11 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
 
     // MARK: - Initialization
 
-    public init(configuration: ModelConfig, preparedModel: PreparedModel) async throws {
+    public init(configuration: ModelConfig, preparedModel: PreparedModel, bundleURL: URL) async throws {
         self.config = configuration
         self.model = preparedModel.model
         self.functions = [:]
+        self.bundleURL = bundleURL
 
         let allNames = model.functionNames
         CLILogger.log("Model loaded: \(allNames.count) functions: \(allNames.sorted())")
@@ -94,7 +120,10 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         var largestContextExtend: (name: String, descriptor: InferenceFunctionDescriptor)?
         for name in extendFunctionNames {
             let desc = try Self.requireDescriptor(model: model, functionName: name)
-            if Self.contextLength(descriptor: desc, config: configuration) == configuration.maxContextLength {
+            let ctx =
+                Self.parseContextLength(functionName: name)
+                ?? Self.contextLength(descriptor: desc, config: configuration)
+            if ctx == configuration.maxContextLength {
                 largestContextExtend = (name, desc)
                 break
             }
@@ -104,32 +133,174 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
                 "Failed to find an extend function with the max context length of \(configuration.maxContextLength)")
         }
 
-        // Validate output/state contract against the max-context function
+        // Validate output contract against the max-context function
         try Self.validateIOContract(descriptor: largestExtendDescriptor, functionName: largestExtendName)
 
         // Load embeddings
         self.embeddingTable = try await Self.loadEmbeddingTable(from: model)
 
-        // Allocate KV cache IOSurfaces sized to the max-context descriptor
-        if case .ndArray(let keyCacheDescriptor) = largestExtendDescriptor.stateDescriptor(of: Self.keyCacheName),
-            case .ndArray(let valueCacheDescriptor) = largestExtendDescriptor.stateDescriptor(of: Self.valueCacheName)
-        {
-            self.keyCache = NDArray(descriptor: keyCacheDescriptor)
-            self.valueCache = NDArray(descriptor: valueCacheDescriptor)
-            CLILogger.log(
-                "KV cache allocated: key \(keyCacheDescriptor.minimumByteCount) bytes, value \(valueCacheDescriptor.minimumByteCount) bytes (IOSurface)"
-            )
-        } else {
-            throw InferenceRuntimeError.invalidState(
-                "No KV cache state descriptors found — cannot allocate cache buffers")
+        // Build the per-ctx-bucket state descriptor table. Each extend bucket declares the
+        // same state NAMES but with its own physical shape/strides; we allocate against the
+        // exact bucket the running graph uses (see the field docs above).
+        var descriptorsByCtx: [Int: [(name: String, descriptor: NDArrayDescriptor)]] = [:]
+        for name in extendFunctionNames where name.hasPrefix("extend") {
+            let desc = try Self.requireDescriptor(model: model, functionName: name)
+            let ctx =
+                Self.parseContextLength(functionName: name)
+                ?? Self.contextLength(descriptor: desc, config: configuration)
+            guard descriptorsByCtx[ctx] == nil else { continue }
+            var descs: [(name: String, descriptor: NDArrayDescriptor)] = []
+            for stateName in desc.stateNames {
+                guard case .ndArray(let d) = desc.stateDescriptor(of: stateName) else {
+                    throw InferenceRuntimeError.invalidState(
+                        "State '\(stateName)' has no NDArray descriptor")
+                }
+                descs.append((stateName, d))
+            }
+            descriptorsByCtx[ctx] = descs
         }
+        guard !descriptorsByCtx.isEmpty else {
+            throw InferenceRuntimeError.invalidState("No extend function to size the state caches from")
+        }
+        let ctxLadder = descriptorsByCtx.keys.sorted()
+        self.stateCtxLadder = ctxLadder
+        self.stateDescriptorsByCtx = descriptorsByCtx
 
-        CLILogger.log("Engine initialized")
+        // Classify each state as ctx-scaled (its sequence extent changes across buckets → must
+        // be re-laid-out on a bucket crossing) or fixed (constant across buckets → allocated
+        // once). Derived by comparing the smallest and largest bucket's descriptor for each state.
+        let smallestCtx = ctxLadder.first!
+        let largestCtx = ctxLadder.last!
+        var ctxScaled: Set<String> = []
+        let smallDescs = descriptorsByCtx[smallestCtx]!
+        let largeDescs = Dictionary(
+            uniqueKeysWithValues: descriptorsByCtx[largestCtx]!.map { ($0.name, $0.descriptor) })
+        for (name, smallDesc) in smallDescs {
+            if let largeDesc = largeDescs[name], largeDesc.shape != smallDesc.shape {
+                ctxScaled.insert(name)
+            }
+        }
+        self.ctxScaledStateNames = ctxScaled
+
+        // Allocate at the smallest bucket; ctx-scaled states grow on demand via ensureStateCtx.
+        self.stateHandler = FixedNDArrayState(states: smallDescs)
+        self.stateNames = smallDescs.map(\.name)
+        self.currentStateCtx = smallestCtx
+        CLILogger.log(
+            "States allocated at ctx=\(smallestCtx): \(stateNames) "
+                + "(ctx-scaled: \(ctxScaled.sorted()))")
+
+        // Assemble input providers (base + model profile) and verify — at load — that every
+        // declared graph input is produced by some provider. Fail closed on any gap.
+        let (providers, profileName) = try StaticModelProfile.assembleInputHandlers(
+            descriptor: largestExtendDescriptor, bundleURL: bundleURL)
+        self.providers = providers
+        self.profileName = profileName
+
+        try Self.checkInputCoverage(
+            providers: providers, model: model, extendFunctionNames: extendFunctionNames)
+
+        CLILogger.log("Engine initialized (profile: \(profileName), \(providers.count) input providers)")
+    }
+
+    /// Ensure the ctx-scaled state buffers are physically laid out for context bucket `ctx`,
+    /// growing + re-laying-out the written prefix when a decode step crosses into a larger
+    /// bucket. Fixed states (constant descriptor across buckets, e.g. a sliding-window ring)
+    /// are carried over verbatim. No-op when already laid out for `ctx`.
+    private func ensureStateCtx(_ ctx: Int) throws {
+        guard ctx != currentStateCtx, ctxScaledStateNames.isEmpty == false else { return }
+        guard let targetDescs = stateDescriptorsByCtx[ctx] else {
+            throw InferenceRuntimeError.invalidState(
+                "No state descriptors for ctx bucket \(ctx) (ladder: \(stateCtxLadder))")
+        }
+        let old = stateHandler
+        var new = FixedNDArrayState(states: targetDescs)
+        let copyPositions = min(processedTokenCount, currentStateCtx)
+        for i in stateNames.indices {
+            let name = stateNames[i]
+            var dst = new[stateIndex: i]
+            let src = old[stateIndex: i]
+            if ctxScaledStateNames.contains(name) {
+                // Grow: copy the written sequence prefix into the larger layout.
+                Self.copyStatePrefix(from: src.array, to: &dst.array, copyPositions: copyPositions)
+            } else {
+                // Fixed: identical shape across buckets — carry the whole buffer over.
+                Self.copyStatePrefix(from: src.array, to: &dst.array, copyPositions: nil)
+            }
+            new[stateIndex: i] = dst
+        }
+        stateHandler = new
+        currentStateCtx = ctx
+        CLILogger.log("State caches re-laid-out: ctx \(currentStateCtx) → \(ctx) (copied \(copyPositions) positions)")
+    }
+
+    /// Copy a state buffer's written sequence prefix from `src` into the (larger) `dst` layout.
+    /// The sequence dim is the last dim; `copyPositions == nil` copies the whole buffer (fixed
+    /// states, identical shape). Honors the cache's channel-interleave: physically the layout is
+    /// `[groups, ctx, factor]`, so positions `[0, copyLen)` across the `factor` interleaved
+    /// channels form one contiguous `copyLen·factor` run per group. src and dst share group order
+    /// + interleave, differing only in ctx — so a per-group run copy is correct.
+    private static func copyStatePrefix(from src: NDArray, to dst: inout NDArray, copyPositions: Int?) {
+        let srcShape = src.shape
+        guard srcShape.isEmpty == false else { return }
+        let dstShape = dst.shape
+        let seqDim = srcShape.count - 1
+        let srcSeq = srcShape[seqDim]
+        let dstSeq = dstShape[seqDim]
+        let factor = src.interleaveLayout?.factor ?? 1
+        let copySeq = min(copyPositions ?? srcSeq, min(srcSeq, dstSeq))
+        guard copySeq > 0 else { return }
+        let groupCount = srcShape.reduce(1, *) / srcSeq / factor
+        let srcGroupStride = srcSeq * factor
+        let dstGroupStride = dstSeq * factor
+        let runElems = copySeq * factor
+
+        func run<T: BitwiseCopyable>(_ type: T.Type) {
+            let srcView = src.view(as: T.self)
+            var dstView = dst.mutableView(as: T.self)
+            dstView.withUnsafeMutablePointer { dstPtr, _, _ in
+                srcView.withUnsafePointer { srcPtr, _, _ in
+                    for g in 0..<groupCount {
+                        dstPtr.advanced(by: g &* dstGroupStride).update(
+                            from: srcPtr.advanced(by: g &* srcGroupStride), count: runElems)
+                    }
+                }
+            }
+        }
+        switch src.scalarType {
+        case .float16, .bfloat16: run(Float16.self)
+        case .float32: run(Float.self)
+        case .int8: run(Int8.self)
+        default: run(Float16.self)
+        }
+    }
+
+    /// Every input any extend/prompt graph declares must be produced by exactly one handler,
+    /// except `transformer_input` / `embedding_table`, which the engine produces directly.
+    private static func checkInputCoverage(
+        providers: [any SyncInputHandler], model: AIModel, extendFunctionNames: [String]
+    ) throws {
+        var declared = Set<String>()
+        for name in extendFunctionNames {
+            if let desc = model.functionDescriptor(for: name) {
+                declared.formUnion(desc.inputNames)
+            }
+        }
+        // Engine-produced inputs (embedding gather needs the model's gather graph).
+        let engineProduced = declared.filter { $0.contains("transformer_input") || $0 == "embedding_table" }
+        var produced = providers.reduce(into: Set<String>()) { $0.formUnion($1.inputNames) }
+        produced.formUnion(engineProduced)
+        let uncovered = declared.subtracting(produced)
+        guard uncovered.isEmpty else {
+            throw InferenceRuntimeError.invalidState(
+                "No input handler produces required input(s): \(uncovered.sorted()). "
+                    + "Add them to the model profile (StaticModelProfile.resolve).")
+        }
     }
 
     public convenience init(configuration: ModelConfig, modelURL: URL) async throws {
         let preparedModel = try await PreparedModel.prepare(at: modelURL)
-        try await self.init(configuration: configuration, preparedModel: preparedModel)
+        try await self.init(configuration: configuration, preparedModel: preparedModel, bundleURL: modelURL)
     }
 
     // MARK: - Initialization Helpers
@@ -160,20 +331,8 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
                 "Function '\(functionName)' missing required output '\(logitsOutputName)'. "
                     + "Available outputs: \(descriptor.outputNames)")
         }
-        if descriptor.stateNames.count == 1 {
-            throw InferenceRuntimeError.invalidState(
-                "Function '\(functionName)' has exactly 1 state (\(descriptor.stateNames)) "
-                    + "— expected 0 (internal to model) or 2 (\(keyCacheName), \(valueCacheName))")
-        }
-        if descriptor.stateNames.count >= 2 {
-            guard descriptor.stateNames.contains(keyCacheName),
-                descriptor.stateNames.contains(valueCacheName)
-            else {
-                throw InferenceRuntimeError.invalidState(
-                    "Function '\(functionName)' has states \(descriptor.stateNames) "
-                        + "but missing required '\(keyCacheName)' and/or '\(valueCacheName)'")
-            }
-        }
+        // States are discovered + allocated generically (FixedNDArrayState) and their inputs
+        // covered by the provider registry — no hardcoded KV-only state contract here.
     }
 
     private static func loadEmbeddingTable(from model: AIModel) async throws -> NDArray {
@@ -238,6 +397,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     /// Returns the context length for a given function by reading the
     /// key_cache state descriptor.
     private func contextLength(of functionName: String) throws -> Int {
+        if let ctx = Self.parseContextLength(functionName: functionName) { return ctx }
         let desc = try functionDescriptor(for: functionName)
         return Self.contextLength(descriptor: desc, config: config)
     }
@@ -245,10 +405,21 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     private static func contextLength(
         model: AIModel, functionName: String, config: ModelConfig
     ) throws -> Int {
+        if let ctx = parseContextLength(functionName: functionName) { return ctx }
         guard let desc = model.functionDescriptor(for: functionName) else {
             return config.maxContextLength
         }
         return contextLength(descriptor: desc, config: config)
+    }
+
+    /// Parse the ctx bucket from a `<prefix>_<ctx>_<q>` function name (e.g. `extend_256_16`
+    /// → 256, `prompt_opt_1024_64` → 1024): the ctx is the second-to-last `_`-component.
+    /// Authoritative over the descriptor heuristic, whose `shape.max()` can exceed the ctx
+    /// when a non-seq dim is larger than a small bucket (e.g. qwen3 `[.,1024,.,256]` @ ctx 256).
+    static func parseContextLength(functionName: String) -> Int? {
+        let parts = functionName.split(separator: "_")
+        guard parts.count >= 2, let ctx = Int(parts[parts.count - 2]) else { return nil }
+        return ctx
     }
 
     private static func contextLength(
@@ -266,63 +437,29 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     // MARK: - Graph Selection
 
     private func forwardGraph(numInputTokens: Int, currentPosition: Int, isPrefill: Bool) throws -> String {
-        var pairs: [(contextLength: Int, queryLength: Int)] = []
-        for name in extendFunctionNames {
-            let parts = Array(name.split(separator: "_").suffix(2))
-            guard parts.count == 2, let maxCtx = Int(parts[0]), let seqLen = Int(parts[1]) else { continue }
-            pairs.append((maxCtx, seqLen))
-        }
-
-        let sorted = pairs.sorted { $0.queryLength < $1.queryLength }
-        guard let maxPair = sorted.last else {
-            throw InferenceRuntimeError.invalidState(
-                "No extend functions found in static-shape engine")
-        }
-        let selectedSeq =
-            sorted.first(where: { $0.queryLength >= numInputTokens })?.queryLength
-            ?? maxPair.queryLength
-        let candidates = pairs.filter { $0.queryLength == selectedSeq }
-
-        guard
-            let selected =
-                candidates
-                .sorted(by: { $0.contextLength < $1.contextLength })
-                .first(where: { $0.contextLength > currentPosition })
-        else {
-            throw InferenceRuntimeError.invalidState(
-                "No graph with cache_len > \(currentPosition) and seq_len = \(selectedSeq)")
-        }
-        return isPrefill
-            ? "prompt_opt_\(selected.contextLength)_\(selected.queryLength)"
-            : "extend_\(selected.contextLength)_\(selected.queryLength)"
-    }
-
-    // MARK: - Causal Mask
-
-    private static func fillCausalMask(
-        _ view: consuming NDArray.MutableView<LogitsScalarType>,
-        tokensInBatch: Int,
-        alignedStep: Int
-    ) {
-        view.withUnsafeMutablePointer { ptr, shape, strides in
-            // Stride-aware indexing for non-contiguous strides
-            for context in 0..<shape[1] {
-                for query in 0..<shape[3] {
-                    let offset = context &* strides[1] &+ query &* strides[3]
-                    ptr[offset] = LogitsScalarType(-40000.0)
-                }
-            }
-
-            // Unmask positions where attention is allowed
-            for query in 0..<tokensInBatch {
-                let queryPos = alignedStep + query
-                let upperBound = min(queryPos, shape[1] &- 1)
-                for context in 0...upperBound {
-                    let offset = context &* strides[1] &+ query &* strides[3]
-                    ptr[offset] = 0
-                }
+        func pairs(prefix: String) -> [(ctx: Int, q: Int, name: String)] {
+            extendFunctionNames.filter { $0.hasPrefix(prefix) }.compactMap { name in
+                let parts = Array(name.split(separator: "_").suffix(2))
+                guard parts.count == 2, let c = Int(parts[0]), let q = Int(parts[1]) else { return nil }
+                return (c, q, name)
             }
         }
+        var candidatesAll = pairs(prefix: isPrefill ? "prompt" : "extend")
+        if candidatesAll.isEmpty { candidatesAll = pairs(prefix: isPrefill ? "extend" : "prompt") }
+        guard !candidatesAll.isEmpty else {
+            throw InferenceRuntimeError.invalidState("No extend/prompt functions in static-shape model")
+        }
+
+        // Smallest q >= numInputTokens (clamp to the largest available q).
+        let qs = Set(candidatesAll.map(\.q)).sorted()
+        let selectedQ = qs.first(where: { $0 >= numInputTokens }) ?? qs.last!
+        // Among that q, the smallest ctx strictly greater than currentPosition (clamp to largest).
+        let candidates = candidatesAll.filter { $0.q == selectedQ }.sorted { $0.ctx < $1.ctx }
+        guard let selected = candidates.first(where: { $0.ctx > currentPosition }) ?? candidates.last else {
+            throw InferenceRuntimeError.invalidState(
+                "No graph with ctx > \(currentPosition) and q = \(selectedQ)")
+        }
+        return selected.name
     }
 
     // MARK: - Generate (primary API)
@@ -380,6 +517,10 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         var logitBuffer = [LogitsScalarType](repeating: 0, count: config.vocabSize)
         var currentPosition = processedTokenCount
 
+        if processedTokenCount == 0 {
+            stateHandler.reset()
+        }
+
         while currentPosition < totalTokenCount {
             let remaining = totalTokenCount - currentPosition
             let usePrefill = remaining > maxQueryLength
@@ -393,41 +534,60 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
 
             CLILogger.log("Graph: \(graphName), batch=\(batchSize), step=\(batchStartToken), tokens=\(tokensInBatch)")
 
+            let fn = try loadFunction(named: graphName)
+            let desc = try functionDescriptor(for: graphName)
+            let graphInputs = Set(desc.inputNames)
+
             let prepareSpan = InstrumentsProfiler.beginPrepareStep(
-                operation: "buildInputs", engine: "StaticShape")
-            let inputs = try await buildInputs(
-                graphName: graphName,
-                batchTokens: inputTokens[batchStartToken...batchEndToken],
-                batchSize: batchSize,
+                operation: "providers", engine: "StaticShape")
+            // Build the shared per-step context: the running graph's input descriptors let
+            // each handler size its own buffer to this bucket.
+            var descriptors: [String: NDArrayDescriptor] = [:]
+            for name in desc.inputNames {
+                if case .ndArray(let d) = desc.inputDescriptor(of: name) { descriptors[name] = d }
+            }
+            let ctx = InputContext(
+                tokens: inputTokens[batchStartToken...batchEndToken],
+                processedTokenCount: currentPosition,
                 alignedStep: batchStartToken,
-                tokensInBatch: tokensInBatch
-            )
+                batchSize: batchSize,
+                slidingWindow: nil,
+                descriptors: descriptors)
+
+            var inputs: [String: NDArray] = [:]
+            // Embedding gather is engine-produced (needs the model's gather graph).
+            if let txName = desc.inputNames.first(where: { $0.contains("transformer_input") }) {
+                if graphInputs.contains("embedding_table") { inputs["embedding_table"] = embeddingTable }
+                guard let gathered = try await runGather(tokenIDs: Array(ctx.tokens), batchSize: batchSize) else {
+                    throw InferenceRuntimeError.invalidState(
+                        "Embedding gather returned no output for batch \(batchSize)")
+                }
+                inputs[txName] = gathered
+            }
+            // Remaining inputs via the shared SyncInputHandler registry.
+            for var provider in providers where provider.inputNames.contains(where: graphInputs.contains) {
+                let produced = try await provider.prepare(ctx)
+                for (name, value) in produced where graphInputs.contains(name) {
+                    inputs[name] = value
+                }
+            }
             prepareSpan.end()
 
             let logitsSpan = InstrumentsProfiler.beginLogitsInference(
                 step: batchStartToken, tokens: tokensInBatch, engine: "StaticShape")
 
-            let fn = try loadFunction(named: graphName)
-            let desc = try functionDescriptor(for: graphName)
-
-            guard case .ndArray(let keyCacheDescriptor) = desc.stateDescriptor(of: Self.keyCacheName),
-                case .ndArray(let valueCacheDescriptor) = desc.stateDescriptor(of: Self.valueCacheName)
-            else {
-                throw InferenceRuntimeError.invalidState("Missing KV cache state descriptors for '\(graphName)'")
-            }
-
-            // Create MutableRawView using this function's descriptor for shape metadata.
-            // No copy is needed on graph switch because all extend functions share the
-            // same KV cache shape, strides, and interleaveLayout
-            let keyCacheView = keyCache.mutableRawView().slice(at: keyCacheDescriptor.shape.map { 0..<$0 })
-            let valueCacheView = valueCache.mutableRawView().slice(at: valueCacheDescriptor.shape.map { 0..<$0 })
-
+            // Right-size the state caches to this graph's ctx bucket, then bind full buffers
+            // by name. Because the buffers are laid out for the exact running bucket, no
+            // slicing is needed — the graph's compiled per-ctx strides match the allocation.
+            try ensureStateCtx((try? contextLength(of: graphName)) ?? currentStateCtx)
+            // Local ref binding so the borrow spans the run() call (bind ties `states`'
+            // lifetime to the handler; a stored-property borrow would end at the call).
+            let handler = stateHandler
             var states = InferenceFunction.MutableViews()
-            states.insert(keyCacheView, for: Self.keyCacheName)
-            states.insert(valueCacheView, for: Self.valueCacheName)
+            handler.bind(into: &states)
             var outputs = try await fn.run(
                 inputs: inputs,
-                states: consume states,
+                states: _unsafeEscapeMutableViews(consume states),
                 outputViews: InferenceFunction.MutableViews()
             )
 
@@ -461,73 +621,6 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
 
     // MARK: - Inference Helpers
 
-    private func buildInputs<Tokens: Collection<Int32>>(
-        graphName: String,
-        batchTokens: Tokens,
-        batchSize: Int,
-        alignedStep: Int,
-        tokensInBatch: Int
-    ) async throws -> [String: NDArray] {
-        let desc = try functionDescriptor(for: graphName)
-        var inputs = [String: NDArray]()
-
-        if desc.inputNames.contains("embedding_table") {
-            inputs["embedding_table"] = embeddingTable
-        }
-
-        // Gather embeddings for this batch's tokens
-        if let txName = desc.inputNames.first(where: { $0.contains("transformer_input") }) {
-            let gatherName = "gather_embeddings_\(batchSize)"
-            guard gatherFunctionNames.contains(gatherName) else {
-                throw InferenceRuntimeError.invalidState(
-                    "No gather function '\(gatherName)' for batch size \(batchSize)")
-            }
-            guard let gathered = try await runGather(tokenIDs: Array(batchTokens), batchSize: batchSize) else {
-                throw InferenceRuntimeError.invalidState("Gather '\(gatherName)' returned no output")
-            }
-            inputs[txName] = gathered
-        }
-
-        // Position IDs
-        guard let posName = desc.inputNames.first(where: { $0.contains("pos") }) else {
-            throw InferenceRuntimeError.invalidState("Graph '\(graphName)' has no position_ids input")
-        }
-        if case .ndArray(let nd) = desc.inputDescriptor(of: posName) {
-            var pos = NDArray(descriptor: nd)
-            let posView = pos.mutableView(as: UInt16.self)
-            guard var posSpan = posView.contiguousElements else {
-                throw InferenceRuntimeError.invalidState("pos array has non-contiguous layout")
-            }
-            for i in 0..<batchSize {
-                posSpan[i] = UInt16(alignedStep + i)
-            }
-            inputs[posName] = pos
-        }
-
-        // Causal mask
-        if case .ndArray(let nd) = desc.inputDescriptor(of: "causal_mask") {
-            var mask = NDArray(descriptor: nd)
-            let maskView = mask.mutableView(as: LogitsScalarType.self)
-            Self.fillCausalMask(maskView, tokensInBatch: tokensInBatch, alignedStep: alignedStep)
-            inputs["causal_mask"] = mask
-        }
-
-        // Step
-        if let stepName = desc.inputNames.first(where: { $0.contains("step") && !$0.contains("pos") }),
-            case .ndArray(let nd) = desc.inputDescriptor(of: stepName)
-        {
-            var step = NDArray(descriptor: nd)
-            let stepView = step.mutableView(as: Int32.self)
-            guard var stepSpan = stepView.contiguousElements else {
-                throw InferenceRuntimeError.invalidState("step array has non-contiguous layout")
-            }
-            stepSpan[0] = Int32(alignedStep)
-            inputs[stepName] = step
-        }
-
-        return inputs
-    }
-
     // MARK: - Gather Embeddings
 
     private func runGather(tokenIDs: [Int32], batchSize: Int) async throws -> NDArray? {
@@ -544,7 +637,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         }
 
         var tokenArray = NDArray(descriptor: tokenNDDesc)
-        let tokenView = tokenArray.mutableView(as: Int32.self)
+        var tokenView = tokenArray.mutableView(as: Int32.self)
         guard var tokenSpan = tokenView.contiguousElements else {
             throw InferenceRuntimeError.invalidState("tokenArray has non-contiguous layout")
         }
@@ -590,6 +683,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         if tokenIndex == 0 {
             processedTokenCount = 0
             history.clear()
+            stateHandler.reset()
         } else {
             processedTokenCount = tokenIndex
             history.truncate(to: tokenIndex)

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -19,6 +19,11 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     private static let logitsOutputName = "out_logits"
     private static let keyCacheName = "key_cache"
     private static let valueCacheName = "value_cache"
+    // Engine-produced I/O names (embedding gather needs the model's gather graph, so these
+    // aren't `SyncInputHandler`s). `transformerInputToken` is a substring: the declared name
+    // may be prefixed (e.g. `out_transformer_input`).
+    private static let embeddingTableName = "embedding_table"
+    private static let transformerInputToken = "transformer_input"
 
     public var vocabSize: Int { config.vocabSize }
 
@@ -59,8 +64,6 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     private let ctxScaledStateNames: Set<String>
     // The ctx bucket the state buffers are currently laid out for.
     private var currentStateCtx: Int
-    // Sorted ascending ctx buckets available in the model.
-    private let stateCtxLadder: [Int]
 
     // Model-specific input preparation (embedding gather, position ids, causal mask, step, and
     // profile extras like PLE / dual-RoPE / sliding-ring). The engine never learns an input name.
@@ -162,15 +165,13 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         guard !descriptorsByCtx.isEmpty else {
             throw InferenceRuntimeError.invalidState("No extend function to size the state caches from")
         }
-        let ctxLadder = descriptorsByCtx.keys.sorted()
-        self.stateCtxLadder = ctxLadder
         self.stateDescriptorsByCtx = descriptorsByCtx
 
         // Classify each state as ctx-scaled (its sequence extent changes across buckets → must
         // be re-laid-out on a bucket crossing) or fixed (constant across buckets → allocated
         // once). Derived by comparing the smallest and largest bucket's descriptor for each state.
-        let smallestCtx = ctxLadder.first!
-        let largestCtx = ctxLadder.last!
+        let smallestCtx = descriptorsByCtx.keys.min()!
+        let largestCtx = descriptorsByCtx.keys.max()!
         var ctxScaled: Set<String> = []
         let smallDescs = descriptorsByCtx[smallestCtx]!
         let largeDescs = Dictionary(
@@ -211,7 +212,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         guard ctx != currentStateCtx, ctxScaledStateNames.isEmpty == false else { return }
         guard let targetDescs = stateDescriptorsByCtx[ctx] else {
             throw InferenceRuntimeError.invalidState(
-                "No state descriptors for ctx bucket \(ctx) (ladder: \(stateCtxLadder))")
+                "No state descriptors for ctx bucket \(ctx) (ladder: \(stateDescriptorsByCtx.keys.sorted()))")
         }
         let old = stateHandler
         var new = FixedNDArrayState(states: targetDescs)
@@ -271,7 +272,10 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         case .float16, .bfloat16: run(Float16.self)
         case .float32: run(Float.self)
         case .int8: run(Int8.self)
-        default: run(Float16.self)
+        default:
+            preconditionFailure(
+                "State cache re-layout: unsupported scalar type \(src.scalarType). "
+                    + "KV caches are fp16/bf16/fp32/int8; add the type here if a new one is introduced.")
         }
     }
 
@@ -287,7 +291,9 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
             }
         }
         // Engine-produced inputs (embedding gather needs the model's gather graph).
-        let engineProduced = declared.filter { $0.contains("transformer_input") || $0 == "embedding_table" }
+        let engineProduced = declared.filter {
+            $0.contains(Self.transformerInputToken) || $0 == Self.embeddingTableName
+        }
         var produced = providers.reduce(into: Set<String>()) { $0.formUnion($1.inputNames) }
         produced.formUnion(engineProduced)
         let uncovered = declared.subtracting(produced)
@@ -341,7 +347,9 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
             throw InferenceRuntimeError.invalidState("Cannot load 'load_embeddings'")
         }
 
-        guard case .ndArray(let embeddingDesc) = embeddingFunction.descriptor.outputDescriptor(of: "embedding_table")
+        guard
+            case .ndArray(let embeddingDesc) = embeddingFunction.descriptor.outputDescriptor(
+                of: Self.embeddingTableName)
         else {
             throw InferenceRuntimeError.invalidState(
                 "load_embeddings has no 'embedding_table' ndArray output descriptor")
@@ -349,7 +357,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         var embeddingArray = NDArray(descriptor: embeddingDesc)
 
         var outputViews = InferenceFunction.MutableViews()
-        outputViews.insert(&embeddingArray, for: "embedding_table")
+        outputViews.insert(&embeddingArray, for: Self.embeddingTableName)
 
         _ = try await embeddingFunction.run(
             inputs: [:],
@@ -383,7 +391,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     /// `transformer_input` descriptor's sequence dimension.
     private func queryLength(of functionName: String) throws -> Int {
         let desc = try functionDescriptor(for: functionName)
-        if let txName = desc.inputNames.first(where: { $0.contains("transformer_input") }),
+        if let txName = desc.inputNames.first(where: { $0.contains(Self.transformerInputToken) }),
             case .ndArray(let nd) = desc.inputDescriptor(of: txName), nd.shape.count >= 2
         {
             return nd.shape[1]
@@ -518,6 +526,8 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         var currentPosition = processedTokenCount
 
         if processedTokenCount == 0 {
+            // Fresh sequence (no prefix reuse): zero the state caches so no KV from a prior
+            // generation leaks into this one.
             stateHandler.reset()
         }
 
@@ -556,8 +566,8 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
 
             var inputs: [String: NDArray] = [:]
             // Embedding gather is engine-produced (needs the model's gather graph).
-            if let txName = desc.inputNames.first(where: { $0.contains("transformer_input") }) {
-                if graphInputs.contains("embedding_table") { inputs["embedding_table"] = embeddingTable }
+            if let txName = desc.inputNames.first(where: { $0.contains(Self.transformerInputToken) }) {
+                if graphInputs.contains(Self.embeddingTableName) { inputs[Self.embeddingTableName] = embeddingTable }
                 guard let gathered = try await runGather(tokenIDs: Array(ctx.tokens), batchSize: batchSize) else {
                     throw InferenceRuntimeError.invalidState(
                         "Embedding gather returned no output for batch \(batchSize)")
@@ -650,7 +660,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         }
 
         var inputs: [String: NDArray] = [tokenInputName: tokenArray]
-        inputs["embedding_table"] = embeddingTable
+        inputs[Self.embeddingTableName] = embeddingTable
 
         var outputs = try await fn.run(
             inputs: inputs,

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIStaticShapeEngine.swift
@@ -46,27 +46,19 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
     // Largest query length across all extend functions — used as prefill threshold.
     private let maxQueryLength: Int
 
-    // Generic persistent state (KV + any hybrid/sliding states), discovered by name from the
-    // descriptor and zero-initialized. No hardcoded KV contract, no per-model state properties.
-    //
-    // Each static graph is compiled with its own per-ctx sequence strides, so a state buffer
-    // MUST be physically laid out for the exact bucket the running graph expects — a max-ctx
-    // allocation viewed through a slice hands the smaller-bucket graph the wrong stride and
-    // corrupts the cache. We therefore RIGHT-SIZE the ctx-scaled states (e.g. the global KV
-    // cache) to the running bucket and grow+re-lay-out on a bucket crossing (`ensureStateCtx`).
-    // States whose descriptor is constant across buckets (e.g. a fixed sliding-window ring)
-    // are allocated once and never re-laid-out.
+    // The persistent state values (KV and any hybrid/sliding states) used by this engine.
+    // They may be reallocated over the engine's lifetime as the context grows — see
+    // `growStatesIfNeeded(for:)` for this engine's sizing strategy.
     private var stateHandler: FixedNDArrayState
     private let stateNames: [String]
-    // ctx bucket -> that bucket's (name, descriptor) list, for re-allocation on crossing.
+    // Per-ctx-bucket state descriptors, used to (re)allocate the state values.
     private let stateDescriptorsByCtx: [Int: [(name: String, descriptor: NDArrayDescriptor)]]
-    // States whose sequence extent scales with the ctx bucket (must be re-laid-out on grow).
+    // States whose size grows with the context (reallocated on growth); the rest are fixed.
     private let ctxScaledStateNames: Set<String>
-    // The ctx bucket the state buffers are currently laid out for.
+    // The context length the state values are currently sized for.
     private var currentStateCtx: Int
 
-    // Model-specific input preparation (embedding gather, position ids, causal mask, step, and
-    // profile extras like PLE / dual-RoPE / sliding-ring). The engine never learns an input name.
+    // The handlers that produce/populate the model inputs.
     private let providers: [any SyncInputHandler]
     private let profileName: String
 
@@ -183,7 +175,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         }
         self.ctxScaledStateNames = ctxScaled
 
-        // Allocate at the smallest bucket; ctx-scaled states grow on demand via ensureStateCtx.
+        // Allocate at the smallest bucket; ctx-scaled states grow on demand via growStatesIfNeeded(for:).
         self.stateHandler = FixedNDArrayState(states: smallDescs)
         self.stateNames = smallDescs.map(\.name)
         self.currentStateCtx = smallestCtx
@@ -204,12 +196,11 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         CLILogger.log("Engine initialized (profile: \(profileName), \(providers.count) input providers)")
     }
 
-    /// Ensure the ctx-scaled state buffers are physically laid out for context bucket `ctx`,
-    /// growing + re-laying-out the written prefix when a decode step crosses into a larger
-    /// bucket. Fixed states (constant descriptor across buckets, e.g. a sliding-window ring)
-    /// are carried over verbatim. No-op when already laid out for `ctx`.
-    private func ensureStateCtx(_ ctx: Int) throws {
-        guard ctx != currentStateCtx, ctxScaledStateNames.isEmpty == false else { return }
+    /// Grow the context-scaled state values to fit context length `ctx`, copying the written
+    /// prefix into the larger layout. Fixed-size states are reused as-is. No-op when the state
+    /// values already fit `ctx` (or the model has no context-scaled states).
+    private func growStatesIfNeeded(for ctx: Int) throws {
+        guard ctx != currentStateCtx, !ctxScaledStateNames.isEmpty else { return }
         guard let targetDescs = stateDescriptorsByCtx[ctx] else {
             throw InferenceRuntimeError.invalidState(
                 "No state descriptors for ctx bucket \(ctx) (ladder: \(stateDescriptorsByCtx.keys.sorted()))")
@@ -218,21 +209,20 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         var new = FixedNDArrayState(states: targetDescs)
         let copyPositions = min(processedTokenCount, currentStateCtx)
         for i in stateNames.indices {
-            let name = stateNames[i]
-            var dst = new[stateIndex: i]
-            let src = old[stateIndex: i]
-            if ctxScaledStateNames.contains(name) {
-                // Grow: copy the written sequence prefix into the larger layout.
-                Self.copyStatePrefix(from: src.array, to: &dst.array, copyPositions: copyPositions)
+            if ctxScaledStateNames.contains(stateNames[i]) {
+                var dst = new[stateIndex: i]
+                Self.copyStatePrefix(
+                    from: old[stateIndex: i].array, to: &dst.array, copyPositions: copyPositions)
+                new[stateIndex: i] = dst
             } else {
-                // Fixed: identical shape across buckets — carry the whole buffer over.
-                Self.copyStatePrefix(from: src.array, to: &dst.array, copyPositions: nil)
+                // Fixed-size state: reuse the existing buffer as-is (no realloc/copy).
+                new[stateIndex: i] = old[stateIndex: i]
             }
-            new[stateIndex: i] = dst
         }
         stateHandler = new
+        let previousCtx = currentStateCtx
         currentStateCtx = ctx
-        CLILogger.log("State caches re-laid-out: ctx \(currentStateCtx) → \(ctx) (copied \(copyPositions) positions)")
+        CLILogger.log("State values grown: ctx \(previousCtx) → \(ctx) (copied \(copyPositions) positions)")
     }
 
     /// Copy a state buffer's written sequence prefix from `src` into the (larger) `dst` layout.
@@ -256,6 +246,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
         let dstGroupStride = dstSeq * factor
         let runElems = copySeq * factor
 
+        // TODO(rdar://…): replace with a first-party NDArray view-to-view copy API once exposed.
         func run<T: BitwiseCopyable>(_ type: T.Type) {
             let srcView = src.view(as: T.self)
             var dstView = dst.mutableView(as: T.self)
@@ -589,7 +580,7 @@ public final class StaticShapeEngine: InferenceEngine, @unchecked Sendable {
             // Right-size the state caches to this graph's ctx bucket, then bind full buffers
             // by name. Because the buffers are laid out for the exact running bucket, no
             // slicing is needed — the graph's compiled per-ctx strides match the allocation.
-            try ensureStateCtx((try? contextLength(of: graphName)) ?? currentStateCtx)
+            try growStatesIfNeeded(for: (try? contextLength(of: graphName)) ?? currentStateCtx)
             // Local ref binding so the borrow spans the run() call (bind ties `states`'
             // lifetime to the handler; a stored-property borrow would end at the call).
             let handler = stateHandler

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/EngineFactory.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/EngineFactory.swift
@@ -203,7 +203,8 @@ public struct EngineFactory: Sendable {
             CLILogger.log("Creating static-shape engine")
             return try await StaticShapeEngine(
                 configuration: modelConfig,
-                preparedModel: preparedModel
+                preparedModel: preparedModel,
+                bundleURL: modelURL
             )
 
         case .sequential:

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticInputProviders.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticInputProviders.swift
@@ -1,0 +1,100 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+import Foundation
+
+// MARK: - Static-shape input handlers
+//
+// Concrete `SyncInputHandler`s (Sukru's shared protocol, #147) for static-shape graphs.
+// Each reads the per-step `InputContext` — including `descriptors` (the running graph's
+// input descriptors) so it can size its own buffer to the active bucket. Embedding gather
+// is produced by the engine directly (it needs the model's gather graph), so there is no
+// handler for `transformer_input`.
+
+/// `position_ids` — absolute UInt16 positions across the aligned block.
+final class PositionIdsProvider: SyncInputHandler {
+    private let name: String
+    var inputNames: [String] { [name] }
+    init(name: String) { self.name = name }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors[name] else { return [:] }
+        guard d.scalarType.byteSize == 2 else {
+            throw InferenceRuntimeError.invalidState(
+                "position_ids '\(name)' expects a 2-byte int type, got \(d.scalarType)")
+        }
+        var pos = NDArray(descriptor: d)
+        var view = pos.mutableView(as: UInt16.self)
+        guard var span = view.contiguousElements else {
+            throw InferenceRuntimeError.invalidState("position_ids non-contiguous")
+        }
+        for i in 0..<ctx.batchSize { span[i] = UInt16(truncatingIfNeeded: ctx.alignedStep + i) }
+        return [name: pos]
+    }
+}
+
+/// `causal_mask` — `-40000` fill, unmask `0...min(queryPos, ctx-1)`.
+final class CausalMaskProvider: SyncInputHandler {
+    private let name: String
+    var inputNames: [String] { [name] }
+    init(name: String) { self.name = name }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors[name] else { return [:] }
+        guard d.shape.count >= 4 else {
+            throw InferenceRuntimeError.invalidState(
+                "causal_mask '\(name)' expects a rank-4 shape (1, ctx, 1, q), got \(d.shape)")
+        }
+        var mask = NDArray(descriptor: d)
+        var view = mask.mutableView(as: LogitsScalarType.self)
+        StaticMaskFill.fill(view, tokensInBatch: ctx.tokens.count, alignedStep: ctx.alignedStep)
+        return [name: mask]
+    }
+}
+
+/// `in_step` — Int32 scalar block-start / KV write offset.
+final class StepProvider: SyncInputHandler {
+    private let name: String
+    var inputNames: [String] { [name] }
+    init(name: String) { self.name = name }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors[name] else { return [:] }
+        guard d.scalarType.byteSize == 4 else {
+            throw InferenceRuntimeError.invalidState(
+                "step '\(name)' expects a 4-byte int type, got \(d.scalarType)")
+        }
+        var step = NDArray(descriptor: d)
+        var view = step.mutableView(as: Int32.self)
+        guard var span = view.contiguousElements else {
+            throw InferenceRuntimeError.invalidState("step non-contiguous")
+        }
+        span[0] = Int32(ctx.alignedStep)
+        return [name: step]
+    }
+}
+
+/// Shared causal-mask fill (stride-aware). Callers validate the mask is rank-4 (1, ctx, 1, q).
+enum StaticMaskFill {
+    static func fill(
+        _ view: consuming NDArray.MutableView<LogitsScalarType>,
+        tokensInBatch: Int,
+        alignedStep: Int
+    ) {
+        view.withUnsafeMutablePointer { ptr, shape, strides in
+            precondition(shape.count >= 4, "causal mask fill expects a rank-4 shape (1, ctx, 1, q)")
+            for context in 0..<shape[1] {
+                for query in 0..<shape[3] {
+                    ptr[context &* strides[1] &+ query &* strides[3]] = LogitsScalarType(-40000.0)
+                }
+            }
+            for query in 0..<tokensInBatch {
+                let upperBound = min(alignedStep + query, shape[1] &- 1)
+                for context in 0...upperBound {
+                    ptr[context &* strides[1] &+ query &* strides[3]] = 0
+                }
+            }
+        }
+    }
+}

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticInputProviders.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticInputProviders.swift
@@ -16,7 +16,7 @@ import Foundation
 // handler for `transformer_input`.
 
 /// `position_ids` — absolute UInt16 positions across the aligned block.
-final class PositionIdsProvider: SyncInputHandler {
+struct PositionIdsProvider: SyncInputHandler {
     private let name: String
     var inputNames: [String] { [name] }
     init(name: String) { self.name = name }
@@ -37,7 +37,7 @@ final class PositionIdsProvider: SyncInputHandler {
 }
 
 /// `causal_mask` — `-40000` fill, unmask `0...min(queryPos, ctx-1)`.
-final class CausalMaskProvider: SyncInputHandler {
+struct CausalMaskProvider: SyncInputHandler {
     private let name: String
     var inputNames: [String] { [name] }
     init(name: String) { self.name = name }
@@ -55,7 +55,7 @@ final class CausalMaskProvider: SyncInputHandler {
 }
 
 /// `in_step` — Int32 scalar block-start / KV write offset.
-final class StepProvider: SyncInputHandler {
+struct StepProvider: SyncInputHandler {
     private let name: String
     var inputNames: [String] { [name] }
     init(name: String) { self.name = name }

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
@@ -1,0 +1,395 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import CoreAIShared
+import Foundation
+
+// MARK: - Static Model Profile
+
+/// A model family's contribution to the static-shape engine: the extra input providers it
+/// needs beyond the universal decoder set. Selected as *data* from the descriptor's declared
+/// inputs/states — no per-model engine subclass, no `matches(model:)` returning an engine.
+struct StaticModelProfile {
+    let name: String
+    let extraHandlers: [any SyncInputHandler]
+
+    /// Assemble the full provider list for a model: universal base providers (gated on the
+    /// descriptor actually declaring each input) + the family-specific profile providers.
+    static func assembleInputHandlers(
+        descriptor desc: InferenceFunctionDescriptor,
+        bundleURL: URL
+    ) throws -> (providers: [any SyncInputHandler], profileName: String) {
+        let inputs = Set(desc.inputNames)
+        var providers: [any SyncInputHandler] = []
+
+        // ── Base providers (universal) ──
+        // `transformer_input` / `embedding_table` are produced by the engine directly
+        // (embedding gather needs the model's gather graph), not by a SyncInputHandler.
+        if let pos = desc.inputNames.first(where: { $0.contains("pos") }) {
+            providers.append(PositionIdsProvider(name: pos))
+        }
+        if inputs.contains("causal_mask") {
+            providers.append(CausalMaskProvider(name: "causal_mask"))
+        }
+        // Base step is the non-sliding step counter (`in_step`); sliding_in_step is a profile input.
+        if let step = desc.inputNames.first(where: {
+            $0.contains("step") && !$0.contains("pos") && !$0.contains("sliding")
+        }) {
+            providers.append(StepProvider(name: step))
+        }
+
+        // ── Profile selection (pure function of declared inputs/states) ──
+        let profile = try resolve(descriptor: desc, bundleURL: bundleURL)
+        providers.append(contentsOf: profile.extraHandlers)
+        return (providers, profile.name)
+    }
+
+    static func resolve(descriptor desc: InferenceFunctionDescriptor, bundleURL: URL) throws -> StaticModelProfile {
+        let inputs = Set(desc.inputNames)
+        let states = Set(desc.stateNames)
+
+        // Gemma4: PLE + dual-RoPE + sliding-window KV cache.
+        if inputs.contains("ple_embeddings") || inputs.contains("rope_cos")
+            || states.contains("sliding_key_cache")
+        {
+            var extras: [any SyncInputHandler] = []
+            let meta = StaticBundleMetadata.load(bundleURL: bundleURL)
+
+            if inputs.contains("rope_cos") {
+                // Always cover rope_cos/rope_sin when declared. Uses metadata dual-RoPE params
+                // when available; falls back to identity (no rotation) so coverage passes and the
+                // graph runs even if params are missing (numeric parity then needs the metadata).
+                extras.append(RoPEProvider(config: meta?.rope))
+            }
+            // A declared ple_embeddings input with a missing/broken sidecar is fatal — let it throw.
+            if inputs.contains("ple_embeddings") {
+                extras.append(PLEProvider(table: try PerLayerEmbeddings(bundleURL: bundleURL)))
+            }
+            if inputs.contains("sliding_in_step") {
+                let ring = slidingRingDepth(descriptor: desc)
+                extras.append(SlidingStepProvider(ringDepth: ring))
+            }
+            if inputs.contains("sliding_causal_mask") {
+                extras.append(
+                    SlidingMaskProvider(
+                        ringDepth: slidingRingDepth(descriptor: desc),
+                        window: meta?.slidingWindow ?? 0))
+            }
+            return StaticModelProfile(name: "gemma4", extraHandlers: extras)
+        }
+
+        // Qwen3.5 hybrid: DeltaNet SSM update flag (conv/recurrent states handled generically).
+        if inputs.contains("ssm_update_flag") {
+            return StaticModelProfile(
+                name: "qwen3.5-hybrid",
+                extraHandlers: [SSMUpdateFlagProvider(name: "ssm_update_flag")])
+        }
+
+        return StaticModelProfile(name: "vanilla", extraHandlers: [])
+    }
+
+    /// Ring depth = the sliding cache's sequence (last) dim from the descriptor.
+    private static func slidingRingDepth(descriptor desc: InferenceFunctionDescriptor) -> Int {
+        if case .ndArray(let d) = desc.stateDescriptor(of: "sliding_key_cache"), let last = d.shape.last {
+            return last
+        }
+        return 0
+    }
+}
+
+// MARK: - Bundle metadata (rope / sliding window)
+
+/// Reads the rope + sliding-window fields from the bundle's `metadata.json`. These live under
+/// `language.*` and are not in the base `ModelConfig`, so we parse them here on demand.
+struct StaticBundleMetadata {
+    struct RoPE {
+        let slidingHeadDim: Int
+        let globalHeadDim: Int
+        let slidingTheta: Double
+        let globalTheta: Double
+        let partialRotaryFactor: Double
+    }
+    let rope: RoPE?
+    let slidingWindow: Int?
+
+    static func load(bundleURL: URL) -> StaticBundleMetadata? {
+        // metadata.json sits beside the .aimodel. Try the dir + its parent, then scan for it.
+        var candidates = [
+            bundleURL.appendingPathComponent("metadata.json"),
+            bundleURL.deletingLastPathComponent().appendingPathComponent("metadata.json"),
+        ]
+        for dir in [bundleURL, bundleURL.deletingLastPathComponent()] {
+            let items =
+                (try? FileManager.default.contentsOfDirectory(
+                    at: dir, includingPropertiesForKeys: nil)) ?? []
+            candidates.append(contentsOf: items.filter { $0.lastPathComponent == "metadata.json" })
+        }
+        // A model bundle has TWO metadata.json files: the bundle *manifest* (with the
+        // `language` block we need) beside the .aimodel, and the .aimodel's own internal
+        // metadata (assetVersion/creationDate/producer, no `language`). When `bundleURL`
+        // is the .aimodel path, `bundleURL/metadata.json` resolves to the internal one
+        // first — so pick the first candidate whose JSON actually carries a `language`
+        // block rather than the first that merely exists.
+        var lang: [String: Any]? = nil
+        for url in candidates where FileManager.default.fileExists(atPath: url.path) {
+            guard let data = try? Data(contentsOf: url),
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let l = json["language"] as? [String: Any]
+            else { continue }
+            lang = l
+            break
+        }
+        guard let lang else { return nil }
+
+        var rope: RoPE? = nil
+        if let r = lang["rope"] as? [String: Any] {
+            func dbl(_ k: String) -> Double? { (r[k] as? NSNumber)?.doubleValue }
+            func int(_ k: String) -> Int? { (r[k] as? NSNumber)?.intValue }
+            rope = RoPE(
+                slidingHeadDim: int("sliding_head_dim") ?? 0,
+                globalHeadDim: int("global_head_dim") ?? 0,
+                slidingTheta: dbl("sliding_rope_theta") ?? 10000,
+                globalTheta: dbl("global_rope_theta") ?? 1_000_000,
+                partialRotaryFactor: dbl("partial_rotary_factor") ?? 1.0)
+        }
+        return StaticBundleMetadata(rope: rope, slidingWindow: (lang["sliding_window"] as? NSNumber)?.intValue)
+    }
+}
+
+// MARK: - Qwen3.5 hybrid provider
+
+/// `ssm_update_flag` — 1.0 on genuinely-new positions, 0.0 on re-sent/padding, so the DeltaNet
+/// recurrence treats re-sent tokens as exact no-ops. (fp16, one element per block column.)
+final class SSMUpdateFlagProvider: SyncInputHandler {
+    private let name: String
+    var inputNames: [String] { [name] }
+    init(name: String) { self.name = name }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors[name] else { return [:] }
+        var flag = NDArray(descriptor: d)
+        var view = flag.mutableView(as: LogitsScalarType.self)
+        guard var span = view.contiguousElements else {
+            throw InferenceRuntimeError.invalidState("ssm_update_flag non-contiguous")
+        }
+        // Offset into the block where genuinely-new (not re-sent) tokens begin.
+        let newTokenStart = ctx.processedTokenCount - ctx.alignedStep
+        for i in 0..<ctx.batchSize {
+            span[i] = (i >= newTokenStart && i < ctx.tokens.count) ? 1.0 : 0.0
+        }
+        return [name: flag]
+    }
+}
+
+// MARK: - Gemma4 providers
+
+/// `sliding_in_step` — Int32 ring-write offset (`alignedStep % ringDepth`) so the graph needs
+/// no in-graph remainder op.
+final class SlidingStepProvider: SyncInputHandler {
+    private let ringDepth: Int
+    var inputNames: [String] { ["sliding_in_step"] }
+    init(ringDepth: Int) { self.ringDepth = ringDepth }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors["sliding_in_step"] else { return [:] }
+        var step = NDArray(descriptor: d)
+        var view = step.mutableView(as: Int32.self)
+        guard var span = view.contiguousElements else {
+            throw InferenceRuntimeError.invalidState("sliding_in_step non-contiguous")
+        }
+        span[0] = ringDepth > 0 ? Int32(ctx.alignedStep % ringDepth) : Int32(ctx.alignedStep)
+        return ["sliding_in_step": step]
+    }
+}
+
+/// `sliding_causal_mask` — like the causal mask but windowed to the last `window` keys and
+/// indexed into the ring by `pos % ringDepth`.
+final class SlidingMaskProvider: SyncInputHandler {
+    private let ringDepth: Int
+    private let window: Int
+    var inputNames: [String] { ["sliding_causal_mask"] }
+    init(ringDepth: Int, window: Int) {
+        self.ringDepth = ringDepth
+        self.window = window
+    }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors["sliding_causal_mask"] else { return [:] }
+        var mask = NDArray(descriptor: d)
+        var view = mask.mutableView(as: LogitsScalarType.self)
+        let ring = ringDepth
+        let window = window
+        view.withUnsafeMutablePointer { ptr, shape, strides in
+            let ringLen = shape[1]  // sliding cache ring length (e.g. 576)
+            for slot in 0..<ringLen {
+                for query in 0..<shape[3] {
+                    ptr[slot &* strides[1] &+ query &* strides[3]] = LogitsScalarType(-40000.0)
+                }
+            }
+            // Unmask the window of keys visible to each query position.
+            for query in 0..<ctx.tokens.count {
+                let queryPos = ctx.alignedStep + query
+                let lowest = window > 0 ? max(0, queryPos - window + 1) : 0
+                for keyPos in lowest...queryPos {
+                    let slot = ring > 0 ? (keyPos % ring) : keyPos
+                    if slot < ringLen {
+                        ptr[slot &* strides[1] &+ query &* strides[3]] = 0
+                    }
+                }
+            }
+        }
+        return ["sliding_causal_mask": mask]
+    }
+}
+
+/// `rope_cos` / `rope_sin` — Gemma4 dual RoPE, precomputed on host and passed as inputs (lets
+/// the model exceed the ANE 16-bit position-id limit). The per-dim theta vector is computed once;
+/// per step we fill `cos(pos·θ)` / `sin(pos·θ)` for each block position.
+///
+/// Sliding sub-range `[0, slidingHeadDim)` = GPT-NeoX full rotary (freqs repeated in two halves).
+/// Global sub-range = partial rotary: only the first `floor(partialRotaryFactor·globalHeadDim/2)`
+/// frequency pairs rotate; the rest are NoPE (θ = 0 ⇒ cos = 1, sin = 0).
+final class RoPEProvider: SyncInputHandler {
+    private let theta: [Double]  // per-output-dim angular frequency; length = width
+    var inputNames: [String] { ["rope_cos", "rope_sin"] }
+
+    init(config: StaticBundleMetadata.RoPE?) {
+        guard let config, config.slidingHeadDim > 0 || config.globalHeadDim > 0 else {
+            self.theta = []  // identity fallback: cos=1, sin=0 (no rotation)
+            return
+        }
+        let sHd = config.slidingHeadDim
+        let gHd = config.globalHeadDim
+        let width = sHd + gHd
+        var theta = [Double](repeating: 0, count: width)
+
+        // Sliding: NeoX full rotary. Half-dim freqs repeated across the two halves.
+        let sHalf = sHd / 2
+        for i in 0..<sHalf {
+            let f = pow(config.slidingTheta, -Double(2 * i) / Double(sHd))
+            theta[i] = f
+            theta[i + sHalf] = f
+        }
+        // Global: partial rotary — first `rot` pairs rotate, rest NoPE (0).
+        let gHalf = gHd / 2
+        let rot = Int((config.partialRotaryFactor * Double(gHd) / 2.0).rounded(.down))
+        for i in 0..<gHalf {
+            let f = i < rot ? pow(config.globalTheta, -Double(2 * i) / Double(gHd)) : 0.0
+            theta[sHd + i] = f
+            theta[sHd + gHalf + i] = f
+        }
+        self.theta = theta
+    }
+
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let cosDesc = ctx.descriptors["rope_cos"],
+            let sinDesc = ctx.descriptors["rope_sin"]
+        else { return [:] }
+        var cos = NDArray(descriptor: cosDesc)
+        var sin = NDArray(descriptor: sinDesc)
+        fill(&cos, ctx: ctx, isSin: false)
+        fill(&sin, ctx: ctx, isSin: true)
+        return ["rope_cos": cos, "rope_sin": sin]
+    }
+
+    private func fill(_ array: inout NDArray, ctx: InputContext, isSin: Bool) {
+        let theta = self.theta
+        var view = array.mutableView(as: LogitsScalarType.self)
+        view.withUnsafeMutablePointer { ptr, shape, strides in
+            // shape: (1, q, width). Fill the FULL width; dims beyond `theta` (or when theta is
+            // empty) get angle 0 → cos=1 / sin=0 (identity), so the buffer is never uninitialized.
+            let q = shape[1]
+            let width = shape[2]
+            for query in 0..<q {
+                let pos = Double(ctx.alignedStep + query)
+                for d in 0..<width {
+                    let angle = d < theta.count ? pos * theta[d] : 0.0
+                    let v = isSin ? Foundation.sin(angle) : Foundation.cos(angle)
+                    ptr[query &* strides[1] &+ d &* strides[2]] = LogitsScalarType(v)
+                }
+            }
+        }
+    }
+}
+
+/// `ple_embeddings` — per-layer embedding INT8 rows, gathered per token from an mmap'd sidecar.
+final class PLEProvider: SyncInputHandler {
+    private let table: PerLayerEmbeddings
+    var inputNames: [String] { ["ple_embeddings"] }
+    init(table: PerLayerEmbeddings) { self.table = table }
+    func prepare(_ ctx: InputContext) async throws -> [String: NDArray] {
+        guard let d = ctx.descriptors["ple_embeddings"] else { return [:] }
+        var ple = NDArray(descriptor: d)
+        try table.gather(tokenIDs: Array(ctx.tokens), batchSize: ctx.batchSize, into: &ple)
+        return ["ple_embeddings": ple]
+    }
+}
+
+/// mmap'd per-layer embedding table (`*_ple.safetensors`, INT8 `[vocab, rowWidth]`), with a
+/// row-major gather. Bounds-checked so no token id can index past the mapping.
+final class PerLayerEmbeddings {
+    private let data: Data
+    private let dataStart: Int
+    let vocabSize: Int
+    let rowWidth: Int
+
+    init(bundleURL: URL) throws {
+        // Locate the sidecar: `<something>_ple.safetensors` beside the .aimodel.
+        let dirs = [bundleURL, bundleURL.deletingLastPathComponent()]
+        var found: URL?
+        for dir in dirs {
+            let items =
+                (try? FileManager.default.contentsOfDirectory(
+                    at: dir,
+                    includingPropertiesForKeys: nil)) ?? []
+            if let m = items.first(where: { $0.lastPathComponent.hasSuffix("_ple.safetensors") }) {
+                found = m
+                break
+            }
+        }
+        guard let url = found else {
+            throw InferenceRuntimeError.invalidState("No *_ple.safetensors sidecar near \(bundleURL.path)")
+        }
+        let mapped = try Data(contentsOf: url, options: .mappedIfSafe)
+        // safetensors: [8-byte LE header length][JSON header][raw bytes]
+        guard mapped.count > 8 else { throw InferenceRuntimeError.invalidState("PLE file too small") }
+        let headerLen = mapped.prefix(8).withUnsafeBytes { $0.load(as: UInt64.self) }
+        let headerData = mapped.subdata(in: 8..<(8 + Int(headerLen)))
+        guard let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any],
+            let entry = header["embed_tokens_per_layer"] as? [String: Any],
+            let shape = entry["shape"] as? [Int], shape.count == 2,
+            let offsets = entry["data_offsets"] as? [Int], offsets.count == 2
+        else {
+            throw InferenceRuntimeError.invalidState("PLE safetensors header missing embed_tokens_per_layer")
+        }
+        self.vocabSize = shape[0]
+        self.rowWidth = shape[1]
+        self.dataStart = 8 + Int(headerLen) + offsets[0]
+        let expected = shape[0] * shape[1]  // INT8 → 1 byte each
+        guard dataStart + expected <= mapped.count else {
+            throw InferenceRuntimeError.invalidState("PLE data out of bounds")
+        }
+        self.data = mapped
+    }
+
+    /// Gather each token's INT8 row into `dst` (shape `(1, batchSize, 1, rowWidth)`), token-major.
+    /// Out-of-range ids / padding slots are left zeroed.
+    func gather(tokenIDs: [Int32], batchSize: Int, into dst: inout NDArray) throws {
+        let rowWidth = self.rowWidth
+        let dataStart = self.dataStart
+        let vocab = self.vocabSize
+        var view = dst.mutableView(as: Int8.self)
+        view.withUnsafeMutablePointer { dstPtr, _, _ in
+            for i in 0..<(batchSize * rowWidth) { dstPtr[i] = 0 }
+            data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                let base = raw.baseAddress!.advanced(by: dataStart).assumingMemoryBound(to: Int8.self)
+                for i in 0..<min(batchSize, tokenIDs.count) {
+                    let tok = Int(tokenIDs[i])
+                    guard tok >= 0 && tok < vocab else { continue }
+                    let src = base.advanced(by: tok * rowWidth)
+                    dstPtr.advanced(by: i * rowWidth).update(from: src, count: rowWidth)
+                }
+            }
+        }
+    }
+}

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
@@ -9,9 +9,10 @@ import Foundation
 
 // MARK: - Static Model Profile
 
-/// A model family's contribution to the static-shape engine: the extra input providers it
-/// needs beyond the universal decoder set. Selected as *data* from the descriptor's declared
-/// inputs/states — no per-model engine subclass, no `matches(model:)` returning an engine.
+/// The set of input handlers a model needs, chosen from the model's declared graph inputs/states.
+/// A standard decoder needs the base set (token embeddings, position ids, causal mask); models
+/// with extra inputs (RoPE tables, per-layer embeddings, a sliding-window mask) add handlers for
+/// those. Selected as *data* from the descriptor — no per-model engine subclass.
 struct StaticModelProfile {
     let name: String
     let extraHandlers: [any SyncInputHandler]
@@ -146,7 +147,7 @@ struct StaticBundleMetadata {
 
 /// `ssm_update_flag` — 1.0 on genuinely-new positions, 0.0 on re-sent/padding, so the DeltaNet
 /// recurrence treats re-sent tokens as exact no-ops. (fp16, one element per block column.)
-final class SSMUpdateFlagProvider: SyncInputHandler {
+struct SSMUpdateFlagProvider: SyncInputHandler {
     private let name: String
     var inputNames: [String] { [name] }
     init(name: String) { self.name = name }
@@ -170,7 +171,7 @@ final class SSMUpdateFlagProvider: SyncInputHandler {
 
 /// `sliding_in_step` — Int32 ring-write offset (`alignedStep % ringDepth`) so the graph needs
 /// no in-graph remainder op.
-final class SlidingStepProvider: SyncInputHandler {
+struct SlidingStepProvider: SyncInputHandler {
     private let ringDepth: Int
     var inputNames: [String] { ["sliding_in_step"] }
     init(ringDepth: Int) { self.ringDepth = ringDepth }
@@ -188,7 +189,7 @@ final class SlidingStepProvider: SyncInputHandler {
 
 /// `sliding_causal_mask` — like the causal mask but windowed to the last `window` keys and
 /// indexed into the ring by `pos % ringDepth`.
-final class SlidingMaskProvider: SyncInputHandler {
+struct SlidingMaskProvider: SyncInputHandler {
     private let ringDepth: Int
     private let window: Int
     var inputNames: [String] { ["sliding_causal_mask"] }
@@ -232,7 +233,7 @@ final class SlidingMaskProvider: SyncInputHandler {
 /// Sliding sub-range `[0, slidingHeadDim)` = GPT-NeoX full rotary (freqs repeated in two halves).
 /// Global sub-range = partial rotary: only the first `floor(partialRotaryFactor·globalHeadDim/2)`
 /// frequency pairs rotate; the rest are NoPE (θ = 0 ⇒ cos = 1, sin = 0).
-final class RoPEProvider: SyncInputHandler {
+struct RoPEProvider: SyncInputHandler {
     private let theta: [Double]  // per-output-dim angular frequency; length = width
     var inputNames: [String] { ["rope_cos", "rope_sin"] }
 
@@ -296,7 +297,7 @@ final class RoPEProvider: SyncInputHandler {
 }
 
 /// `ple_embeddings` — per-layer embedding INT8 rows, gathered per token from an mmap'd sidecar.
-final class PLEProvider: SyncInputHandler {
+struct PLEProvider: SyncInputHandler {
     private let table: PerLayerEmbeddings
     var inputNames: [String] { ["ple_embeddings"] }
     init(table: PerLayerEmbeddings) { self.table = table }
@@ -310,7 +311,7 @@ final class PLEProvider: SyncInputHandler {
 
 /// mmap'd per-layer embedding table (`*_ple.safetensors`, INT8 `[vocab, rowWidth]`), with a
 /// row-major gather. Bounds-checked so no token id can index past the mapping.
-final class PerLayerEmbeddings {
+struct PerLayerEmbeddings {
     private let data: Data
     private let dataStart: Int
     let vocabSize: Int

--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/StaticModelProfile.swift
@@ -51,7 +51,7 @@ struct StaticModelProfile {
         let inputs = Set(desc.inputNames)
         let states = Set(desc.stateNames)
 
-        // Gemma4: PLE + dual-RoPE + sliding-window KV cache.
+        // Models with per-layer embeddings + dual-RoPE + a sliding-window KV cache.
         if inputs.contains("ple_embeddings") || inputs.contains("rope_cos")
             || states.contains("sliding_key_cache")
         {
@@ -78,13 +78,13 @@ struct StaticModelProfile {
                         ringDepth: slidingRingDepth(descriptor: desc),
                         window: meta?.slidingWindow ?? 0))
             }
-            return StaticModelProfile(name: "gemma4", extraHandlers: extras)
+            return StaticModelProfile(name: "ple-dual-rope-sliding", extraHandlers: extras)
         }
 
-        // Qwen3.5 hybrid: DeltaNet SSM update flag (conv/recurrent states handled generically).
+        // Hybrid models with a DeltaNet/SSM update flag (conv/recurrent states handled generically).
         if inputs.contains("ssm_update_flag") {
             return StaticModelProfile(
-                name: "qwen3.5-hybrid",
+                name: "ssm-hybrid",
                 extraHandlers: [SSMUpdateFlagProvider(name: "ssm_update_flag")])
         }
 
@@ -116,33 +116,16 @@ struct StaticBundleMetadata {
     let slidingWindow: Int?
 
     static func load(bundleURL: URL) -> StaticBundleMetadata? {
-        // metadata.json sits beside the .aimodel. Try the dir + its parent, then scan for it.
-        var candidates = [
-            bundleURL.appendingPathComponent("metadata.json"),
-            bundleURL.deletingLastPathComponent().appendingPathComponent("metadata.json"),
-        ]
-        for dir in [bundleURL, bundleURL.deletingLastPathComponent()] {
-            let items =
-                (try? FileManager.default.contentsOfDirectory(
-                    at: dir, includingPropertiesForKeys: nil)) ?? []
-            candidates.append(contentsOf: items.filter { $0.lastPathComponent == "metadata.json" })
-        }
-        // A model bundle has TWO metadata.json files: the bundle *manifest* (with the
-        // `language` block we need) beside the .aimodel, and the .aimodel's own internal
-        // metadata (assetVersion/creationDate/producer, no `language`). When `bundleURL`
-        // is the .aimodel path, `bundleURL/metadata.json` resolves to the internal one
-        // first — so pick the first candidate whose JSON actually carries a `language`
-        // block rather than the first that merely exists.
-        var lang: [String: Any]? = nil
-        for url in candidates where FileManager.default.fileExists(atPath: url.path) {
-            guard let data = try? Data(contentsOf: url),
-                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                let l = json["language"] as? [String: Any]
-            else { continue }
-            lang = l
-            break
-        }
-        guard let lang else { return nil }
+        // `ModelBundle` resolves the manifest metadata.json (handling the .aimodel's own internal
+        // metadata) and preserves its raw bytes. `bundleURL` may be the bundle dir or the .aimodel
+        // inside it, so try both. We read `rope`/`sliding_window` from the raw bytes because they
+        // aren't part of the typed `LanguageConfig`.
+        guard
+            let bundle = (try? ModelBundle(at: bundleURL))
+                ?? (try? ModelBundle(at: bundleURL.deletingLastPathComponent())),
+            let json = try? JSONSerialization.jsonObject(with: bundle.raw) as? [String: Any],
+            let lang = json["language"] as? [String: Any]
+        else { return nil }
 
         var rope: RoPE? = nil
         if let r = lang["rope"] as? [String: Any] {
@@ -159,7 +142,7 @@ struct StaticBundleMetadata {
     }
 }
 
-// MARK: - Qwen3.5 hybrid provider
+// MARK: - SSM / hybrid provider
 
 /// `ssm_update_flag` — 1.0 on genuinely-new positions, 0.0 on re-sent/padding, so the DeltaNet
 /// recurrence treats re-sent tokens as exact no-ops. (fp16, one element per block column.)
@@ -183,7 +166,7 @@ final class SSMUpdateFlagProvider: SyncInputHandler {
     }
 }
 
-// MARK: - Gemma4 providers
+// MARK: - Providers for PLE / dual-RoPE / sliding-window models
 
 /// `sliding_in_step` — Int32 ring-write offset (`alignedStep % ringDepth`) so the graph needs
 /// no in-graph remainder op.
@@ -242,7 +225,7 @@ final class SlidingMaskProvider: SyncInputHandler {
     }
 }
 
-/// `rope_cos` / `rope_sin` — Gemma4 dual RoPE, precomputed on host and passed as inputs (lets
+/// `rope_cos` / `rope_sin` — dual RoPE, precomputed on host and passed as inputs (lets
 /// the model exceed the ANE 16-bit position-id limit). The per-dim theta vector is computed once;
 /// per step we fill `cos(pos·θ)` / `sin(pos·θ)` for each block position.
 ///

--- a/swift/Tests/LanguageModelsTests/StaticShapeEngineTests.swift
+++ b/swift/Tests/LanguageModelsTests/StaticShapeEngineTests.swift
@@ -1,0 +1,85 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import CoreAI
+import Foundation
+import Testing
+
+@testable import CoreAILanguageModels
+
+// MARK: - Context-bucket parsing
+
+@Suite("StaticShapeEngine context-bucket parsing")
+struct StaticContextParseTests {
+    @Test("parses ctx from extend/prompt function names")
+    func parsesCtx() {
+        #expect(StaticShapeEngine.parseContextLength(functionName: "extend_256_16") == 256)
+        #expect(StaticShapeEngine.parseContextLength(functionName: "extend_1024_8") == 1024)
+        #expect(StaticShapeEngine.parseContextLength(functionName: "extend_32768_8") == 32768)
+        #expect(StaticShapeEngine.parseContextLength(functionName: "prompt_opt_1024_64") == 1024)
+        #expect(StaticShapeEngine.parseContextLength(functionName: "prompt_opt_512_8") == 512)
+    }
+
+    @Test("ctx is the second-to-last component, not shape.max()")
+    func ctxNotShapeMax() {
+        // Regression: qwen3 key_cache is [.,1024,.,256] at the 256 bucket, so `shape.max()`
+        // would wrongly report 1024. The name is authoritative.
+        #expect(StaticShapeEngine.parseContextLength(functionName: "extend_256_64") == 256)
+    }
+
+    @Test("returns nil for names without a numeric ctx component")
+    func nilOnMalformed() {
+        #expect(StaticShapeEngine.parseContextLength(functionName: "load_embeddings") == nil)
+        #expect(StaticShapeEngine.parseContextLength(functionName: "gather") == nil)
+    }
+}
+
+// MARK: - Causal mask fill
+
+@Suite("Static causal mask fill")
+struct StaticMaskFillTests {
+    /// Build a rank-4 (1, ctx, 1, q) mask, fill it, and read it back as [ctx][q].
+    private func filledMask(ctx: Int, q: Int, tokensInBatch: Int, alignedStep: Int) -> [[Float]] {
+        var mask = NDArray(shape: [1, ctx, 1, q], scalarType: .float16)
+        let view = mask.mutableView(as: LogitsScalarType.self)
+        StaticMaskFill.fill(view, tokensInBatch: tokensInBatch, alignedStep: alignedStep)
+        let flat = readNDArray(mask, as: LogitsScalarType.self, count: ctx * q)
+        var out = [[Float]](repeating: [Float](repeating: 0, count: q), count: ctx)
+        for c in 0..<ctx {
+            for query in 0..<q {
+                out[c][query] = Float(flat[c * q + query])
+            }
+        }
+        return out
+    }
+
+    @Test("prefill: query i attends to keys 0...i, masks the rest")
+    func prefillCausal() {
+        // ctx=4, q=4, all 4 tokens new, block starts at position 0.
+        let m = filledMask(ctx: 4, q: 4, tokensInBatch: 4, alignedStep: 0)
+        for query in 0..<4 {
+            for key in 0..<4 {
+                if key <= query {
+                    #expect(m[key][query] == 0, "query \(query) should see key \(key)")
+                } else {
+                    #expect(m[key][query] < -1000, "query \(query) should mask key \(key)")
+                }
+            }
+        }
+    }
+
+    @Test("decode: absolute positions via alignedStep")
+    func decodeAligned() {
+        // A single query at absolute position 5 (alignedStep=5) should see keys 0...5.
+        let m = filledMask(ctx: 8, q: 1, tokensInBatch: 1, alignedStep: 5)
+        for key in 0..<8 {
+            if key <= 5 {
+                #expect(m[key][0] == 0)
+            } else {
+                #expect(m[key][0] < -1000)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Static-shape LLM inference engine (StaticShapeEngine) built on the `bind(into:)` state binding from #156. States are discovered by name and the KV cache is right-sized per context bucket; ctx is parsed from the function name. Input preparation is pluggable per model family via StaticInputProvider + StaticModelProfile; StaticInputContext composes the shared InputContext and the provider mirrors SyncInputHandler.

Testing: LanguageModelsTests (317) pass; correct output on static assets.