### PR TITLE
Propagate GPU sampler errors through completion callbacks

### DIFF
--- a/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
+++ b/swift/Sources/CoreAILanguageModels/InferenceEngines/CoreAIPipelinedEngine.swift
@@ -975,23 +975,27 @@ private struct EngineImpl: ~Copyable {
         let sampleSpan = InstrumentsProfiler.beginSampleEncoding(
             step: currentStep, strategy: samplerStrategy, temperature: samplerTemperature)
 
-        do {
-            let queue = pipelineQueue
-            let localInFlightGate = inFlightGate
-            let completionCallback: (Int32) -> Void = { nextToken in
-                // Release the pipeline slot acquired before encode. Happens on
-                // Metal's callback thread — PipelineGate.release() is thread-safe.
-                localInFlightGate.release()
-                InstrumentsProfiler.endCustomInterval(
-                    name: "CoreAIPipelinedEncodeNextStep",
-                    signpostID: encodeStepID,
-                    details: "token=\(nextToken)"
-                )
-                continuation.yield(nextToken)
+        let queue = pipelineQueue
+        let localInFlightGate = inFlightGate
+        let completionCallback: (Int32, Error?) -> Void = { nextToken, error in
+            // Release the pipeline slot acquired before encode. Happens on
+            // Metal's callback thread — PipelineGate.release() is thread-safe.
+            localInFlightGate.release()
+            InstrumentsProfiler.endCustomInterval(
+                name: "CoreAIPipelinedEncodeNextStep",
+                signpostID: encodeStepID,
+                details: "token=\(nextToken)"
+            )
+            if let error {
+                continuation.finish(throwing: error)
+                return
             }
+            continuation.yield(nextToken)
+        }
 
+        do {
             if queryLength == 1 {
-                localGPUSampler.encode(
+                try localGPUSampler.encode(
                     to: queue,
                     logitsBuffer: samplerLogitsBuffer,
                     logitsOffset: logitsOffset,
@@ -1009,6 +1013,15 @@ private struct EngineImpl: ~Copyable {
                     completion: completionCallback
                 )
             }
+        } catch {
+            localInFlightGate.release()
+            InstrumentsProfiler.endCustomInterval(
+                name: "CoreAIPipelinedEncodeNextStep",
+                signpostID: encodeStepID,
+                details: "error"
+            )
+            sampleSpan.end()
+            throw error
         }
 
         sampleSpan.end()
@@ -1222,8 +1235,12 @@ private struct EngineImpl: ~Copyable {
                     tokens: prefillTokens,
                     gpuSampler: gpuSampler,
                     applyBitmask: applyInitialMask
-                ) { token in
-                    cont.resume(returning: token)
+                ) { token, error in
+                    if let error = error {
+                        cont.resume(throwing: error)
+                    } else {
+                        cont.resume(returning: token)
+                    }
                 }
             } catch {
                 cont.resume(throwing: error)
@@ -1259,8 +1276,12 @@ private struct EngineImpl: ~Copyable {
                             tokens: [lastToken] + jumpTokens,
                             gpuSampler: gpuSampler,
                             applyBitmask: applyMaskAfterJump
-                        ) { token in
-                            cont.resume(returning: token)
+                        ) { token, error in
+                            if let error = error {
+                                cont.resume(throwing: error)
+                            } else {
+                                cont.resume(returning: token)
+                            }
                         }
                     } catch {
                         cont.resume(throwing: error)
@@ -1289,8 +1310,12 @@ private struct EngineImpl: ~Copyable {
                         tokens: [],
                         gpuSampler: gpuSampler,
                         applyBitmask: applyMask
-                    ) { token in
-                        cont.resume(returning: token)
+                    ) { token, error in
+                        if let error = error {
+                            cont.resume(throwing: error)
+                        } else {
+                            cont.resume(returning: token)
+                        }
                     }
                 } catch {
                     cont.resume(throwing: error)
@@ -1368,7 +1393,7 @@ private struct EngineImpl: ~Copyable {
         tokens: [Int32],
         gpuSampler: any MPSGraphSampler,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) throws {
         let actualTokenCount = tokens.isEmpty ? 1 : tokens.count
         let queryLength = actualTokenCount
@@ -1459,7 +1484,7 @@ private struct EngineImpl: ~Copyable {
         let queue = pipelineQueue
 
         if queryLength == 1 {
-            gpuSampler.encode(
+            try gpuSampler.encode(
                 to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                 outputBuffer: outputBuffer, outputOffset: 0,
                 applyBitmask: applyBitmask, completion: completion
@@ -1673,14 +1698,20 @@ private struct EngineImpl: ~Copyable {
 
             do {
                 let queue = pipelineQueue
-                warmupSampler.encode(
+                var error: Error?
+                try warmupSampler.encode(
                     to: queue,
                     logitsBuffer: warmupLogitsBuffer,
                     logitsOffset: logitsOffset,
                     outputBuffer: warmupOutputBuffer,
                     outputOffset: 0,
-                    completion: { _ in }
+                    completion: { _, e in
+                        error = e
+                    }
                 )
+                if let error {
+                    throw error
+                }
             }
 
             step += 1

--- a/swift/Sources/CoreAILanguageModels/Samplers/MPSGraphSamplers.swift
+++ b/swift/Sources/CoreAILanguageModels/Samplers/MPSGraphSamplers.swift
@@ -61,8 +61,8 @@ protocol MPSGraphSampler: AnyObject, Sendable {
         outputBuffer: MTLBuffer,
         outputOffset: Int,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
-    )
+        completion: @escaping (Int32, Error?) -> Void
+    ) throws
 
     /// Encode sampling with slice support for prefill.
     func encodeWithSlice(
@@ -71,7 +71,7 @@ protocol MPSGraphSampler: AnyObject, Sendable {
         queryLength: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     )
 }
 
@@ -84,9 +84,9 @@ extension MPSGraphSampler {
         logitsOffset: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
-    ) {
-        encode(
+        completion: @escaping (Int32, Error?) -> Void
+    ) throws {
+        try encode(
             to: queue, logitsBuffer: logitsBuffer, logitsOffset: logitsOffset,
             outputBuffer: outputBuffer, outputOffset: outputOffset,
             applyBitmask: false, completion: completion)
@@ -385,11 +385,11 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         outputBuffer: MTLBuffer,
         outputOffset: Int,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
-    ) {
+        completion: @escaping (Int32, Error?) -> Void
+    ) throws {
         if applyBitmask {
             guard let (constrained, bitmaskTensorData) = try? ensureConstrainedResources() else {
-                completion(0)
+                completion(0, MPSGraphSamplerError.bufferAllocationFailed)
                 return
             }
             let inputData = MPSGraphTensorData(
@@ -399,14 +399,13 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
             let execDesc = MPSGraphExecutableExecutionDescriptor()
             execDesc.completionHandler = { [outputBuffer, outputOffset] (_, error) in
                 if let error = error {
-                    print("MPSGraph constrained argmax error: \(error)")
-                    completion(0)
+                    completion(0, error)
                     return
                 }
                 let result = outputBuffer.contents()
                     .advanced(by: outputOffset)
                     .assumingMemoryBound(to: Int32.self).pointee
-                completion(result)
+                completion(result, nil)
             }
             constrained.runAsync(
                 with: queue, inputs: [inputData, bitmaskTensorData],
@@ -427,13 +426,17 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         outputBuffer: MTLBuffer,
         outputOffset: Int,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         if queryLength == 1 {
-            encode(
-                to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
-                outputBuffer: outputBuffer, outputOffset: outputOffset,
-                applyBitmask: applyBitmask, completion: completion)
+            do {
+                try encode(
+                    to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
+                    outputBuffer: outputBuffer, outputOffset: outputOffset,
+                    applyBitmask: applyBitmask, completion: completion)
+            } catch {
+                completion(0, error)
+            }
             return
         }
         // For prefill with bitmask, slice last token then apply constrained path
@@ -443,7 +446,7 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
             let blitCmdBuffer = queue.makeCommandBuffer(),
             let blitEncoder = blitCmdBuffer.makeBlitCommandEncoder()
         else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitEncoder.copy(
@@ -452,10 +455,14 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         blitEncoder.endEncoding()
         blitCmdBuffer.commit()
 
-        encode(
-            to: queue, logitsBuffer: tempBuffer, logitsOffset: 0,
-            outputBuffer: outputBuffer, outputOffset: outputOffset,
-            applyBitmask: applyBitmask, completion: completion)
+        do {
+            try encode(
+                to: queue, logitsBuffer: tempBuffer, logitsOffset: 0,
+                outputBuffer: outputBuffer, outputOffset: outputOffset,
+                applyBitmask: applyBitmask, completion: completion)
+        } catch {
+            completion(0, error)
+        }
     }
 
     /// Encode argmax sampling.
@@ -476,7 +483,7 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         logitsOffset: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         // Reuse MPSGraphTensorData if buffers haven't changed (avoids object creation overhead)
         let inputData: MPSGraphTensorData
@@ -508,9 +515,8 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         // Reuse pre-allocated execution descriptor, update completion handler
         let execDescriptor = MPSGraphExecutableExecutionDescriptor()
         execDescriptor.completionHandler = { [outputBuffer, outputOffset] (resultsDictionary, error) in
-            if let error = error {
-                print("MPSGraph argmax error: \(error)")
-                completion(0)
+            if error != nil {
+                completion(0, error)
                 return
             }
 
@@ -519,7 +525,7 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
                 .advanced(by: outputOffset)
                 .assumingMemoryBound(to: Int32.self)
                 .pointee
-            completion(result)
+            completion(result, nil)
         }
 
         executable.runAsync(
@@ -548,7 +554,7 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         queryLength: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         // Calculate offset to last token's logits
         let logitsOffset = (queryLength - 1) * vocabSize * MemoryLayout<UInt16>.size
@@ -573,19 +579,19 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
         // Create a temporary buffer for the single token's logits
         let sliceSize = vocabSize * MemoryLayout<UInt16>.size
         guard let tempBuffer = device.makeBuffer(length: sliceSize, options: .storageModeShared) else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
 
         // Step 1: Create and commit blit command buffer separately
         guard let blitCmdBuffer = queue.makeCommandBuffer() else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitCmdBuffer.label = "MPSGraph Argmax Blit"
 
         guard let blitEncoder = blitCmdBuffer.makeBlitCommandEncoder() else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitEncoder.copy(
@@ -611,12 +617,10 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
             dataType: .int32
         )
 
-        // Set up execution descriptor with completion handler
         let execDescriptor = MPSGraphExecutableExecutionDescriptor()
         execDescriptor.completionHandler = { [outputBuffer, outputOffset] (_, error) in
-            if let error = error {
-                print("MPSGraph argmax error: \(error)")
-                completion(0)
+            if error != nil {
+                completion(0, error)
                 return
             }
 
@@ -624,7 +628,7 @@ final class MPSGraphArgmaxSampler: @unchecked Sendable {
                 .advanced(by: outputOffset)
                 .assumingMemoryBound(to: Int32.self)
                 .pointee
-            completion(result)
+            completion(result, nil)
         }
 
         // Run async - GPU naturally orders this after the blit due to queue ordering
@@ -1002,11 +1006,11 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         outputBuffer: MTLBuffer,
         outputOffset: Int,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
-    ) {
+        completion: @escaping (Int32, Error?) -> Void
+    ) throws {
         if applyBitmask {
             guard let (constrained, bitmaskTensorData) = try? ensureConstrainedResources() else {
-                completion(0)
+                completion(0, MPSGraphSamplerError.bufferAllocationFailed)
                 return
             }
             temperatureBuffer.contents().assumingMemoryBound(to: Float.self).pointee = max(temperature, 0.01)
@@ -1022,14 +1026,13 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
             let execDesc = MPSGraphExecutableExecutionDescriptor()
             execDesc.completionHandler = { [outputBuffer, outputOffset] (_, error) in
                 if let error = error {
-                    print("MPSGraph constrained composite error: \(error)")
-                    completion(0)
+                    completion(0, error)
                     return
                 }
                 let result = outputBuffer.contents()
                     .advanced(by: outputOffset)
                     .assumingMemoryBound(to: Int32.self).pointee
-                completion(result)
+                completion(result, nil)
             }
             constrained.runAsync(
                 with: queue,
@@ -1051,10 +1054,10 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         outputBuffer: MTLBuffer,
         outputOffset: Int,
         applyBitmask: Bool,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         if queryLength == 1 {
-            encode(
+            try? encode(
                 to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                 outputBuffer: outputBuffer, outputOffset: outputOffset,
                 applyBitmask: applyBitmask, completion: completion)
@@ -1066,7 +1069,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
             let blitCmdBuffer = queue.makeCommandBuffer(),
             let blitEncoder = blitCmdBuffer.makeBlitCommandEncoder()
         else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitEncoder.copy(
@@ -1075,7 +1078,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         blitEncoder.endEncoding()
         blitCmdBuffer.commit()
 
-        encode(
+        try? encode(
             to: queue, logitsBuffer: tempBuffer, logitsOffset: 0,
             outputBuffer: outputBuffer, outputOffset: outputOffset,
             applyBitmask: applyBitmask, completion: completion)
@@ -1088,7 +1091,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         logitsOffset: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         // Write runtime values to buffers
         temperatureBuffer.contents().assumingMemoryBound(to: Float.self).pointee = max(temperature, 0.01)
@@ -1125,13 +1128,10 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
             cachedOutputBuffer = outputBuffer
         }
 
-        // Per-call descriptor — reusing one across pipelined steps corrupts
-        // intermediate scratch buffers when multiple runAsync calls overlap.
         let desc = MPSGraphExecutableExecutionDescriptor()
         desc.completionHandler = { [outputBuffer, outputOffset] (_, error) in
-            if let error = error {
-                print("MPSGraph composite sampler error: \(error)")
-                completion(0)
+            if error != nil {
+                completion(0, error)
                 return
             }
 
@@ -1139,7 +1139,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
                 .advanced(by: outputOffset)
                 .assumingMemoryBound(to: Int32.self)
                 .pointee
-            completion(result)
+            completion(result, nil)
         }
 
         executable.runAsync(
@@ -1157,7 +1157,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         queryLength: Int,
         outputBuffer: MTLBuffer,
         outputOffset: Int,
-        completion: @escaping (Int32) -> Void
+        completion: @escaping (Int32, Error?) -> Void
     ) {
         if queryLength == 1 {
             encode(
@@ -1175,18 +1175,18 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
         let sliceSize = vocabSize * MemoryLayout<UInt16>.size
 
         guard let tempBuffer = device.makeBuffer(length: sliceSize, options: .storageModeShared) else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
 
         guard let blitCmdBuffer = queue.makeCommandBuffer() else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitCmdBuffer.label = "MPSGraph Composite Blit"
 
         guard let blitEncoder = blitCmdBuffer.makeBlitCommandEncoder() else {
-            completion(0)
+            completion(0, MPSGraphSamplerError.bufferAllocationFailed)
             return
         }
         blitEncoder.copy(
@@ -1211,9 +1211,8 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
 
         let prefillExecDescriptor = MPSGraphExecutableExecutionDescriptor()
         prefillExecDescriptor.completionHandler = { [outputBuffer, outputOffset] (_, error) in
-            if let error = error {
-                print("MPSGraph composite sampler error: \(error)")
-                completion(0)
+            if error != nil {
+                completion(0, error)
                 return
             }
 
@@ -1221,7 +1220,7 @@ final class MPSGraphCompositeSampler: @unchecked Sendable {
                 .advanced(by: outputOffset)
                 .assumingMemoryBound(to: Int32.self)
                 .pointee
-            completion(result)
+            completion(result, nil)
         }
 
         executable.runAsync(

--- a/swift/Tests/LanguageModelsTests/CoreAIPipelinedTests.swift
+++ b/swift/Tests/LanguageModelsTests/CoreAIPipelinedTests.swift
@@ -481,7 +481,7 @@ struct GPUSamplerContinuationSyncTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { nextToken in
+                completion: { nextToken, _ in
                     let task = Task {
                         for await _ in proceedStream { break }
                         continuation.yield(nextToken)
@@ -522,7 +522,7 @@ struct GPUSamplerContinuationSyncTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { nextToken in
+                completion: { nextToken, _ in
                     continuation.yield(nextToken)
                     earlyDoneContinuation.yield(())
                 }
@@ -548,7 +548,7 @@ struct GPUSamplerContinuationSyncTests {
                 logitsOffset: 0,
                 outputBuffer: lastOutput,
                 outputOffset: 0,
-                completion: { nextToken in
+                completion: { nextToken, _ in
                     let task = Task {
                         for await _ in proceedStream { break }
                         continuation.yield(nextToken)
@@ -590,7 +590,7 @@ struct GPUSamplerContinuationSyncTests {
             logitsOffset: 0,
             outputBuffer: outputBuffer,
             outputOffset: 0,
-            completion: { nextToken in
+            completion: { nextToken, _ in
                 continuation.yield(nextToken)
             }
         )
@@ -631,7 +631,7 @@ struct GPUSamplerContinuationSyncTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { nextToken in
+                completion: { nextToken, _ in
                     continuation.yield(nextToken)
                 }
             )

--- a/swift/Tests/LanguageModelsTests/MPSGraphSamplerTests.swift
+++ b/swift/Tests/LanguageModelsTests/MPSGraphSamplerTests.swift
@@ -46,7 +46,7 @@ struct MPSGraphArgmaxSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -79,7 +79,7 @@ struct MPSGraphArgmaxSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -117,7 +117,7 @@ struct MPSGraphArgmaxSamplerTests {
                 queryLength: queryLength,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -146,7 +146,7 @@ struct MPSGraphArgmaxSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -164,7 +164,7 @@ struct MPSGraphArgmaxSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -203,7 +203,7 @@ struct MPSGraphArgmaxSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -224,7 +224,7 @@ struct MPSGraphArgmaxSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -277,7 +277,7 @@ struct MPSGraphCompositeSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -327,7 +327,7 @@ struct MPSGraphCompositeSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -377,7 +377,7 @@ struct MPSGraphCompositeSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -423,7 +423,7 @@ struct MPSGraphCompositeSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -441,7 +441,7 @@ struct MPSGraphCompositeSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in
+                    completion: { _, _ in
                         continuation.resume()
                     }
                 )
@@ -491,7 +491,7 @@ struct MPSGraphCompositeSamplerTests {
                 queryLength: queryLength,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in
+                completion: { _, _ in
                     continuation.resume()
                 }
             )
@@ -543,7 +543,7 @@ struct MPSGraphTopPSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in continuation.resume() }
+                    completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -581,7 +581,7 @@ struct MPSGraphTopPSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in continuation.resume() }
+                completion: { _, _ in continuation.resume() }
             )
         }
 
@@ -617,7 +617,7 @@ struct MPSGraphTopPSamplerTests {
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
-                completion: { _ in continuation.resume() }
+                completion: { _, _ in continuation.resume() }
             )
         }
 
@@ -666,7 +666,7 @@ struct MPSGraphMinPSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in continuation.resume() }
+                    completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -708,7 +708,7 @@ struct MPSGraphMinPSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in continuation.resume() }
+                    completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -755,7 +755,7 @@ struct MPSGraphMinPSamplerTests {
                     logitsOffset: 0,
                     outputBuffer: outputBuffer,
                     outputOffset: 0,
-                    completion: { _ in continuation.resume() }
+                    completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee

--- a/swift/Tests/LanguageModelsTests/MPSGraphSamplerTests.swift
+++ b/swift/Tests/LanguageModelsTests/MPSGraphSamplerTests.swift
@@ -40,7 +40,7 @@ struct MPSGraphArgmaxSamplerTests {
         let queue = try #require(device.makeCommandQueue())
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -73,7 +73,7 @@ struct MPSGraphArgmaxSamplerTests {
         let queue = try #require(device.makeCommandQueue())
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -140,7 +140,7 @@ struct MPSGraphArgmaxSamplerTests {
         // Warm up
         for _ in 0..<10 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -158,7 +158,7 @@ struct MPSGraphArgmaxSamplerTests {
         let start = SuspendingClock().now
         for _ in 0..<iterations {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -197,7 +197,7 @@ struct MPSGraphArgmaxSamplerTests {
         }
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -218,7 +218,7 @@ struct MPSGraphArgmaxSamplerTests {
         }
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -271,7 +271,7 @@ struct MPSGraphCompositeSamplerTests {
         var sampledTokens = Set<Int32>()
         for _ in 0..<20 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -321,7 +321,7 @@ struct MPSGraphCompositeSamplerTests {
         sampler.testingOnlyRandomOverride = 0.5
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -371,7 +371,7 @@ struct MPSGraphCompositeSamplerTests {
             sampler.testingOnlyRandomOverride = randomValue
 
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -417,7 +417,7 @@ struct MPSGraphCompositeSamplerTests {
         // Warm up
         for _ in 0..<10 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -435,7 +435,7 @@ struct MPSGraphCompositeSamplerTests {
         let start = SuspendingClock().now
         for _ in 0..<iterations {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -537,7 +537,7 @@ struct MPSGraphTopPSamplerTests {
         var sampledTokens = Set<Int32>()
         for _ in 0..<30 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -575,7 +575,7 @@ struct MPSGraphTopPSamplerTests {
 
         sampler.testingOnlyRandomOverride = 0.5
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -611,7 +611,7 @@ struct MPSGraphTopPSamplerTests {
         // With topP=0.01 and a dominant token, should always pick the top one
         sampler.testingOnlyRandomOverride = 0.005
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
@@ -660,7 +660,7 @@ struct MPSGraphMinPSamplerTests {
         var sampledTokens = Set<Int32>()
         for _ in 0..<30 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -702,7 +702,7 @@ struct MPSGraphMinPSamplerTests {
         for r in randomValues {
             sampler.testingOnlyRandomOverride = r
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -749,7 +749,7 @@ struct MPSGraphMinPSamplerTests {
         for r in randomValues {
             sampler.testingOnlyRandomOverride = r
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue,
                     logitsBuffer: logitsBuffer,
                     logitsOffset: 0,
@@ -857,14 +857,14 @@ struct MPSGraphConstrainedArgmaxTests {
         let queue = try #require(device.makeCommandQueue())
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue,
                 logitsBuffer: logitsBuffer,
                 logitsOffset: 0,
                 outputBuffer: outputBuffer,
                 outputOffset: 0,
                 applyBitmask: true,
-                completion: { _ in continuation.resume() }
+                completion: { _, _ in continuation.resume() }
             )
         }
 
@@ -892,19 +892,19 @@ struct MPSGraphConstrainedArgmaxTests {
         let queue = try #require(device.makeCommandQueue())
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                 outputBuffer: outputBuffer, outputOffset: 0,
-                applyBitmask: true, completion: { _ in continuation.resume() }
+                applyBitmask: true, completion: { _, _ in continuation.resume() }
             )
         }
         let constrainedResult = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                 outputBuffer: outputBuffer, outputOffset: 0,
-                applyBitmask: false, completion: { _ in continuation.resume() }
+                applyBitmask: false, completion: { _, _ in continuation.resume() }
             )
         }
         let unconstrainedResult = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -939,10 +939,10 @@ struct MPSGraphConstrainedArgmaxTests {
         let queue = try #require(device.makeCommandQueue())
 
         await withCheckedContinuation { continuation in
-            sampler.encode(
+            try! sampler.encode(
                 to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                 outputBuffer: outputBuffer, outputOffset: 0,
-                applyBitmask: true, completion: { _ in continuation.resume() }
+                applyBitmask: true, completion: { _, _ in continuation.resume() }
             )
         }
 
@@ -982,10 +982,10 @@ struct MPSGraphConstrainedCompositeTests {
         var sampledTokens = Set<Int32>()
         for _ in 0..<20 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                     outputBuffer: outputBuffer, outputOffset: 0,
-                    applyBitmask: true, completion: { _ in continuation.resume() }
+                    applyBitmask: true, completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -1025,10 +1025,10 @@ struct MPSGraphConstrainedCompositeTests {
         var sampledTokens = Set<Int32>()
         for _ in 0..<50 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                     outputBuffer: outputBuffer, outputOffset: 0,
-                    applyBitmask: true, completion: { _ in continuation.resume() }
+                    applyBitmask: true, completion: { _, _ in continuation.resume() }
                 )
             }
             let result = outputBuffer.contents().assumingMemoryBound(to: Int32.self).pointee
@@ -1059,10 +1059,10 @@ struct MPSGraphConstrainedCompositeTests {
 
         for _ in 0..<10 {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                     outputBuffer: outputBuffer, outputOffset: 0,
-                    applyBitmask: true, completion: { _ in continuation.resume() }
+                    applyBitmask: true, completion: { _, _ in continuation.resume() }
                 )
             }
         }
@@ -1071,10 +1071,10 @@ struct MPSGraphConstrainedCompositeTests {
         let start = SuspendingClock().now
         for _ in 0..<iterations {
             await withCheckedContinuation { continuation in
-                sampler.encode(
+                try! sampler.encode(
                     to: queue, logitsBuffer: logitsBuffer, logitsOffset: 0,
                     outputBuffer: outputBuffer, outputOffset: 0,
-                    applyBitmask: true, completion: { _ in continuation.resume() }
+                    applyBitmask: true, completion: { _, _ in continuation.resume() }
                 )
             }
         }


### PR DESCRIPTION
GPU sampler completion handlers previously swallowed errors with `print()` + `completion(0)`, silently yielding garbage token 0 on failure.

Changes:
- Completion callback: `(Int32) -> Void` becomes `(Int32, Error?) -> Void`
- Protocol `encode()` now throws for synchronous failures
- `encodeWithSlice` early-exit errors pass typed `MPSGraphSamplerError`
- Pipelined engine propagates sampler errors to the generation stream