### PR TITLE
Extract shared model I/O name-discovery helpers into CoreAIShared

### DIFF
--- a/swift/Sources/CoreAIImageSegmenter/ImageSegmentationEngine.swift
+++ b/swift/Sources/CoreAIImageSegmenter/ImageSegmentationEngine.swift
@@ -168,7 +168,7 @@ public struct CoreAISegmentationEngine {
         let iouScoresOutputName: String?
 
         init(model: AIModel, descriptor: InferenceFunctionDescriptor) async throws {
-            guard let imageInputName = findImageInputName(in: descriptor.inputNames) else {
+            guard let imageInputName = ModelIONameResolver.findImageInputName(in: descriptor.inputNames) else {
                 throw SegmentationRuntimeError.invalidConfiguration(
                     "Cannot find image input in model. Inputs: \(descriptor.inputNames)"
                 )
@@ -188,8 +188,8 @@ public struct CoreAISegmentationEngine {
                 throw SegmentationRuntimeError.outputMissing(masksOutputName)
             }
 
-            let boxesOutputName = findBoxesOutputName(in: descriptor.outputNames)
-            let logitsOutputName = findLogitsOutputName(in: descriptor.outputNames)
+            let boxesOutputName = ModelIONameResolver.findBoxesOutputName(in: descriptor.outputNames)
+            let logitsOutputName = ModelIONameResolver.findLogitsOutputName(in: descriptor.outputNames)
             let presenceLogitsOutputName = findPresenceOutputName(in: descriptor.outputNames)
             let semanticSegOutputName = findSemanticOutputName(in: descriptor.outputNames)
             let iouScoresOutputName = findIouScoresOutputName(in: descriptor.outputNames)
@@ -284,7 +284,8 @@ public struct CoreAISegmentationEngine {
             detectDescriptor: InferenceFunctionDescriptor
         ) async throws {
             // image_encode: needs an image input + backbone-features output.
-            guard let imageInputName = findImageInputName(in: imageEncodeDescriptor.inputNames) else {
+            guard let imageInputName = ModelIONameResolver.findImageInputName(in: imageEncodeDescriptor.inputNames)
+            else {
                 throw SegmentationRuntimeError.invalidConfiguration(
                     "Cannot find image input in 'image_encode'. Inputs: \(imageEncodeDescriptor.inputNames)"
                 )
@@ -336,12 +337,13 @@ public struct CoreAISegmentationEngine {
             guard case .ndArray = detectDescriptor.outputDescriptor(of: masksOutputName) else {
                 throw SegmentationRuntimeError.outputMissing(masksOutputName)
             }
-            guard let boxesOutputName = findBoxesOutputName(in: detectDescriptor.outputNames) else {
+            guard let boxesOutputName = ModelIONameResolver.findBoxesOutputName(in: detectDescriptor.outputNames) else {
                 throw SegmentationRuntimeError.invalidConfiguration(
                     "Cannot find boxes output in 'detect'. Outputs: \(detectDescriptor.outputNames)"
                 )
             }
-            guard let logitsOutputName = findLogitsOutputName(in: detectDescriptor.outputNames) else {
+            guard let logitsOutputName = ModelIONameResolver.findLogitsOutputName(in: detectDescriptor.outputNames)
+            else {
                 throw SegmentationRuntimeError.invalidConfiguration(
                     "Cannot find logits output in 'detect'. Outputs: \(detectDescriptor.outputNames)"
                 )
@@ -1190,13 +1192,6 @@ public struct CoreAISegmentationEngine {
 
     // MARK: - Static name-discovery helpers
 
-    static func findImageInputName(in names: [String]) -> String? {
-        names.first {
-            let l = $0.lowercased()
-            return l.contains("pixel") || l.contains("image")
-        }
-    }
-
     static func findTextInputName(in names: [String]) -> String? {
         names.first {
             let l = $0.lowercased()
@@ -1241,17 +1236,6 @@ public struct CoreAISegmentationEngine {
 
     static func findMasksOutputName(in names: [String]) -> String? {
         names.first { $0.lowercased().contains("mask") }
-    }
-
-    static func findBoxesOutputName(in names: [String]) -> String? {
-        names.first { $0.lowercased().contains("box") }
-    }
-
-    static func findLogitsOutputName(in names: [String]) -> String? {
-        names.first {
-            let l = $0.lowercased()
-            return l.contains("logit") && !l.contains("presence")
-        }
     }
 
     static func findPresenceOutputName(in names: [String]) -> String? {

--- a/swift/Sources/CoreAIObjectDetector/ObjectDetector.swift
+++ b/swift/Sources/CoreAIObjectDetector/ObjectDetector.swift
@@ -40,19 +40,19 @@ public struct ObjectDetector {
         }
 
         // Discover input names
-        guard let imageInputName = Self.findImageInputName(in: descriptor.inputNames) else {
+        guard let imageInputName = ModelIONameResolver.findImageInputName(in: descriptor.inputNames) else {
             throw DetectionRuntimeError.invalidConfiguration(
                 "Cannot find image input in model. Inputs: \(descriptor.inputNames)"
             )
         }
 
         // Discover output names
-        guard let logitsOutputName = Self.findLogitsOutputName(in: descriptor.outputNames) else {
+        guard let logitsOutputName = ModelIONameResolver.findLogitsOutputName(in: descriptor.outputNames) else {
             throw DetectionRuntimeError.invalidConfiguration(
                 "Cannot find logits output in model. Outputs: \(descriptor.outputNames)"
             )
         }
-        guard let boxesOutputName = Self.findBoxesOutputName(in: descriptor.outputNames) else {
+        guard let boxesOutputName = ModelIONameResolver.findBoxesOutputName(in: descriptor.outputNames) else {
             throw DetectionRuntimeError.invalidConfiguration(
                 "Cannot find boxes output in model. Outputs: \(descriptor.outputNames)"
             )
@@ -309,26 +309,6 @@ public struct ObjectDetector {
         let width = widthExpected < 0 ? parameters.inputWidth : widthExpected
 
         return BatchPlan(batch: imageCount, height: height, width: width)
-    }
-
-    // MARK: - Name Discovery
-
-    static func findImageInputName(in names: [String]) -> String? {
-        names.first {
-            let l = $0.lowercased()
-            return l.contains("pixel") || l.contains("image")
-        }
-    }
-
-    static func findLogitsOutputName(in names: [String]) -> String? {
-        names.first { $0.lowercased().contains("logit") }
-    }
-
-    static func findBoxesOutputName(in names: [String]) -> String? {
-        names.first {
-            let l = $0.lowercased()
-            return l.contains("box")
-        }
     }
 }
 

--- a/swift/Sources/CoreAIShared/Runtime/ModelIONameResolver.swift
+++ b/swift/Sources/CoreAIShared/Runtime/ModelIONameResolver.swift
@@ -1,0 +1,23 @@
+/// Shared helpers for discovering model input/output names by substring matching.
+public enum ModelIONameResolver {
+    /// Finds the first name containing "pixel" or "image" (case-insensitive).
+    public static func findImageInputName(in names: [String]) -> String? {
+        names.first {
+            let l = $0.lowercased()
+            return l.contains("pixel") || l.contains("image")
+        }
+    }
+
+    /// Finds the first name containing "logit" but NOT "presence" (case-insensitive).
+    public static func findLogitsOutputName(in names: [String]) -> String? {
+        names.first {
+            let l = $0.lowercased()
+            return l.contains("logit") && !l.contains("presence")
+        }
+    }
+
+    /// Finds the first name containing "box" (case-insensitive).
+    public static func findBoxesOutputName(in names: [String]) -> String? {
+        names.first { $0.lowercased().contains("box") }
+    }
+}


### PR DESCRIPTION
Move findImageInputName, findLogitsOutputName, and findBoxesOutputName into a new ModelIONameResolver enum in CoreAIShared/Runtime, eliminating duplication between ObjectDetector and ImageSegmentationEngine.