### PR TITLE
Extension to InputContext design: adding per-graph descriptors

### DIFF
--- a/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
+++ b/swift/Sources/CoreAILanguageModels/Handlers/InputHandler.swift
@@ -18,6 +18,9 @@ public struct InputContext: Sendable {
     public let batchSize: Int
     /// Sliding window size (nil for models without sliding attention).
     public let slidingWindow: Int?
+    /// The active graph's input descriptors, keyed by input name. Lets a handler size its
+    /// own output buffer to the running bucket. Empty for engines that don't vary by bucket.
+    public let descriptors: [String: NDArrayDescriptor]
 
     /// For dynamic-shape engines (Sequential, Pipelined).
     /// alignedStep = processedTokenCount, batchSize = tokens.count.
@@ -30,7 +33,8 @@ public struct InputContext: Sendable {
             processedTokenCount: processedTokenCount,
             alignedStep: processedTokenCount,
             batchSize: tokens.count,
-            slidingWindow: nil)
+            slidingWindow: nil,
+            descriptors: [:])
     }
 
     /// For static-shape engines. Batch is fixed-size and aligned.
@@ -38,14 +42,16 @@ public struct InputContext: Sendable {
         tokens: ArraySlice<Int32>,
         alignedStep: Int,
         batchSize: Int,
-        slidingWindow: Int?
+        slidingWindow: Int?,
+        descriptors: [String: NDArrayDescriptor] = [:]
     ) -> InputContext {
         InputContext(
             tokens: tokens,
             processedTokenCount: alignedStep,
             alignedStep: alignedStep,
             batchSize: batchSize,
-            slidingWindow: slidingWindow)
+            slidingWindow: slidingWindow,
+            descriptors: descriptors)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a `descriptors: [String: NDArrayDescriptor]` field to `InputContext` (from #147) so an input handler can size its output buffer to the running graph's shape. Backward-compatible: defaults to empty, and the dynamic path is unchanged.

## Why

Static-shape / bucketed engines select a different graph per step, so a handler (position ids, causal mask, RoPE, PLE, ...) needs the active graph's input descriptors to allocate correctly. `InputContext` didn't carry them.

## Change

- New `descriptors` field; threaded through `.dynamic()` (empty) and `.static()` (optional, defaults empty).
- No change to the `SyncInputHandler` protocol or existing callers.

Enabling change for the static-shape engine (PR to follow).
