### PR TITLE
Update sam3 CLI flags and default values with new CLI unit tests

### DIFF
--- a/models/sam3/README.md
+++ b/models/sam3/README.md
@@ -39,18 +39,19 @@ uv run export.py --help
 
 **Options:**
 
-| Flag                   | Description                                    | Default                |
-|------------------------|------------------------------------------------|------------------------|
-| `--full`               | Export plain HF `Sam3Model` (no iOS targeting) | —                      |
-| `--output-dir`         | Output directory for the bundle                | `<repo-root>/exports/` |
-| `--output-name`        | Custom bundle directory name                   | derived                |
-| `--image-size`         | Input resolution (336 lite / 1008 full)        | `336` / `1008`         |
-| `--max-text-seq-len`   | (lite) Static text sequence length             | `32`                   |
-| `--n-bits`             | (lite) Uniform palettization bit-width override applied to BOTH encoders | asymmetric: image w4, text w6 |
-| `--group-size`         | (lite) Uniform palettization group-size override applied to BOTH encoders | asymmetric: image gs32, text gs8 |
-| `--dtype`              | (`--full`) Torch dtype: `float16` or `float32` | `float32`              |
-| `--overwrite`          | Overwrite existing bundle                      | —                      |
-| `--dry-run`            | Print resolved config and exit                 | —                      |
+| Flag                 | Description                                                               | Default                          |
+|----------------------|---------------------------------------------------------------------------|----------------------------------|
+| `--model`            | Model to export: `sam3` (shortname) or `facebook/sam3`                    | `facebook/sam3`                  |
+| `--full`             | Export plain HF `Sam3Model` (no iOS targeting)                            | —                                |
+| `--output-dir`       | Output directory for the bundle                                           | `<repo-root>/exports/`           |
+| `--output-name`      | Custom bundle directory name                                              | derived                          |
+| `--image-size`       | Input resolution (336 lite / 1008 full)                                   | `336` / `1008`                   |
+| `--max-text-seq-len` | (lite) Static text sequence length                                        | `32`                             |
+| `--n-bits`           | (lite) Uniform palettization bit-width override applied to BOTH encoders  | asymmetric: image w4, text w6    |
+| `--group-size`       | (lite) Uniform palettization group-size override applied to BOTH encoders | asymmetric: image gs32, text gs8 |
+| `--dtype`            | (`--full`) Torch dtype: `float16` or `float32`                            | `float32`                        |
+| `--overwrite`        | Overwrite existing bundle                                                 | —                                |
+| `--dry-run`          | Print resolved config and exit                                            | —                                |
 
 `image-size=336` is the resolution we recommend for iOS deployment.
 

--- a/models/sam3/export.py
+++ b/models/sam3/export.py
@@ -44,18 +44,12 @@ Usage:
     uv run models/sam3/export.py [--image-size N] [--n-bits N] [--output-dir PATH] ...
 """
 
-import sys
-
 
 def main() -> None:
     # Lazy import so the inline-script header parses cleanly even if the
     # workspace package isn't on sys.path yet (uv handles that before main()).
     from coreai_models.segmentation.export import main as segmentation_main
 
-    # The shared CLI takes a `model` positional. This script only handles SAM3,
-    # so inject "sam3" and forward any user-supplied flags untouched.
-    if len(sys.argv) == 1 or sys.argv[1].startswith("-"):
-        sys.argv.insert(1, "sam3")
     segmentation_main()
 
 

--- a/python/src/coreai_models/segmentation/export.py
+++ b/python/src/coreai_models/segmentation/export.py
@@ -25,7 +25,6 @@ import argparse
 import logging
 from pathlib import Path
 
-from coreai_models.model_registry import lookup_utility_model
 from coreai_models.segmentation.pipeline import (
     FullExportConfig,
     SegmentationExportConfig,
@@ -33,16 +32,12 @@ from coreai_models.segmentation.pipeline import (
     export_segmentation,
 )
 
+# Accepted ``--model`` spellings → canonical HF id. Doubles as the source of
+# truth for the flag's ``choices``, so adding an alias here is all it takes.
 _SUPPORTED = {
     "sam3": "facebook/sam3",
     "facebook/sam3": "facebook/sam3",
 }
-
-# Defaults that differ between the two export paths. Used only when
-# ``--image-size`` isn't passed explicitly so each mode picks the
-# resolution it was designed for.
-_LITE_DEFAULT_IMAGE_SIZE = 336
-_FULL_DEFAULT_IMAGE_SIZE = 1008
 
 
 def _find_repo_root() -> Path | None:
@@ -60,16 +55,12 @@ def _default_output_dir() -> str:
 
 
 def _resolve_hf_model_id(model: str) -> str:
-    """Accept registry short-name or HF id; reject anything else."""
-    if model in _SUPPORTED:
-        return _SUPPORTED[model]
-    preset = lookup_utility_model(model)
-    if preset is not None and preset.task == "segmentation" and preset.hf_id in _SUPPORTED:
-        return _SUPPORTED[preset.hf_id]
-    raise SystemExit(
-        f"Error: '{model}' is not a supported segmentation model. "
-        f"Supported: {sorted(set(_SUPPORTED.values()))}"
-    )
+    """Map an accepted ``--model`` value to its canonical HF id.
+
+    ``--model`` derives its ``choices`` from ``_SUPPORTED``, so argparse has
+    already rejected anything unknown by the time this runs.
+    """
+    return _SUPPORTED[model]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -84,7 +75,9 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "model",
+        "--model",
+        choices=sorted(_SUPPORTED),
+        default="facebook/sam3",
         help=(
             "Segmentation model. Either the registry short-name (e.g. 'sam3') "
             "or its HuggingFace id (e.g. 'facebook/sam3')."
@@ -118,11 +111,14 @@ def build_parser() -> argparse.ArgumentParser:
         help=("Input resolution. Defaults to 336 (lite) or 1008 (--full). "),
     )
     # ---- Lite-only flags -------------------------------------------
+    # Mode-specific flags default to None rather than their real default so
+    # _warn_unused_flags can tell "user passed this" from "user left it alone",
+    # even when the value passed matches the default. Resolved in main().
     parser.add_argument(
         "--max-text-seq-len",
         type=int,
-        default=32,
-        help="(lite) Static text sequence length used at export time.",
+        default=None,
+        help="(lite) Static text sequence length used at export time. Default: 32.",
     )
     parser.add_argument(
         "--n-bits",
@@ -147,8 +143,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dtype",
         choices=["float16", "float32"],
-        default="float32",
-        help="(--full) Torch dtype to use for the model.",
+        default=None,
+        help="(--full) Torch dtype to use for the model. Default: float32.",
     )
     # ---- Shared flags ---------------------------------------------------
     parser.add_argument(
@@ -171,32 +167,40 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_image_size(args: argparse.Namespace) -> int:
+    """Pick the resolution each mode was designed for when --image-size is omitted.
+
+    Mode-specific flags default to None so ``_warn_unused_flags`` can detect
+    "passed" regardless of value; the real defaults live on the config
+    dataclasses. ``@dataclass`` leaves plain defaults as class attributes, so
+    they're readable without constructing a config.
+    """
     if args.image_size is not None:
         return args.image_size
-    return _FULL_DEFAULT_IMAGE_SIZE if args.full else _LITE_DEFAULT_IMAGE_SIZE
+    return FullExportConfig.image_size if args.full else SegmentationExportConfig.image_size
 
 
-def _warn_unused_flags(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+def _warn_unused_flags(args: argparse.Namespace) -> None:
     """Surface flags that don't apply to the chosen mode so users notice typos.
 
-    argparse can't natively express "this flag only applies when --full
-    is set" without subparsers, so we just check after parsing.
+    argparse can't natively express "this flag only applies when --full is set"
+    without subparsers. Every mode-specific flag defaults to ``None``, so "not
+    None" means the user passed it explicitly — including when the value they
+    passed happens to equal the mode's resolved default.
     """
-    parser_defaults = parser.parse_args([args.model])
     if args.full:
         # Lite-only flags shouldn't be set in full mode.
-        ignored = []
-        for name in ("max_text_seq_len", "n_bits", "group_size"):
-            if getattr(args, name) != getattr(parser_defaults, name):
-                ignored.append(name.replace("_", "-"))
+        ignored = [
+            name.replace("_", "-")
+            for name in ("max_text_seq_len", "n_bits", "group_size")
+            if getattr(args, name) is not None
+        ]
         if ignored:
             logging.warning(
                 "Ignoring lite-only flag(s) in full mode: %s",
                 ", ".join(f"--{n}" for n in ignored),
             )
-    else:
-        if args.dtype != parser_defaults.dtype:
-            logging.warning("Ignoring --dtype outside full mode (lite path is fp16).")
+    elif args.dtype is not None:
+        logging.warning("Ignoring --dtype outside full mode (lite path is fp16).")
 
 
 def main() -> None:
@@ -211,13 +215,13 @@ def main() -> None:
 
     hf_model_id = _resolve_hf_model_id(args.model)
     image_size = _resolve_image_size(args)
-    _warn_unused_flags(parser, args)
+    _warn_unused_flags(args)
 
     if args.full:
         config = FullExportConfig(
             hf_model_id=hf_model_id,
             image_size=image_size,
-            dtype=args.dtype,
+            dtype=args.dtype or FullExportConfig.dtype,
             output_dir=args.output_dir or _default_output_dir(),
             output_name=args.output_name,
             overwrite=args.overwrite,
@@ -249,7 +253,7 @@ def main() -> None:
         config = SegmentationExportConfig(
             hf_model_id=hf_model_id,
             image_size=image_size,
-            max_text_seq_len=args.max_text_seq_len,
+            max_text_seq_len=args.max_text_seq_len or defaults.max_text_seq_len,
             image_n_bits=image_n_bits,
             image_group_size=image_group_size,
             text_n_bits=text_n_bits,

--- a/python/tests/test_model_units/test_export/test_segmentation_cli.py
+++ b/python/tests/test_model_units/test_export/test_segmentation_cli.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for the ``coreai.segmentation.export`` CLI.
+
+Flag plumbing only — nothing here downloads weights or runs an export, so
+these are safe on any machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import pytest
+
+from coreai_models.segmentation.export import (
+    _SUPPORTED,
+    _resolve_hf_model_id,
+    _resolve_image_size,
+    _warn_unused_flags,
+    build_parser,
+)
+from coreai_models.segmentation.pipeline import FullExportConfig, SegmentationExportConfig
+
+
+def _parse(*argv: str) -> tuple[argparse.ArgumentParser, argparse.Namespace]:
+    """Build a fresh parser and parse ``argv``, returning both."""
+    parser = build_parser()
+    return parser, parser.parse_args(list(argv))
+
+
+# --- --model ---------------------------------------------------------
+
+
+def test_every_supported_spelling_parses_and_resolves() -> None:
+    """``--model`` takes its ``choices`` from ``_SUPPORTED``, which is what lets
+    ``_resolve_hf_model_id`` be a bare dict lookup. Pin that coupling: every
+    key must parse, and every value must be a canonical HF id."""
+    for spelling in _SUPPORTED:
+        _, args = _parse("--model", spelling)
+        assert _resolve_hf_model_id(args.model) == _SUPPORTED[spelling]
+
+
+def test_model_defaults_to_sam3() -> None:
+    _, args = _parse()
+    assert _resolve_hf_model_id(args.model) == "facebook/sam3"
+
+
+def test_model_accepts_registry_short_name() -> None:
+    _, args = _parse("--model", "sam3")
+    assert _resolve_hf_model_id(args.model) == "facebook/sam3"
+
+
+def test_model_accepts_hf_id() -> None:
+    _, args = _parse("--model", "facebook/sam3")
+    assert _resolve_hf_model_id(args.model) == "facebook/sam3"
+
+
+def test_model_rejects_unknown_value() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--model", "facebook/sam2"])
+
+
+def test_bare_positional_is_rejected() -> None:
+    """``--model`` replaced a positional, so a bare value is no longer valid."""
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["sam3"])
+
+
+# --- mode + image size -----------------------------------------------
+
+
+def test_lite_is_the_default_mode() -> None:
+    _, args = _parse()
+    assert args.full is False
+
+
+def test_image_size_defaults_per_mode() -> None:
+    _, lite = _parse()
+    _, full = _parse("--full")
+    assert _resolve_image_size(lite) == SegmentationExportConfig.image_size
+    assert _resolve_image_size(full) == FullExportConfig.image_size
+
+
+def test_explicit_image_size_overrides_mode_default() -> None:
+    _, args = _parse("--full", "--image-size", "512")
+    assert _resolve_image_size(args) == 512
+
+
+# --- _warn_unused_flags ----------------------------------------------
+
+
+def test_warn_unused_flags_does_not_reparse_argv() -> None:
+    """Regression: this recovered defaults via ``parse_args([args.model])``,
+    which argparse rejected as a stray positional once ``model`` became
+    ``--model`` — killing the process before the export started."""
+    _, args = _parse("--full", "--dtype", "float16")
+    _warn_unused_flags(args)
+
+
+def test_warns_on_dtype_equal_to_default_in_lite_mode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression: comparing against the default missed ``--dtype float32``,
+    since float32 *is* the default — the flag was silently ignored with no
+    warning. Mode-specific flags now default to None so "passed" is detectable
+    regardless of the value."""
+    _, args = _parse("--dtype", "float32")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert "--dtype" in caplog.text
+
+
+def test_warns_on_lite_only_flag_equal_to_default_in_full_mode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same class of bug as the --dtype case: 32 is the resolved default."""
+    _, args = _parse("--full", "--max-text-seq-len", "32")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert "--max-text-seq-len" in caplog.text
+
+
+def test_warns_on_lite_only_flags_in_full_mode(caplog: pytest.LogCaptureFixture) -> None:
+    _, args = _parse("--full", "--n-bits", "4", "--max-text-seq-len", "64")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert "--n-bits" in caplog.text
+    assert "--max-text-seq-len" in caplog.text
+
+
+def test_warns_on_dtype_in_lite_mode(caplog: pytest.LogCaptureFixture) -> None:
+    _, args = _parse("--dtype", "float16")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert "--dtype" in caplog.text
+
+
+def test_no_warning_for_lite_flags_in_lite_mode(caplog: pytest.LogCaptureFixture) -> None:
+    _, args = _parse("--n-bits", "4", "--group-size", "16")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert caplog.text == ""
+
+
+def test_no_warning_for_dtype_in_full_mode(caplog: pytest.LogCaptureFixture) -> None:
+    _, args = _parse("--full", "--dtype", "float16")
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert caplog.text == ""
+
+
+def test_no_warning_when_nothing_mode_specific_is_passed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    for argv in ((), ("--full",)):
+        _, args = _parse(*argv)
+        with caplog.at_level(logging.WARNING):
+            _warn_unused_flags(args)
+        assert caplog.text == "", f"unexpected warning for {argv}"


### PR DESCRIPTION
## Summary

To be more consistent with the other non-LLM export scripts and for better CLI argument parsing, this PR makes the following changes:

1. `model` is no longer a positional argument, but a `--model` flag with `facebook/sam3` as the default. Users can omit this flag with the same behavior as before, or include it but must use the `--model` keyword. 
2. Streamline the supported variant lookup. 
3. Fix `_warn_unused_flags`, which prints which flags are ignored depending on whether the default "lite" SAM3 is exported or `--full` (vanilla HF version) is passed.
4. New Python unit tests for CLI arg parsing

**NOTE:** There are no functional changes in this PR, besides these CLI argument updates.