### PR TITLE
Default to release mode for exporting, with --include-debug-info opt-in

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -88,6 +88,53 @@ uv run coreai.llm.export Qwen/Qwen3-0.6B --max-context-length 4096
 uv run coreai.llm.export Qwen/Qwen3-0.6B --platform iOS --max-context-length 4096
 ```
 
+#### Debug Information
+
+Exports default to the converter's `RELEASE` mode, which embeds minimum debug information in the exported `.aimodel`. This keeps assets as small as possible and is what you want for anything you ship.
+
+Pass `--include-debug-info` to switch the converter to `DEBUG` mode, which embeds full debug information in the exported `.aimodel`. That's worth doing when you're diagnosing a conversion — wrong numerics, an op that fails to lower, or a graph you need to map back to Python source:
+
+```bash
+uv run coreai.llm.export Qwen/Qwen3-0.6B --include-debug-info
+```
+
+The flag is available on `coreai.llm.export`, `coreai.vlm.export`, `coreai.diffusion.export`, `coreai.segmentation.export`, and every standalone `models/<name>/export.py` recipe, so all export paths produce assets carrying the same debug information by default.
+
+**Note:** `--include-debug-info` is independent of `--verbose`/`-v`. `--verbose` only raises the console log level; it does not change what goes into the asset.
+
+You don't need to re-export to shed debug information from an asset you already converted. Load it, strip the debug information in place, and save it back out:
+
+```python
+from pathlib import Path
+
+from coreai.authoring import AIModelAsset
+from coreai_torch.debugging.debug_info import strip_debug_info
+
+source = AIModelAsset.load("inputModel.aimodel")
+
+# `save_asset` writes only what the program carries, so capture the curated
+# metadata first — it lives on the asset, not on the program.
+metadata = source.metadata
+author, license_, description = metadata.author, metadata.license, metadata.model_description
+
+program = source.program
+strip_debug_info(program)  # modifies the program in place
+program.save_asset(Path("outputModel.aimodel"))  # save_asset requires a Path
+
+# Re-attach it, otherwise `author`, `license` and `description` are lost.
+AIModelAsset.load("outputModel.aimodel").update_metadata(
+    lambda m: (
+        setattr(m, "author", author),
+        setattr(m, "license", license_),
+        setattr(m, "model_description", description),
+    )
+)
+```
+
+`outputModel.aimodel` then carries the same minimum debug information a default `RELEASE` export would produce.
+
+**Note:** the re-attach step is not optional bookkeeping. `program.save_asset()` persists only `creationDate`, `assetVersion` and `producer`; without it the round-trip silently drops the model's `author`, `license` and `description`, so a shipped asset would lose its attribution and license. The metadata attribute is `model_description`, even though the key serialized into `metadata.json` is `description`. `creationDate` is always reset to the time of the save.
+
 ### Diffusion Models
 
 ```bash
@@ -113,6 +160,7 @@ Models with a standalone `export.py` are run directly:
 
 ```bash
 uv run models/<name>/export.py
+uv run models/<name>/export.py --include-debug-info   # embed debug information in exported .aimodel
 ```
 
 ## Model Catalog
@@ -164,7 +212,7 @@ To make a new model exportable via short-name, add a `ModelPreset(...)` entry to
 
 For models with bespoke export logic that doesn't fit the standard `coreai.llm.export` / `coreai.diffusion.export` flow, write a standalone recipe under `models/<name>/export.py` — see existing recipes for the [PEP 723](https://peps.python.org/pep-0723/) pattern and `models/README.md` for the contribution checklist.
 
-- `export.py` — Standalone conversion script with [PEP 723](https://peps.python.org/pep-0723/) inline dependencies.
+- `export.py` — Standalone conversion script with [PEP 723](https://peps.python.org/pep-0723/) inline dependencies. It must accept a `--include-debug-info` flag and construct its `TorchConverter` with `TorchConverter.Mode.RELEASE` by default, so that every export path in the repo produces assets with the same debug information. See [Debug Information](#debug-information).
 - `README.md` — Model introduction, export recipe and example Swift code to make app integration easier.
 
 For models that fit the standard `coreai.llm.export` or `coreai.diffusion.export` pipeline, add a `ModelPreset` entry to [`model_registry.py`](../python/src/coreai_models/model_registry.py) instead.

--- a/models/clap/export.py
+++ b/models/clap/export.py
@@ -133,6 +133,7 @@ def create_clap(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = ClapModule(model_name)
@@ -150,7 +151,10 @@ def create_clap(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["input_ids", "attention_mask", "input_features", "is_longer"],
         output_names=[
@@ -201,6 +205,12 @@ def main():
         action="store_true",
         help="Export with dynamic batch size.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -215,6 +225,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/clip/export.py
+++ b/models/clip/export.py
@@ -139,6 +139,7 @@ def create_clip(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = ClipModule(model_name)
@@ -156,7 +157,10 @@ def create_clip(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["pixel_values", "input_ids", "attention_mask"],
         output_names=[
@@ -207,6 +211,12 @@ def main():
         action="store_true",
         help="Export with dynamic batch size.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -222,6 +232,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/depth-anything/export.py
+++ b/models/depth-anything/export.py
@@ -128,6 +128,7 @@ def create_depth_anything(
     model_name: str,
     dtype: torch.dtype,
     overwrite: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = DepthAnythingModule(model_name)
@@ -145,7 +146,10 @@ def create_depth_anything(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["image"],
         output_names=["depth", "depth_conf", "extrinsics", "intrinsics"],
@@ -186,6 +190,12 @@ def main():
         action="store_true",
         help="Overwrite an existing .aimodel asset at the output path.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -198,6 +208,7 @@ def main():
         args.model,
         dtype,
         args.overwrite,
+        args.include_debug_info,
     )
 
 

--- a/models/edsr/export.py
+++ b/models/edsr/export.py
@@ -94,6 +94,7 @@ def create_edsr(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = torchsr.models.edsr_r16f64(scale=2, pretrained=True)
@@ -111,7 +112,10 @@ def create_edsr(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["x"],
         output_names=["output"],
@@ -157,6 +161,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -172,6 +182,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/efficient-sam/export.py
+++ b/models/efficient-sam/export.py
@@ -132,6 +132,7 @@ def create_efficient_sam(
     dynamic: bool,
     num_queries: int,
     num_pts: int,
+    include_debug_info: bool,
 ):
     if dynamic and dtype == torch.float16:
         raise ValueError(
@@ -170,7 +171,10 @@ def create_efficient_sam(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["batched_images", "batched_points", "batched_point_labels"],
         output_names=["pred_masks", "iou_scores"],
@@ -242,6 +246,12 @@ def main():
             "bottom-right). Higher values support combined point+box prompts."
         ),
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -259,6 +269,7 @@ def main():
         args.dynamic,
         args.num_queries,
         args.num_pts,
+        args.include_debug_info,
     )
 
 

--- a/models/parakeet/export.py
+++ b/models/parakeet/export.py
@@ -176,6 +176,7 @@ def _convert(
     input_names: list[str],
     output_names: list[str],
     dtype: torch.dtype,
+    include_debug_info: bool,
     dynamic_shapes: dict | None = None,
 ):
     module.eval()
@@ -187,7 +188,10 @@ def _convert(
             dynamic_shapes=dynamic_shapes,
         )
     exported = exported.run_decompositions(get_decomp_table())
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=input_names,
         output_names=output_names,
@@ -297,6 +301,7 @@ def create_parakeet(
     overwrite: bool,
     dynamic: bool,
     audio_seconds: float,
+    include_debug_info: bool,
 ):
     print(f"[INFO] Sourcing {model_name}...")
     model = transformers.AutoModelForTDT.from_pretrained(
@@ -327,6 +332,7 @@ def create_parakeet(
         input_names=["input_features", "attention_mask"],
         output_names=["encoder_hidden_states"],
         dtype=dtype,
+        include_debug_info=include_debug_info,
         dynamic_shapes=_encoder_dynamic_shapes() if dynamic else None,
     )
     _save_program(encoder_program, assets[ENCODER_GRAPH], ENCODER_GRAPH)
@@ -338,6 +344,7 @@ def create_parakeet(
         input_names=["input_ids", "hidden_state", "cell_state"],
         output_names=["decoder_output", "new_hidden_state", "new_cell_state"],
         dtype=dtype,
+        include_debug_info=include_debug_info,
     )
     _save_program(decoder_program, assets[DECODER_STEP_GRAPH], DECODER_STEP_GRAPH)
 
@@ -348,6 +355,7 @@ def create_parakeet(
         input_names=["decoder_hidden_states", "encoder_hidden_states"],
         output_names=["logits"],
         dtype=dtype,
+        include_debug_info=include_debug_info,
     )
     _save_program(joint_program, assets[JOINT_GRAPH], JOINT_GRAPH)
 
@@ -402,6 +410,12 @@ def main():
             "trace. Ignored when --dynamic is set."
         ),
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -417,6 +431,7 @@ def main():
         args.overwrite,
         args.dynamic,
         args.audio_seconds,
+        args.include_debug_info,
     )
 
 

--- a/models/pvt/export.py
+++ b/models/pvt/export.py
@@ -92,6 +92,7 @@ def create_pvt(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = timm.create_model(model_name, pretrained=True)
@@ -109,7 +110,10 @@ def create_pvt(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["x"],
         output_names=["logits"],
@@ -155,6 +159,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -170,6 +180,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/roberta/export.py
+++ b/models/roberta/export.py
@@ -95,6 +95,7 @@ def create_roberta(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = transformers.RobertaModel.from_pretrained(
@@ -114,7 +115,10 @@ def create_roberta(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["input_ids"],
         output_names=["last_hidden_state"],
@@ -160,6 +164,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -175,6 +185,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/t5/export.py
+++ b/models/t5/export.py
@@ -135,6 +135,7 @@ def create_t5(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = T5Module(model_name)
@@ -152,7 +153,10 @@ def create_t5(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["input_ids", "decoder_input_ids"],
         output_names=["logits", "encoder_last_hidden_state"],
@@ -198,6 +202,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -212,6 +222,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/wav2vec2/export.py
+++ b/models/wav2vec2/export.py
@@ -102,6 +102,7 @@ def create_wav2vec2(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = Wav2Vec2Module()
@@ -119,7 +120,10 @@ def create_wav2vec2(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["waveform"],
         output_names=["emission"],
@@ -165,6 +169,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -179,6 +189,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/models/whisper/export.py
+++ b/models/whisper/export.py
@@ -99,6 +99,7 @@ def create_whisper(
     model_name: str,
     dtype: torch.dtype,
     overwrite: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = WhisperModule(model_name, dtype)
@@ -121,7 +122,10 @@ def create_whisper(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["input_features", "decoder_input_ids"],
         output_names=["logits"],
@@ -162,6 +166,12 @@ def main():
         action="store_true",
         help="Overwrite an existing .aimodel asset at the output path.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -171,7 +181,9 @@ def main():
     }[args.dtype]
 
     output_dir = args.output_dir or _default_output_dir()
-    create_whisper(output_dir, args.model, dtype, args.overwrite)
+    create_whisper(
+        output_dir, args.model, dtype, args.overwrite, args.include_debug_info
+    )
 
 
 if __name__ == "__main__":

--- a/models/yolo/export.py
+++ b/models/yolo/export.py
@@ -110,6 +110,7 @@ def create_yolos(
     dtype: torch.dtype,
     overwrite: bool,
     dynamic: bool,
+    include_debug_info: bool,
 ):
     print("[INFO] Sourcing model...")
     model = YolosModule(model_name)
@@ -127,7 +128,10 @@ def create_yolos(
     exported = exported.run_decompositions(get_decomp_table())
     print("[INFO] Model exported. Converting to Core AI...")
 
-    converter = TorchConverter().add_exported_program(
+    mode = (
+        TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    )
+    converter = TorchConverter(mode=mode).add_exported_program(
         exported_program=exported,
         input_names=["pixel_values"],
         output_names=["logits", "pred_boxes", "last_hidden_state"],
@@ -173,6 +177,12 @@ def main():
         action="store_true",
         help="Export with dynamic input shapes.",
     )
+    parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help="Embed debug information in the exported .aimodel for debugging a conversion. "
+        "Default: off, which embeds minimum debug information and makes the exported asset smaller.",
+    )
     args = parser.parse_args()
 
     dtype = {
@@ -188,6 +198,7 @@ def main():
         dtype,
         args.overwrite,
         args.dynamic,
+        args.include_debug_info,
     )
 
 

--- a/python/src/coreai_models/_constants.py
+++ b/python/src/coreai_models/_constants.py
@@ -52,3 +52,8 @@ VALUE_CACHE_INPUT_NAME = "value_cache"
 KEY_CACHE_OUTPUT_NAME = "new_k_cache"
 VALUE_CACHE_OUTPUT_NAME = "new_v_cache"
 OUTPUT_LOGITS_NAME = "out_logits"
+
+# Whether exports embed debug information into .aimodel. Off by default, which puts
+# the converter in RELEASE mode and embeds minimum debug information. The
+# --include-debug-info flag turns it on (DEBUG mode).
+DEFAULT_INCLUDE_DEBUG_INFO = False

--- a/python/src/coreai_models/diffusion/export.py
+++ b/python/src/coreai_models/diffusion/export.py
@@ -98,6 +98,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the resolved export config and exit without exporting",
     )
     parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help=(
+            "Embed debug information in the exported .aimodel for debugging a conversion. "
+            "Default: off, which embeds minimum debug information and makes the "
+            "exported asset smaller."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -212,19 +221,21 @@ def main() -> None:
         compute_precision=compute_precision,
         compression=compression,
         overwrite=args.overwrite,
+        include_debug_info=args.include_debug_info,
     )
 
     if args.dry_run:
         print("Dry run — resolved export config:")
-        print(f"  model:             {config.hf_model_id}")
-        print(f"  compression:       {config.compression}")
-        print(f"  compute_precision: {config.compute_precision}")
-        print(f"  output_dir:        {config.output_dir}")
+        print(f"  model:              {config.hf_model_id}")
+        print(f"  compression:        {config.compression}")
+        print(f"  compute_precision:  {config.compute_precision}")
+        print(f"  output_dir:         {config.output_dir}")
         if config.components:
-            print(f"  components:        {', '.join(config.components)}")
+            print(f"  components:         {', '.join(config.components)}")
         else:
-            print("  components:        all")
-        print(f"  overwrite:         {config.overwrite}")
+            print("  components:         all")
+        print(f"  overwrite:          {config.overwrite}")
+        print(f"  include_debug_info: {config.include_debug_info}")
         return
 
     try:

--- a/python/src/coreai_models/diffusion/gpu.py
+++ b/python/src/coreai_models/diffusion/gpu.py
@@ -16,6 +16,8 @@ import coreai_torch
 import torch
 from coreai.authoring import AIProgram
 
+from coreai_models._constants import DEFAULT_INCLUDE_DEBUG_INFO
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +26,7 @@ def export_stateless(
     dummy_inputs: tuple[torch.Tensor, ...],
     input_names: tuple[str, ...],
     output_names: tuple[str, ...],
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> AIProgram:
     """Export a stateless model to a Core AI AIProgram.
 
@@ -32,6 +35,9 @@ def export_stateless(
         dummy_inputs: Reference input tensors (positional) for tracing.
         input_names: Names for the exported model's inputs.
         output_names: Names for the exported model's outputs.
+        include_debug_info: When True, the converter runs in ``DEBUG`` mode and embeds debug
+            information in the exported ``.aimodel``. Defaults to ``RELEASE`` mode,
+            which embeds minimum debug information and makes the exported asset smaller.
 
     Returns:
         An optimized AIProgram ready for saving/compilation.
@@ -45,7 +51,13 @@ def export_stateless(
         decomposed: torch.export.ExportedProgram = exported.run_decompositions(coreai_decomp_table)
         return decomposed
 
-    converter = coreai_torch.TorchConverter()
+    converter = coreai_torch.TorchConverter(
+        mode=(
+            coreai_torch.TorchConverter.Mode.DEBUG
+            if include_debug_info
+            else coreai_torch.TorchConverter.Mode.RELEASE
+        )
+    )
     converter.add_pytorch_module(
         wrapper,
         export_fn=export_fn,

--- a/python/src/coreai_models/diffusion/pipeline.py
+++ b/python/src/coreai_models/diffusion/pipeline.py
@@ -27,6 +27,7 @@ import numpy as np
 import torch
 from huggingface_hub import snapshot_download
 
+from coreai_models._constants import DEFAULT_INCLUDE_DEBUG_INFO
 from coreai_models.diffusion.components import get_component_registry
 from coreai_models.diffusion.gpu import export_stateless
 from coreai_models.diffusion.models import get_pipeline_type
@@ -49,6 +50,7 @@ class DiffusionExportConfig:
     compute_precision: str = "float16"
     compression: str = "none"
     overwrite: bool = False
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO
 
 
 def export_diffusion(config: DiffusionExportConfig) -> dict[str, str]:
@@ -108,7 +110,13 @@ async def _async_export_diffusion(config: DiffusionExportConfig) -> dict[str, st
         wrapper = spec.wrapper_fn(hf_pipe)
         dummy_inputs = spec.dummy_fn(hf_pipe)
 
-        program = export_stateless(wrapper, dummy_inputs, spec.input_names, spec.output_names)
+        program = export_stateless(
+            wrapper,
+            dummy_inputs,
+            spec.input_names,
+            spec.output_names,
+            include_debug_info=config.include_debug_info,
+        )
 
         # Optional MLIR quantization
         component_quant = quant_config if spec.quantizable else None

--- a/python/src/coreai_models/export/ios.py
+++ b/python/src/coreai_models/export/ios.py
@@ -22,6 +22,7 @@ from coreai.authoring import AIProgram
 from coreai_torch import TorchConverter
 
 from coreai_models._constants import (
+    DEFAULT_INCLUDE_DEBUG_INFO,
     EXTEND_FUNCTION_NAME,
     GATHER_EMBEDDINGS_FUNCTION_NAME,
     LOAD_EMBEDDINGS_FUNCTION_NAME,
@@ -95,6 +96,7 @@ async def _convert_to_coreai(
     programs: dict[str, torch.export.ExportedProgram],
     config,
     max_context_length: int,
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> AIProgram:
     """Convert the traced programs to one AIProgram with iOS constraints.
 
@@ -114,7 +116,8 @@ async def _convert_to_coreai(
         PROMPT_OPT_FUNCTION_NAME: EXTEND_FUNCTION_NAME,
     }
 
-    converter = TorchConverter()
+    mode = TorchConverter.Mode.DEBUG if include_debug_info else TorchConverter.Mode.RELEASE
+    converter = TorchConverter(mode=mode)
     register_custom_torch_lowering(converter)
     for entrypoint, graph in contract_for.items():
         converter.add_exported_program(
@@ -185,4 +188,5 @@ async def export_ios_model(
         programs=programs,
         config=config,
         max_context_length=max_context_length,
+        include_debug_info=getattr(export_config, "include_debug_info", DEFAULT_INCLUDE_DEBUG_INFO),
     )

--- a/python/src/coreai_models/export/macos.py
+++ b/python/src/coreai_models/export/macos.py
@@ -18,7 +18,11 @@ import coreai_torch.composite_ops
 import torch
 from coreai.authoring import AIProgram
 
-from coreai_models._constants import MAIN_GRAPH_NAME, TRACE_KV_CACHE_SEQ_LEN
+from coreai_models._constants import (
+    DEFAULT_INCLUDE_DEBUG_INFO,
+    MAIN_GRAPH_NAME,
+    TRACE_KV_CACHE_SEQ_LEN,
+)
 from coreai_models.export.mlir_ops import (
     register_custom_torch_lowering,
     remove_functionalization,
@@ -88,6 +92,7 @@ def export_to_coreai(
     input_names: tuple[str, ...] | None = None,
     output_names: tuple[str, ...] | None = None,
     state_names: tuple[str, ...] | None = None,
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> AIProgram:
     """Export a stateful macOS model to a AIProgram.
 
@@ -114,6 +119,9 @@ def export_to_coreai(
         state_names: Names of inputs that are state (i.e. mutated in place by
             the forward pass and surfaced via the runtime ``state=`` kwarg
             rather than as regular inputs/outputs).
+        include_debug_info: When True, the converter runs in ``DEBUG`` mode and embeds debug
+            information in the exported ``.aimodel``. Defaults to ``RELEASE`` mode,
+            which embeds minimum debug information and makes the exported asset smaller.
 
     Returns:
         A AIProgram ready for optimization and compilation.
@@ -140,7 +148,12 @@ def export_to_coreai(
         return coreaten_exported_program
 
     model.eval()
-    converter = coreai_torch.TorchConverter()
+    mode = (
+        coreai_torch.TorchConverter.Mode.DEBUG
+        if include_debug_info
+        else coreai_torch.TorchConverter.Mode.RELEASE
+    )
+    converter = coreai_torch.TorchConverter(mode=mode)
     converter.add_pytorch_module(
         model,
         export_fn=export_fn,
@@ -197,6 +210,7 @@ def export_macos_model(
         input_names=model.export_input_names()[MAIN_GRAPH_NAME],
         output_names=model.export_output_names()[MAIN_GRAPH_NAME],
         state_names=model.export_state_names()[MAIN_GRAPH_NAME],
+        include_debug_info=getattr(export_config, "include_debug_info", DEFAULT_INCLUDE_DEBUG_INFO),
     )
 
     logger.info("Optimizing AIProgram...")

--- a/python/src/coreai_models/export/pipeline.py
+++ b/python/src/coreai_models/export/pipeline.py
@@ -25,6 +25,7 @@ from coreai_opt.palettization.config.palettization_config import KMeansPalettize
 from transformers import AutoConfig, AutoTokenizer
 
 from coreai_models._constants import (
+    DEFAULT_INCLUDE_DEBUG_INFO,
     IOS_DEFAULT_MAX_CONTEXT_LENGTH,
     TRACE_KV_CACHE_SEQ_LEN,
 )
@@ -61,6 +62,10 @@ class ExportConfig:
     overwrite: bool = False
     # iOS only. When True, embedding table is not quantized to int8.
     disable_embedding_quantization: bool = False
+    # When True, the converter embeds debug information in the exported .aimodel
+    # (DEBUG mode). Default keeps the converter in RELEASE mode, which embeds
+    # minimum debug information and makes the exported asset smaller.
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO
     # Optional prebuilt coreai-opt config (KMeansPalettizerConfig or
     # QuantizerConfig) loaded from a user-provided YAML. When set, the pipeline
     # uses this directly and ignores `compression` for config resolution

--- a/python/src/coreai_models/llm/export.py
+++ b/python/src/coreai_models/llm/export.py
@@ -145,6 +145,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow exporting models without a registry preset. Requires --compute-precision.",
     )
     parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help=(
+            "Embed debug information in the exported .aimodel for debugging a conversion. "
+            "Default: off, which embeds minimum debug information and makes the "
+            "exported asset smaller."
+        ),
+    )
+    parser.add_argument(
         "--disable-embedding-quantization-ios",
         action="store_true",
         help=(
@@ -365,6 +374,7 @@ def _resolve_export_config(args: argparse.Namespace) -> ExportConfig:
         overwrite=args.overwrite,
         compression_config_object=compression_config_object,
         disable_embedding_quantization=args.disable_embedding_quantization_ios,
+        include_debug_info=args.include_debug_info,
     )
 
 
@@ -428,6 +438,7 @@ def main() -> None:
         if config.num_layers:
             print(f"  num_layers:         {config.num_layers}")
         print(f"  overwrite:          {config.overwrite}")
+        print(f"  include_debug_info: {config.include_debug_info}")
         if config.variant == "iOS":
             print(f"  disable_embedding_quantization: {config.disable_embedding_quantization}")
         return

--- a/python/src/coreai_models/segmentation/export.py
+++ b/python/src/coreai_models/segmentation/export.py
@@ -153,6 +153,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Overwrite an existing bundle directory.",
     )
     parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help=(
+            "Embed debug information in the exported .aimodel for debugging a conversion. "
+            "Default: off, which embeds minimum debug information and makes the "
+            "exported asset smaller. Applies to both modes."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the resolved export config and exit without exporting.",
@@ -225,16 +234,18 @@ def main() -> None:
             output_dir=args.output_dir or _default_output_dir(),
             output_name=args.output_name,
             overwrite=args.overwrite,
+            include_debug_info=args.include_debug_info,
         )
         if args.dry_run:
             print("Dry run — resolved full export config:")
-            print(f"  model:       {config.hf_model_id}")
-            print(f"  image_size:  {config.image_size}")
-            print(f"  dtype:       {config.dtype}")
-            print(f"  output_dir:  {config.output_dir}")
+            print(f"  model:              {config.hf_model_id}")
+            print(f"  image_size:         {config.image_size}")
+            print(f"  dtype:              {config.dtype}")
+            print(f"  output_dir:         {config.output_dir}")
             if config.output_name:
-                print(f"  output_name: {config.output_name}")
-            print(f"  overwrite:   {config.overwrite}")
+                print(f"  output_name:        {config.output_name}")
+            print(f"  overwrite:          {config.overwrite}")
+            print(f"  include_debug_info: {config.include_debug_info}")
             return
         bundle_path = export_full(config)
     else:
@@ -261,20 +272,22 @@ def main() -> None:
             output_dir=args.output_dir or _default_output_dir(),
             output_name=args.output_name,
             overwrite=args.overwrite,
+            include_debug_info=args.include_debug_info,
         )
         if args.dry_run:
             print("Dry run — resolved export config:")
-            print(f"  model:             {config.hf_model_id}")
-            print(f"  image_size:        {config.image_size}")
-            print(f"  max_text_seq_len:  {config.max_text_seq_len}")
-            print(f"  image_n_bits:      {config.image_n_bits}")
-            print(f"  image_group_size:  {config.image_group_size}")
-            print(f"  text_n_bits:       {config.text_n_bits}")
-            print(f"  text_group_size:   {config.text_group_size}")
-            print(f"  output_dir:        {config.output_dir}")
+            print(f"  model:              {config.hf_model_id}")
+            print(f"  image_size:         {config.image_size}")
+            print(f"  max_text_seq_len:   {config.max_text_seq_len}")
+            print(f"  image_n_bits:       {config.image_n_bits}")
+            print(f"  image_group_size:   {config.image_group_size}")
+            print(f"  text_n_bits:        {config.text_n_bits}")
+            print(f"  text_group_size:    {config.text_group_size}")
+            print(f"  output_dir:         {config.output_dir}")
             if config.output_name:
-                print(f"  output_name:       {config.output_name}")
-            print(f"  overwrite:         {config.overwrite}")
+                print(f"  output_name:        {config.output_name}")
+            print(f"  overwrite:          {config.overwrite}")
+            print(f"  include_debug_info: {config.include_debug_info}")
             return
         bundle_path = export_segmentation(config)
 

--- a/python/src/coreai_models/segmentation/pipeline.py
+++ b/python/src/coreai_models/segmentation/pipeline.py
@@ -32,6 +32,8 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 
+from coreai_models._constants import DEFAULT_INCLUDE_DEBUG_INFO
+
 logger = logging.getLogger(__name__)
 
 
@@ -151,6 +153,7 @@ class SegmentationExportConfig:
     output_dir: str = "exports"
     output_name: str | None = None
     overwrite: bool = False
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO
 
 
 def _bundle_name(config: SegmentationExportConfig) -> str:
@@ -263,7 +266,13 @@ async def _async_export_segmentation(config: SegmentationExportConfig) -> str:
     det_program = cast_to_16_bit_precision(det_program)
 
     logger.info("Converting to Core AI...")
-    converter = coreai_torch.TorchConverter()
+    converter = coreai_torch.TorchConverter(
+        mode=(
+            coreai_torch.TorchConverter.Mode.DEBUG
+            if config.include_debug_info
+            else coreai_torch.TorchConverter.Mode.RELEASE
+        )
+    )
     converter.add_exported_program(
         img_program,
         entrypoint_name="image_encode",
@@ -359,6 +368,7 @@ class FullExportConfig:
     output_dir: str = "exports"
     output_name: str | None = None
     overwrite: bool = False
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO
 
 
 class _Sam3FullModule(nn.Module):
@@ -442,7 +452,13 @@ async def _async_export_full(config: FullExportConfig) -> str:
     exported = exported.run_decompositions(get_decomp_table())
 
     logger.info("Converting to Core AI...")
-    converter = coreai_torch.TorchConverter().add_exported_program(
+    converter = coreai_torch.TorchConverter(
+        mode=(
+            coreai_torch.TorchConverter.Mode.DEBUG
+            if config.include_debug_info
+            else coreai_torch.TorchConverter.Mode.RELEASE
+        )
+    ).add_exported_program(
         exported_program=exported,
         input_names=["pixel_values", "input_ids"],
         output_names=[

--- a/python/src/coreai_models/vlm/export.py
+++ b/python/src/coreai_models/vlm/export.py
@@ -35,6 +35,7 @@ from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from transformers import AutoConfig, AutoTokenizer
 
+from coreai_models._constants import DEFAULT_INCLUDE_DEBUG_INFO
 from coreai_models.export.macos import export_to_coreai
 from coreai_models.export.metadata import build_aimodel_metadata
 from coreai_models.models.macos.qwen3_vl import Qwen3VLForCausalLMEmbeddings
@@ -209,7 +210,12 @@ def _load_embed_weight(model_dir: str) -> torch.Tensor:
 
 
 async def export_embed_model(
-    spec: VLMSpec, bundle_path: Path, model_dir: str, max_ctx: int, overwrite: bool
+    spec: VLMSpec,
+    bundle_path: Path,
+    model_dir: str,
+    max_ctx: int,
+    overwrite: bool,
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> str:
     """Export the token-embedding lookup as embed.aimodel (asset role `embedding`)."""
     weight = _load_embed_weight(model_dir)
@@ -225,6 +231,7 @@ async def export_embed_model(
         input_names=("input_ids",),
         output_names=("embeddings",),
         state_names=None,
+        include_debug_info=include_debug_info,
     )
     program.optimize()
 
@@ -251,6 +258,7 @@ async def export_text_bundle(
     num_layers: int | None,
     output_dir: Path,
     overwrite: bool,
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> Path:
     """Download weights and write the text portion of the VLM bundle.
 
@@ -327,6 +335,7 @@ async def export_text_bundle(
         input_names=("inputs_embeds", "position_ids"),
         output_names=("logits",),
         state_names=KV_STATE_NAMES,
+        include_debug_info=include_debug_info,
     )
     logging.info("Optimizing AIProgram...")
     program.optimize()
@@ -348,7 +357,9 @@ async def export_text_bundle(
 
     # ---- 6. Embed model ----
     logging.info("Exporting embed.aimodel...")
-    embed_rel = await export_embed_model(spec, bundle_path, model_dir, max_ctx, overwrite)
+    embed_rel = await export_embed_model(
+        spec, bundle_path, model_dir, max_ctx, overwrite, include_debug_info=include_debug_info
+    )
 
     # ---- 7. Tokenizer ----
     logging.info("Saving tokenizer...")
@@ -605,7 +616,11 @@ def _patch_fast_pos_embed_interpolate(vision_model_cls: type) -> None:
 
 
 async def export_vision_encoder(
-    spec: VLMSpec, bundle_path: Path, overwrite: bool, num_frames: int = 1
+    spec: VLMSpec,
+    bundle_path: Path,
+    overwrite: bool,
+    num_frames: int = 1,
+    include_debug_info: bool = DEFAULT_INCLUDE_DEBUG_INFO,
 ) -> str:
     """Export the vision encoder as vision.aimodel and patch metadata.json."""
     from transformers.models.qwen3_vl.modeling_qwen3_vl import (
@@ -694,6 +709,7 @@ async def export_vision_encoder(
         dynamic_shapes=None,
         input_names=("pixel_values",),
         output_names=("image_features",),
+        include_debug_info=include_debug_info,
     )
     logging.info("Optimizing AIProgram...")
     program.optimize()
@@ -797,6 +813,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Overwrite existing output files",
     )
     parser.add_argument(
+        "--include-debug-info",
+        action="store_true",
+        help=(
+            "Embed debug information in the exported .aimodel for debugging a conversion. "
+            "Default: off, which embeds minimum debug information and makes the "
+            "exported asset smaller."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -813,10 +838,17 @@ async def _run(spec: VLMSpec, args: argparse.Namespace) -> Path:
         num_layers=args.num_layers,
         output_dir=output_dir,
         overwrite=args.overwrite,
+        include_debug_info=args.include_debug_info,
     )
     if not args.skip_vision:
         logging.info("Exporting vision encoder...")
-        await export_vision_encoder(spec, bundle_path, args.overwrite, args.num_frames)
+        await export_vision_encoder(
+            spec,
+            bundle_path,
+            args.overwrite,
+            args.num_frames,
+            include_debug_info=args.include_debug_info,
+        )
     return bundle_path
 
 

--- a/python/tests/test_model_units/test_export/test_include_debug_info.py
+++ b/python/tests/test_model_units/test_export/test_include_debug_info.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for the ``--include-debug-info`` flag across every export surface.
+
+Exports default to the converter's ``RELEASE`` mode so shipped ``.aimodel``
+assets embed minimum debug information; ``--include-debug-info`` opts into ``DEBUG``
+mode and its full debug information.
+
+Flag plumbing only — nothing here downloads weights or runs an export.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from coreai_models._constants import DEFAULT_INCLUDE_DEBUG_INFO
+from coreai_models.diffusion.pipeline import DiffusionExportConfig
+from coreai_models.export.pipeline import ExportConfig
+from coreai_models.llm.export import build_parser
+
+
+def _repo_root() -> Path:
+    """Walk up to the workspace root (where ``pyproject.toml`` + ``python/`` live)."""
+    d = Path(__file__).resolve().parent
+    while d != d.parent:
+        if (d / "pyproject.toml").exists() and (d / "python").exists():
+            return d
+        d = d.parent
+    raise RuntimeError("workspace root not found")
+
+
+# --- the shared default ----------------------------------------------
+
+
+def test_the_default_is_release_mode() -> None:
+    """Pins the repo-wide default. Flipping this changes every shipped asset."""
+    assert DEFAULT_INCLUDE_DEBUG_INFO is False
+
+
+@pytest.mark.parametrize("config_cls", [ExportConfig, DiffusionExportConfig])
+def test_config_dataclasses_default_to_the_shared_constant(config_cls) -> None:
+    config = config_cls(hf_model_id="org/model")
+    assert config.include_debug_info is DEFAULT_INCLUDE_DEBUG_INFO
+
+
+# --- coreai.llm.export ------------------------------------------------
+
+
+def test_llm_cli_defaults_to_off() -> None:
+    args = build_parser().parse_args(["qwen3-0.6b"])
+    assert args.include_debug_info is False
+
+
+def test_llm_cli_accepts_the_flag() -> None:
+    args = build_parser().parse_args(["qwen3-0.6b", "--include-debug-info"])
+    assert args.include_debug_info is True
+
+
+def test_llm_cli_flag_is_independent_of_verbose() -> None:
+    """``-v`` is console log level only; it must not change the asset contents."""
+    args = build_parser().parse_args(["qwen3-0.6b", "-v"])
+    assert args.verbose is True
+    assert args.include_debug_info is False
+
+
+def test_llm_cli_resolves_the_flag_onto_the_export_config() -> None:
+    """Covers the wiring in ``_resolve_export_config``, not just the parser."""
+    from coreai_models.llm.export import _resolve_export_config
+
+    for argv, expected in ((["qwen3-0.6b"], False), (["qwen3-0.6b", "--include-debug-info"], True)):
+        config = _resolve_export_config(build_parser().parse_args(argv))
+        assert config.include_debug_info is expected
+
+
+# --- standalone models/*/export.py recipes ----------------------------
+
+# ``models/sam3/export.py`` delegates to the segmentation CLI, so it inherits
+# the flag rather than declaring one.
+_DELEGATING_RECIPES = {"sam3"}
+
+
+def _standalone_recipes() -> list[Path]:
+    recipes = sorted(
+        p
+        for p in _repo_root().glob("models/*/export.py")
+        if p.parent.name not in _DELEGATING_RECIPES
+    )
+    assert recipes, "no standalone recipes found — glob or layout changed"
+    return recipes
+
+
+def test_every_standalone_recipe_is_discovered() -> None:
+    # Guards the glob itself: a silently-empty list would make the checks below vacuous.
+    assert len(_standalone_recipes()) >= 12
+
+
+@pytest.mark.parametrize("recipe", _standalone_recipes(), ids=lambda p: p.parent.name)
+def test_standalone_recipe_defaults_to_release_and_offers_include_debug_info(recipe: Path) -> None:
+    """A ``.aimodel`` must not differ based on which script produced it.
+
+    Source-text scan rather than an import: these are PEP 723 scripts whose
+    inline dependencies are not installed in the test environment.
+    """
+    source = recipe.read_text()
+    assert "--include-debug-info" in source, (
+        f"{recipe.parent.name}: missing the --include-debug-info flag"
+    )
+    assert "Mode.RELEASE" in source, f"{recipe.parent.name}: does not default to RELEASE mode"
+    assert "TorchConverter()" not in source, (
+        f"{recipe.parent.name}: constructs TorchConverter() with no mode, "
+        "which silently inherits the library's DEBUG default"
+    )

--- a/python/tests/test_model_units/test_export/test_segmentation_cli.py
+++ b/python/tests/test_model_units/test_export/test_segmentation_cli.py
@@ -163,3 +163,36 @@ def test_no_warning_when_nothing_mode_specific_is_passed(
         with caplog.at_level(logging.WARNING):
             _warn_unused_flags(args)
         assert caplog.text == "", f"unexpected warning for {argv}"
+
+
+# --- --include-debug-info -----------------------------------------------------
+
+
+def test_include_debug_info_defaults_to_off() -> None:
+    """Exports default to the converter's RELEASE mode: minimum debug information."""
+    _, args = _parse()
+    assert args.include_debug_info is False
+
+
+def test_include_debug_info_can_be_enabled() -> None:
+    _, args = _parse("--include-debug-info")
+    assert args.include_debug_info is True
+
+
+def test_include_debug_info_reaches_both_config_dataclasses() -> None:
+    """The flag is mode-agnostic, so both branches of ``main`` must carry it."""
+    for config_cls in (SegmentationExportConfig, FullExportConfig):
+        assert config_cls().include_debug_info is False
+        assert config_cls(include_debug_info=True).include_debug_info is True
+
+
+@pytest.mark.parametrize("argv", [("--include-debug-info",), ("--full", "--include-debug-info")])
+def test_include_debug_info_is_not_treated_as_mode_specific(
+    argv: tuple[str, ...], caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression guard: --include-debug-info applies to both modes, so it must never be
+    added to the mode-specific warn lists in ``_warn_unused_flags``."""
+    _, args = _parse(*argv)
+    with caplog.at_level(logging.WARNING):
+        _warn_unused_flags(args)
+    assert caplog.text == ""


### PR DESCRIPTION
This PR makes model export by default using release mode, so the exported asset carries minimum debug information (smaller asset and runtime memory usage). Added `--include-debug-info` option if that is needed for debugging purpose, e.g., using Core AI Debugger. 

Also provided in `models/README.md` an example python code snippet to strip out debug information for models exported using v0.2.0 onwards