### PR TITLE
Extract generateNoise into shared RNG-customizable utility

### DIFF
--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/Flux2Pipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/Flux2Pipeline.swift
@@ -581,13 +581,6 @@ public struct Flux2Pipeline: DiffusionPipeline {
         return result
     }
 
-    // MARK: - Noise Generation
-
-    private func generateNoise(count: Int, seed: UInt32) -> [Float] {
-        var rng = NumPyRandomSource(seed: seed)
-        return (0..<count).map { _ in Float(rng.nextNormal()) }
-    }
-
     // MARK: - Image Conversion
 
     // MARK: - Half/Tiled Decode Helpers

--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/SD3Pipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/SD3Pipeline.swift
@@ -280,11 +280,6 @@ public struct SD3Pipeline: DiffusionPipeline {
         return result
     }
 
-    private func generateNoise(count: Int, seed: UInt32) -> [Float] {
-        var rng = NumPyRandomSource(seed: seed)
-        return (0..<count).map { _ in Float(rng.nextNormal()) }
-    }
-
     // MARK: - SD 3.5 Medium constants
 
     private static let clipSeqLen = 77

--- a/swift/Sources/CoreAIDiffusionPipeline/Pipelines/StableDiffusionPipeline.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/Pipelines/StableDiffusionPipeline.swift
@@ -228,9 +228,4 @@ public struct StableDiffusionPipeline: DiffusionPipeline {
                 "discreteFlow is not supported by StableDiffusionPipeline — use SD3Pipeline or Flux2Pipeline")
         }
     }
-
-    private func generateNoise(count: Int, seed: UInt32) -> [Float] {
-        var rng = NumPyRandomSource(seed: seed)
-        return (0..<count).map { _ in Float(rng.nextNormal()) }
-    }
 }

--- a/swift/Sources/CoreAIDiffusionPipeline/RNG/NoiseGeneration.swift
+++ b/swift/Sources/CoreAIDiffusionPipeline/RNG/NoiseGeneration.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+/// Which random number generator to use for noise generation.
+public enum RandomSourceType: Sendable {
+    case numPy
+    case torch
+    case nvidia
+}
+
+/// Generate Gaussian noise (mean 0, stdev 1) using the specified random source.
+public func generateNoise(count: Int, seed: UInt32, sourceType: RandomSourceType = .numPy) -> [Float] {
+    switch sourceType {
+    case .numPy:
+        var rng = NumPyRandomSource(seed: seed)
+        return (0..<count).map { _ in Float(rng.nextNormal()) }
+    case .torch:
+        var rng = TorchRandomSource(seed: seed)
+        return (0..<count).map { _ in Float(rng.nextNormal()) }
+    case .nvidia:
+        var rng = NvRandomSource(seed: seed)
+        return (0..<count).map { _ in Float(rng.nextNormal()) }
+    }
+}


### PR DESCRIPTION
Move the duplicated private generateNoise(count:seed:) from Flux2Pipeline, SD3Pipeline, and StableDiffusionPipeline into a module-level free function in RNG/NoiseGeneration.swift.

The new function accepts a RandomSourceType parameter (.numPy, .torch, .nvidia) defaulting to .numPy for backwards compatibility, allowing callers to select the appropriate RNG for their model.