### PR TITLE
Extract lastSafeIndex into shared free function

### DIFF
--- a/swift/Sources/CoreAILanguageModels/LanguageModel/ThinkTagParser.swift
+++ b/swift/Sources/CoreAILanguageModels/LanguageModel/ThinkTagParser.swift
@@ -72,7 +72,7 @@ struct ThinkTagParser {
                 // a partial-marker suffix; emit the entire buffer. Otherwise:
                 // hold back at most `marker.count - 1` characters in case the
                 // next delta completes the marker.
-                let safe = isFinal ? buffer.endIndex : lastSafeIndex(forTag: marker)
+                let safe = isFinal ? buffer.endIndex : lastSafeIndex(in: buffer, forTag: marker)
                 if safe > buffer.startIndex {
                     let toEmit = String(buffer[buffer.startIndex..<safe])
                     if !toEmit.isEmpty { events.append(makeEvent(toEmit)) }
@@ -81,23 +81,5 @@ struct ThinkTagParser {
                 return events
             }
         }
-    }
-
-    /// Rightmost index such that the suffix from there to end-of-buffer is
-    /// NOT a non-empty prefix of `tag`. Conservative: only scans the last
-    /// `tag.count - 1` characters (the longest possible held-back prefix).
-    private func lastSafeIndex(forTag tag: String) -> String.Index {
-        let maxHold = tag.count - 1
-        guard !buffer.isEmpty, maxHold > 0 else { return buffer.endIndex }
-        let holdStart = buffer.index(buffer.endIndex, offsetBy: -min(maxHold, buffer.count))
-        for offset in 0..<buffer.distance(from: holdStart, to: buffer.endIndex) {
-            let idx = buffer.index(holdStart, offsetBy: offset)
-            // `starts(with:)` accepts any Sequence<Character>, so we pass the
-            // Substring directly — avoids a per-iteration String allocation.
-            if tag.starts(with: buffer[idx...]) {
-                return idx
-            }
-        }
-        return buffer.endIndex
     }
 }

--- a/swift/Sources/CoreAILanguageModels/StreamingMarkerMatcher.swift
+++ b/swift/Sources/CoreAILanguageModels/StreamingMarkerMatcher.swift
@@ -1,0 +1,24 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+/// Returns the rightmost index in `buffer` such that the suffix from that
+/// index to the end is NOT a non-empty prefix of `tag`.
+///
+/// Used by streaming parsers to decide how much of a buffer can be safely
+/// emitted without cutting off a marker that might span two deltas. At most
+/// `tag.count - 1` trailing characters are held back (the longest partial
+/// prefix that could still complete on the next delta).
+func lastSafeIndex(in buffer: String, forTag tag: String) -> String.Index {
+    let maxHold = tag.count - 1
+    guard !buffer.isEmpty, maxHold > 0 else { return buffer.endIndex }
+    let holdStart = buffer.index(buffer.endIndex, offsetBy: -min(maxHold, buffer.count))
+    for offset in 0..<buffer.distance(from: holdStart, to: buffer.endIndex) {
+        let idx = buffer.index(holdStart, offsetBy: offset)
+        if tag.starts(with: buffer[idx...]) {
+            return idx
+        }
+    }
+    return buffer.endIndex
+}

--- a/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
+++ b/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
@@ -69,7 +69,7 @@ struct ToolCallParser {
             }
             buffer = ""
         } else {
-            let safe = isFinal ? buffer.endIndex : lastSafeIndex(for: openMarker)
+            let safe = isFinal ? buffer.endIndex : lastSafeIndex(in: buffer, forTag: openMarker)
             if safe > buffer.startIndex {
                 let toEmit = String(buffer[buffer.startIndex..<safe])
                 if !toEmit.isEmpty { events.append(.text(toEmit)) }
@@ -112,20 +112,5 @@ struct ToolCallParser {
         }
 
         return .toolCall(id: UUID().uuidString, name: name, argsJSON: argsJSON)
-    }
-
-    /// Rightmost index such that the suffix from there to end-of-buffer is NOT
-    /// a non-empty prefix of `tag`. Same implementation as `ThinkTagParser`.
-    private func lastSafeIndex(for tag: String) -> String.Index {
-        let maxHold = tag.count - 1
-        guard !buffer.isEmpty, maxHold > 0 else { return buffer.endIndex }
-        let holdStart = buffer.index(buffer.endIndex, offsetBy: -min(maxHold, buffer.count))
-        for offset in 0..<buffer.distance(from: holdStart, to: buffer.endIndex) {
-            let idx = buffer.index(holdStart, offsetBy: offset)
-            if tag.starts(with: buffer[idx...]) {
-                return idx
-            }
-        }
-        return buffer.endIndex
     }
 }

--- a/swift/Tests/LanguageModelsTests/StreamingMarkerMatcherTests.swift
+++ b/swift/Tests/LanguageModelsTests/StreamingMarkerMatcherTests.swift
@@ -34,4 +34,30 @@ struct StreamingMarkerMatcherTests {
         let buffer = "<thin"
         #expect(lastSafeIndex(in: buffer, forTag: "<think>") == buffer.startIndex)
     }
+
+    @Test("Empty buffer returns endIndex")
+    func emptyBuffer() {
+        let buffer = ""
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == buffer.endIndex)
+    }
+
+    @Test("Buffer is just '<' — held back as prefix")
+    func bufferIsSingleOpenAngle() {
+        let buffer = "<"
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == buffer.startIndex)
+    }
+
+    @Test("'>' and '!' are not prefixes — safe to emit")
+    func nonPrefixSpecialChars() {
+        let gt = ">"
+        let bang = "!"
+        #expect(lastSafeIndex(in: gt, forTag: "<think>") == gt.endIndex)
+        #expect(lastSafeIndex(in: bang, forTag: "<think>") == bang.endIndex)
+    }
+
+    @Test("Single-char tag — nothing is ever held back")
+    func singleCharTag() {
+        let buffer = "abc<"
+        #expect(lastSafeIndex(in: buffer, forTag: "X") == buffer.endIndex)
+    }
 }

--- a/swift/Tests/LanguageModelsTests/StreamingMarkerMatcherTests.swift
+++ b/swift/Tests/LanguageModelsTests/StreamingMarkerMatcherTests.swift
@@ -1,0 +1,37 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Testing
+
+@testable import CoreAILanguageModels
+
+@Suite("StreamingMarkerMatcher")
+struct StreamingMarkerMatcherTests {
+    @Test("No partial match — entire buffer is safe")
+    func noMatch() {
+        let buffer = "hello world"
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == buffer.endIndex)
+    }
+
+    @Test("Single-char prefix held back")
+    func singleCharHoldback() {
+        let buffer = "hello<"
+        let expected = buffer.index(buffer.startIndex, offsetBy: 5)
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == expected)
+    }
+
+    @Test("Multi-char partial prefix held back")
+    func multiCharHoldback() {
+        let buffer = "some text<thi"
+        let expected = buffer.index(buffer.startIndex, offsetBy: 9)
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == expected)
+    }
+
+    @Test("Maximum holdback — entire buffer is a prefix of tag")
+    func maxHoldback() {
+        let buffer = "<thin"
+        #expect(lastSafeIndex(in: buffer, forTag: "<think>") == buffer.startIndex)
+    }
+}


### PR DESCRIPTION
Both ThinkTagParser and ToolCallParser had identical private implementations of the streaming marker hold-back logic. 

Pull itinto a module-internal free function in StreamingMarkerMatcher.swift to eliminate the duplication.