### PR TITLE
Add Muse Glimmer 30B text decoder support

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -171,6 +171,7 @@ uv run models/<name>/export.py --include-debug-info   # embed debug information 
 - [GPT-OSS](gpt_oss)
 - [Mistral](mistral)
 - [Mixtral](mixtral)
+- [Muse Glimmer](muse_glimmer)
 - [Qwen2.5](qwen2)
 - [Qwen3](qwen3)
 - [Qwen3 MoE](qwen3_moe)

--- a/models/muse_glimmer/README.md
+++ b/models/muse_glimmer/README.md
@@ -8,52 +8,71 @@ Meta's Muse Glimmer 30B for on-device agentic tasks via Core AI. Apache 2.0 lice
 |------------------|-----------|---------|-------|-----|
 | Muse-Glimmer-30B | ~29.6B    | 131072  | Yes   | No  |
 
-**Architecture notes:**
+## Setup to export models
 
-- Dense causal transformer with perception encoder (ViT-G/14, ~1.8B, separate).
-- **Local/Global attention**: [S,S,S,G] repeating (39 sliding + 13 full). Sliding window = 2048.
-- **RoPE on local layers only** (θ=500K). Global layers skip RoPE.
-- **Gated attention**: learned gate projection (`sigmoid(gate_proj(x))`) on attention output.
-- **Extreme GQA**: 32 Q / 2 KV heads (16:1 ratio).
-- **CenteredRMSNorm** (`1 + weight`) for all layer norms; plain RMSNorm for final norm.
-- **Weight-less RMSNorm** on embeddings (no learned scale).
-- **QK norm**: shared RMSNorm applied to Q and K per-head before attention.
-- **qk_scale_factor**: multiplies Q directly after QK norm (3.87). SDPA uses default `1/sqrt(d)`.
-- **output_multiplier**: scales final hidden state before lm_head (0.196).
-- **Logit softcapping**: `tanh(logits/20) * 20`.
-- SwiGLU MLP, no attention bias.
+If you haven't installed `uv`, install it by
+```bash
+brew install uv
+```
 
-## Evaluation Results
-
-Perplexity on [WikiText-2](https://huggingface.co/datasets/EleutherAI/wikitext_document_level) (word_perplexity, lower is better):
-
-| Model | Compression | Precision | word_ppl |
-|-------|-------------|-----------|----------|
-| 30B   | none        | FP16      | 7.71     |
-| 30B   | INT4        | FP16      | ~8.4     |
-
-## Export
+## Export models
 
 ```bash
+# Defaults to macOS variant
 uv run coreai.llm.export muse-glimmer-30b
 ```
 
-## Run
+**Options:**
+
+```bash
+# Full precision
+uv run coreai.llm.export muse-glimmer-30b --compression none
+
+# Custom output directory
+uv run coreai.llm.export muse-glimmer-30b --output-dir ./my-models/
+
+# Preview resolved config without exporting
+uv run coreai.llm.export muse-glimmer-30b --dry-run
+```
+
+## Run a Core AI Language Model
+
+### In your iOS and macOS applications via Foundation Models
+
+```swift
+import FoundationModels
+import CoreAILanguageModels
+
+let model = try await CoreAILanguageModel(resourcesAt: modelURL)
+
+let session = LanguageModelSession(model: model)
+
+let response = try await session.respond(to: "What is quantum computing?")
+
+print(response)
+```
+
+### On your Mac using built-in Command Line Tool
 
 ```bash
 swift run -c release llm-runner --model path/to/exported_model --prompt "Hello"
 ```
 
-## Benchmark
+## Benchmark a Core AI Language Model
 
 ```bash
-swift run -c release llm-benchmark --model path/to/exported_model -p 512 -g 1024 -n 5
+swift run -c release llm-benchmark --model path/to/exported_model
 ```
 
-## Notes
+Defaults: 512 prompt tokens, 1024 generation tokens, 5 trials. Override with `-p`, `-g`, and `-n`.
 
-- At 30B parameters, the model requires ~60 GB memory unquantized (FP16).
-  With INT4 quantization, the language model fits in ~17 GB.
-- DFlash speculative decoding drafter is not yet implemented.
-- The perception encoder (ViT-G/14) is separate and not included in the
-  text-only export.
+## Evaluation
+
+Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherAI/wikitext_document_level) dataset computed using the [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/wikitext/README.md) with the Core AI PyTorch models.
+
+| Model | Compression               | Bits Per Weight (BPW) | Platform | Perplexity Score |
+|-------|---------------------------|-----------------------|----------|------------------|
+| 30B   | none (`float16`)          | 16.00                 | macOS    | 7.71             |
+| 30B   | [4-bit quantized][p-4bit] | 4.50                  | macOS    | 8.46             |
+
+[p-4bit]: ../README.md#quantization-options

--- a/models/muse_glimmer/README.md
+++ b/models/muse_glimmer/README.md
@@ -1,0 +1,59 @@
+# Muse Glimmer
+
+Meta's Muse Glimmer 30B for on-device agentic tasks via Core AI. Apache 2.0 license.
+
+## Supported Models
+
+| Model            | Parameters | Context | macOS | iOS |
+|------------------|-----------|---------|-------|-----|
+| Muse-Glimmer-30B | ~29.6B    | 131072  | Yes   | No  |
+
+**Architecture notes:**
+
+- Dense causal transformer with perception encoder (ViT-G/14, ~1.8B, separate).
+- **Local/Global attention**: [S,S,S,G] repeating (39 sliding + 13 full). Sliding window = 2048.
+- **RoPE on local layers only** (θ=500K). Global layers skip RoPE.
+- **Gated attention**: learned gate projection (`sigmoid(gate_proj(x))`) on attention output.
+- **Extreme GQA**: 32 Q / 2 KV heads (16:1 ratio).
+- **CenteredRMSNorm** (`1 + weight`) for all layer norms; plain RMSNorm for final norm.
+- **Weight-less RMSNorm** on embeddings (no learned scale).
+- **QK norm**: shared RMSNorm applied to Q and K per-head before attention.
+- **qk_scale_factor**: multiplies Q directly after QK norm (3.87). SDPA uses default `1/sqrt(d)`.
+- **output_multiplier**: scales final hidden state before lm_head (0.196).
+- **Logit softcapping**: `tanh(logits/20) * 20`.
+- SwiGLU MLP, no attention bias.
+
+## Evaluation Results
+
+Perplexity on [WikiText-2](https://huggingface.co/datasets/EleutherAI/wikitext_document_level) (word_perplexity, lower is better):
+
+| Model | Compression | Precision | word_ppl |
+|-------|-------------|-----------|----------|
+| 30B   | none        | FP16      | 7.71     |
+| 30B   | INT4        | FP16      | ~8.4     |
+
+## Export
+
+```bash
+uv run coreai.llm.export muse-glimmer-30b
+```
+
+## Run
+
+```bash
+swift run -c release llm-runner --model path/to/exported_model --prompt "Hello"
+```
+
+## Benchmark
+
+```bash
+swift run -c release llm-benchmark --model path/to/exported_model -p 512 -g 1024 -n 5
+```
+
+## Notes
+
+- At 30B parameters, the model requires ~60 GB memory unquantized (FP16).
+  With INT4 quantization, the language model fits in ~17 GB.
+- DFlash speculative decoding drafter is not yet implemented.
+- The perception encoder (ViT-G/14) is separate and not included in the
+  text-only export.

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -131,6 +131,16 @@ LLM_PRESETS: list[ModelPreset] = [
     ModelPreset(
         "gpt-oss-20b", "openai/gpt-oss-20b", "gpt-oss", "llm", "macOS", "none", "bfloat16", 32768
     ),
+    ModelPreset(
+        "muse-glimmer-30b",
+        "meta-models/Muse-Glimmer-30B",
+        "muse_glimmer",
+        "llm",
+        "macOS",
+        "4bit",
+        "float16",
+        131072,
+    ),
     # --- iOS (compression = palettized) ---
     ModelPreset(
         "qwen3-0.6b",

--- a/python/src/coreai_models/models/macos/muse_glimmer.py
+++ b/python/src/coreai_models/models/macos/muse_glimmer.py
@@ -1,0 +1,356 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Muse Glimmer text decoder for CoreAI model export.
+
+Meta's 30B on-device agentic model (Apache 2.0). Architecture features:
+- Local/Global attention: [S,S,S,G] repeating (39 sliding + 13 full)
+- RoPE on local layers only (global layers skip RoPE)
+- Extreme GQA: 32Q / 2KV heads
+- Gated attention: learned gate_proj on attention output
+- Sandwich norm: pre+post norm on both attention and MLP
+- qk_scale_factor: custom attention scaling (not 1/sqrt(d))
+- output_multiplier: scales final hidden state before lm_head
+- Logit softcapping: tanh(logits/cap) * cap
+"""
+
+import gc
+import json
+import os
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from huggingface_hub import snapshot_download
+from typing_extensions import Self, override
+
+from coreai_models.models.base import (
+    BaseForCausalLM,
+    _load_tensors_for_keys,
+    _resolve_safetensors_files,
+)
+from coreai_models.primitives.macos.cache import KVCache
+from coreai_models.primitives.macos.mlp import MLP
+from coreai_models.primitives.macos.rms_norm import RMSNorm, RMSNormPlusOne
+from coreai_models.primitives.macos.rope import initialize_rope
+from coreai_models.primitives.macos.sdpa import SDPA
+
+
+class Attention(nn.Module):
+    def __init__(self, config, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+
+        dim = config.hidden_size
+        self.n_heads = n_heads = config.num_attention_heads
+        self.n_kv_heads = n_kv_heads = config.num_key_value_heads
+        self.head_dim = head_dim = config.head_dim
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+        self.gate_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
+
+        self.qk_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
+        self.qk_scale_factor = getattr(config, "qk_scale_factor", 1.0)
+
+        layer_types = config.layer_types
+        self.is_sliding = layer_types[layer_idx] == "sliding_attention"
+
+        layer_rope_theta = config.layer_rope_theta
+        rope_theta = layer_rope_theta[layer_idx] if layer_rope_theta else 500000.0
+        self.has_rope = rope_theta > 0
+
+        if self.is_sliding:
+            self.sdpa = SDPA(is_causal=True, window_size=config.sliding_window)
+        else:
+            self.sdpa = SDPA(is_causal=True)
+
+        if self.has_rope:
+            self.rope = initialize_rope(base=rope_theta)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        batch_size, query_len, _ = x.shape
+        n_heads, n_kv_heads = self.n_heads, self.n_kv_heads
+
+        query = self.qk_norm(
+            self.q_proj(x)
+            .reshape(batch_size, query_len, n_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        ) * self.qk_scale_factor
+        key = self.qk_norm(
+            self.k_proj(x)
+            .reshape(batch_size, query_len, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+        value = (
+            self.v_proj(x)
+            .reshape(batch_size, query_len, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+
+        gate = torch.sigmoid(self.gate_proj(x))
+
+        seq_len = position_ids.shape[-1]
+        torch._check_is_size(query_len)
+        torch._check_is_size(seq_len)
+        offset = seq_len - query_len
+        torch._check_is_size(offset)
+        rope_positions = position_ids.narrow(-1, offset, query_len)
+
+        if self.has_rope:
+            query = self.rope(query, position_ids=rope_positions)
+            key = self.rope(key, position_ids=rope_positions)
+
+        if cache is not None:
+            key, value = cache.update_and_fetch(
+                self.layer_idx, offset, key, value, seq_len=seq_len, query_len=query_len
+            )
+
+        attn_output = (
+            self.sdpa(query, key, value)
+            .permute(0, 2, 1, 3)
+            .reshape(batch_size, query_len, self.n_heads * self.head_dim)
+        )
+
+        return self.o_proj(attn_output * gate)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config, layer_idx: int) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        self.self_attn = Attention(config, layer_idx=layer_idx)
+        self.mlp = MLP(hidden_size, config.intermediate_size)
+
+        post_eps = getattr(config, "post_norm_eps", config.rms_norm_eps)
+        self.input_layernorm = RMSNormPlusOne(hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNormPlusOne(hidden_size, eps=post_eps)
+        self.pre_feedforward_layernorm = RMSNormPlusOne(hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = RMSNormPlusOne(hidden_size, eps=post_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        r = self.self_attn(self.input_layernorm(x), position_ids, cache)
+        r = self.post_attention_layernorm(r)
+        h = x + r
+        r = self.mlp(self.pre_feedforward_layernorm(h))
+        r = self.post_feedforward_layernorm(r)
+        return h + r
+
+
+class MuseGlimmerModel(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.config = config
+        hidden_size = config.hidden_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, hidden_size)
+        self.output_multiplier = getattr(config, "output_multiplier", 1.0)
+        self.layers = nn.ModuleList(
+            [TransformerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: KVCache | None = None,
+    ) -> torch.Tensor:
+        h = self.embed_tokens(input_ids)
+        # MuseGlimmerTextNormedEmbedding: weight-less RMSNorm on embeddings
+        h = h * torch.rsqrt(h.pow(2).mean(-1, keepdim=True) + self.config.rms_norm_eps)
+        for layer in self.layers:
+            h = layer(h, position_ids, cache)
+        h = self.norm(h)
+        if self.output_multiplier != 1.0:
+            h = h * self.output_multiplier
+        return h
+
+
+class MuseGlimmerForCausalLM(BaseForCausalLM):
+    _HF_MODEL_CLASS = None  # Not in our transformers version
+
+    @classmethod
+    def _get_reauthored_config(cls, hf_config, max_context_length=None, num_layers=None):
+        text_config = hf_config.text_config if hasattr(hf_config, "text_config") else hf_config
+        if max_context_length is not None:
+            text_config.max_position_embeddings = max_context_length
+        if num_layers is not None:
+            text_config.num_hidden_layers = num_layers
+        return text_config
+
+    @override
+    @classmethod
+    def from_hf(
+        cls,
+        huggingface_model_id: str,
+        max_context_length: int | None = None,
+        target_dtype: torch.dtype = torch.float16,
+        mmap_path: str | None = None,
+        num_layers: int | None = None,
+        disable_embedding_quantization: bool = False,
+    ) -> Self:
+        return cls.from_hf_memory_efficient(
+            huggingface_model_id,
+            max_context_length=max_context_length,
+            target_dtype=target_dtype,
+            mmap_path=mmap_path,
+            num_layers=num_layers,
+            hf_config_attr="text_config",
+            hf_state_dict_prefix="model.language_model.",
+        )
+
+    @override
+    @classmethod
+    def from_hf_memory_efficient(
+        cls,
+        huggingface_model_id: str,
+        max_context_length: int | None = None,
+        target_dtype: torch.dtype = torch.float16,
+        mmap_path: str | None = None,
+        num_layers: int | None = None,
+        hf_config_attr: str | None = "text_config",
+        hf_state_dict_prefix: str = "model.language_model.",
+        disable_embedding_quantization: bool = False,
+    ) -> Self:
+        import re
+
+        model_dir = snapshot_download(
+            huggingface_model_id,
+            allow_patterns=["*.safetensors", "*.safetensors.index.json", "config.json"],
+        )
+
+        with open(os.path.join(model_dir, "config.json")) as f:
+            raw = json.load(f)
+        cfg_dict = raw.get(hf_config_attr, raw) if hf_config_attr else raw
+        hf_config = SimpleNamespace(**cfg_dict) if isinstance(cfg_dict, dict) else cfg_dict
+
+        config = cls._get_reauthored_config(hf_config, max_context_length, num_layers=num_layers)
+        model = cls(config=config, model_device="meta")
+        model.to(dtype=target_dtype)
+
+        safetensors_files = _resolve_safetensors_files(model_dir)
+
+        # Build key index with Muse Glimmer's actual key layout:
+        #   model.language_model.layers.N.*  → per-layer
+        #   model.language_model.embed_tokens.weight, .norm.weight → shared
+        #   lm_head.weight → shared (no prefix)
+        #   model.vision_* → skip
+        layer_pattern = re.compile(r"model\.language_model\.layers\.(\d+)\.")
+        from safetensors import safe_open
+
+        per_layer: dict[int, dict[str, str]] = {}
+        shared: dict[str, str] = {}
+        for path in safetensors_files:
+            with safe_open(path, framework="pt", device="cpu") as f:
+                for key in f.keys():  # noqa: SIM118
+                    if key.startswith("model.vision_tower.") or key.startswith("model.vision_"):
+                        continue
+                    match = layer_pattern.match(key)
+                    if match:
+                        layer_idx = int(match.group(1))
+                        if num_layers is not None and layer_idx >= num_layers:
+                            continue
+                        per_layer.setdefault(layer_idx, {})[key] = path
+                    else:
+                        shared[key] = path
+
+        # Load shared params (embed_tokens, norm, lm_head)
+        shared_dict = _load_tensors_for_keys(shared, target_dtype)
+        # Normalize keys: strip "model.language_model." prefix where present
+        normalized: dict[str, torch.Tensor] = {}
+        prefix = "model.language_model."
+        for k, v in shared_dict.items():
+            if k.startswith(prefix):
+                normalized["model." + k[len(prefix):]] = v
+            else:
+                normalized[k] = v
+        del shared_dict
+        model.load_state_dict(normalized, assign=True, strict=False)
+        del normalized
+        gc.collect()
+
+        # Load one layer at a time
+        for layer_idx in sorted(per_layer.keys()):
+            layer_key_to_file = per_layer.pop(layer_idx)
+            layer_sd = _load_tensors_for_keys(layer_key_to_file, target_dtype)
+            del layer_key_to_file
+            # Strip prefix → "layers.N.*", then add "model." → "model.layers.N.*"
+            remapped: dict[str, torch.Tensor] = {}
+            for k, v in layer_sd.items():
+                remapped["model." + k[len(prefix):]] = v
+            del layer_sd
+            model.load_state_dict(remapped, assign=True, strict=False)
+            del remapped
+            gc.collect()
+
+        # qk_norm has no checkpoint weights — initialize to ones (identity RMSNorm)
+        for layer in model.model.layers:
+            layer.self_attn.qk_norm.weight = nn.Parameter(
+                torch.ones(model.config.head_dim, dtype=target_dtype)
+            )
+
+        meta_params = [n for n, p in model.named_parameters() if p.is_meta]
+        if meta_params:
+            raise RuntimeError(f"Parameters not loaded: {meta_params}")
+
+        return model
+
+    @override
+    def _init_model(self, config) -> None:
+        self.model = MuseGlimmerModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._softcap = getattr(config, "final_logit_softcapping", None)
+        if getattr(config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.embed_tokens.weight
+
+    @BaseForCausalLM.cast_logits_bfloat16_to_float16
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        cache = KVCache(k_cache, v_cache)
+        out = self.model(input_ids, position_ids, cache)
+        logits = self.lm_head(out)
+        if self._softcap:
+            logits = torch.tanh(logits / self._softcap) * self._softcap
+        return logits
+
+    @override
+    def _mutate_state_dict(self: Self, state_dict: dict[str, torch.Tensor]) -> None:
+        # Keys arrive in one of two forms:
+        # (a) Raw: "model.language_model.layers.0.self_attn.q_proj.weight"
+        # (b) Already-stripped by from_hf_memory_efficient: "layers.0.self_attn.q_proj.weight"
+        # Normalize all to "model.layers.N.*" / "model.embed_tokens.*" / "lm_head.*"
+        prefix = "model.language_model."
+        keys = list(state_dict.keys())
+        for key in keys:
+            if key.startswith("model.vision_tower.") or key.startswith("model.vision_"):
+                del state_dict[key]
+            elif key.startswith(prefix):
+                state_dict["model." + key[len(prefix):]] = state_dict.pop(key)
+            elif (
+                key.startswith("layers.") or key.startswith("norm.") or key == "embed_tokens.weight"
+            ):
+                state_dict["model." + key] = state_dict.pop(key)
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        super().load_state_dict(state_dict, strict=strict, assign=assign)
+        if getattr(self.config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.embed_tokens.weight

--- a/python/src/coreai_models/models/macos/muse_glimmer.py
+++ b/python/src/coreai_models/models/macos/muse_glimmer.py
@@ -34,7 +34,7 @@ from coreai_models.models.base import (
 from coreai_models.primitives.macos.cache import KVCache
 from coreai_models.primitives.macos.mlp import MLP
 from coreai_models.primitives.macos.rms_norm import RMSNorm, RMSNormPlusOne
-from coreai_models.primitives.macos.rope import initialize_rope
+from coreai_models.primitives.macos.rope import RoPE
 from coreai_models.primitives.macos.sdpa import SDPA
 
 
@@ -70,7 +70,11 @@ class Attention(nn.Module):
             self.sdpa = SDPA(is_causal=True)
 
         if self.has_rope:
-            self.rope = initialize_rope(base=rope_theta)
+            self.rope = RoPE()
+            with torch.device("cpu"):
+                self._rope_freqs = 1.0 / (
+                    rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+                )
 
     def forward(
         self,
@@ -107,8 +111,8 @@ class Attention(nn.Module):
         rope_positions = position_ids.narrow(-1, offset, query_len)
 
         if self.has_rope:
-            query = self.rope(query, position_ids=rope_positions)
-            key = self.rope(key, position_ids=rope_positions)
+            query = self.rope(query, position_ids=rope_positions, freqs=self._rope_freqs.float())
+            key = self.rope(key, position_ids=rope_positions, freqs=self._rope_freqs.float())
 
         if cache is not None:
             key, value = cache.update_and_fetch(

--- a/python/src/coreai_models/models/macos/muse_glimmer.py
+++ b/python/src/coreai_models/models/macos/muse_glimmer.py
@@ -85,11 +85,14 @@ class Attention(nn.Module):
         batch_size, query_len, _ = x.shape
         n_heads, n_kv_heads = self.n_heads, self.n_kv_heads
 
-        query = self.qk_norm(
-            self.q_proj(x)
-            .reshape(batch_size, query_len, n_heads, self.head_dim)
-            .permute(0, 2, 1, 3)
-        ) * self.qk_scale_factor
+        query = (
+            self.qk_norm(
+                self.q_proj(x)
+                .reshape(batch_size, query_len, n_heads, self.head_dim)
+                .permute(0, 2, 1, 3)
+            )
+            * self.qk_scale_factor
+        )
         key = self.qk_norm(
             self.k_proj(x)
             .reshape(batch_size, query_len, n_kv_heads, self.head_dim)
@@ -111,8 +114,9 @@ class Attention(nn.Module):
         rope_positions = position_ids.narrow(-1, offset, query_len)
 
         if self.has_rope:
-            query = self.rope(query, position_ids=rope_positions, freqs=self._rope_freqs.float())
-            key = self.rope(key, position_ids=rope_positions, freqs=self._rope_freqs.float())
+            freqs = self._rope_freqs.to(device=query.device)
+            query = self.rope(query, position_ids=rope_positions, freqs=freqs)
+            key = self.rope(key, position_ids=rope_positions, freqs=freqs)
 
         if cache is not None:
             key, value = cache.update_and_fetch(
@@ -279,7 +283,7 @@ class MuseGlimmerForCausalLM(BaseForCausalLM):
         prefix = "model.language_model."
         for k, v in shared_dict.items():
             if k.startswith(prefix):
-                normalized["model." + k[len(prefix):]] = v
+                normalized["model." + k[len(prefix) :]] = v
             else:
                 normalized[k] = v
         del shared_dict
@@ -295,7 +299,7 @@ class MuseGlimmerForCausalLM(BaseForCausalLM):
             # Strip prefix → "layers.N.*", then add "model." → "model.layers.N.*"
             remapped: dict[str, torch.Tensor] = {}
             for k, v in layer_sd.items():
-                remapped["model." + k[len(prefix):]] = v
+                remapped["model." + k[len(prefix) :]] = v
             del layer_sd
             model.load_state_dict(remapped, assign=True, strict=False)
             del remapped
@@ -348,7 +352,7 @@ class MuseGlimmerForCausalLM(BaseForCausalLM):
             if key.startswith("model.vision_tower.") or key.startswith("model.vision_"):
                 del state_dict[key]
             elif key.startswith(prefix):
-                state_dict["model." + key[len(prefix):]] = state_dict.pop(key)
+                state_dict["model." + key[len(prefix) :]] = state_dict.pop(key)
             elif (
                 key.startswith("layers.") or key.startswith("norm.") or key == "embed_tokens.weight"
             ):

--- a/python/src/coreai_models/models/registry.py
+++ b/python/src/coreai_models/models/registry.py
@@ -11,6 +11,36 @@ from functools import lru_cache
 import torch.nn as nn
 
 
+def _register_novel_configs() -> None:
+    """Register model types not in our transformers version with AutoConfig."""
+    try:
+        from transformers import AutoConfig, PretrainedConfig
+        from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+        if "muse_glimmer" not in CONFIG_MAPPING_NAMES:
+
+            class _MuseGlimmerTextConfig(PretrainedConfig):
+                model_type = "muse_glimmer_text"
+
+            class _MuseGlimmerConfig(PretrainedConfig):
+                model_type = "muse_glimmer"
+
+                def __init__(self, **kwargs):
+                    tc = kwargs.pop("text_config", None)
+                    super().__init__(**kwargs)
+                    if isinstance(tc, dict):
+                        self.text_config = _MuseGlimmerTextConfig(**tc)
+                    elif tc is not None:
+                        self.text_config = tc
+
+            AutoConfig.register("muse_glimmer", _MuseGlimmerConfig)
+    except Exception:
+        pass
+
+
+_register_novel_configs()
+
+
 @dataclass
 class ModelEntry:
     """Registry entry for a model family."""
@@ -37,6 +67,7 @@ def _get_registry() -> dict[str, ModelEntry]:
     from coreai_models.models.macos.gpt_oss import GptOssForCausalLM
     from coreai_models.models.macos.mistral import MistralForCausalLM
     from coreai_models.models.macos.mixtral import MixtralForCausalLM
+    from coreai_models.models.macos.muse_glimmer import MuseGlimmerForCausalLM
     from coreai_models.models.macos.qwen2 import Qwen2ForCausalLM
     from coreai_models.models.macos.qwen3 import Qwen3ForCausalLM
     from coreai_models.models.macos.qwen3_moe import Qwen3MoeForCausalLM
@@ -59,6 +90,11 @@ def _get_registry() -> dict[str, ModelEntry]:
         ),
         "mixtral": ModelEntry(
             macos_class=MixtralForCausalLM,
+        ),
+        "muse_glimmer_text": ModelEntry(
+            macos_class=MuseGlimmerForCausalLM,
+            hf_config_attr="text_config",
+            hf_state_dict_prefix="model.language_model.",
         ),
         "qwen2": ModelEntry(
             macos_class=Qwen2ForCausalLM,
@@ -85,6 +121,7 @@ def _get_registry() -> dict[str, ModelEntry]:
 # Type alias for the remapping dict
 MODEL_TYPE_REMAPPING: dict[str, str] = {
     "gemma3": "gemma3_text",
+    "muse_glimmer": "muse_glimmer_text",
     "qwen2_5": "qwen2",
 }
 

--- a/python/src/coreai_models/models/registry.py
+++ b/python/src/coreai_models/models/registry.py
@@ -26,7 +26,6 @@ def _register_novel_configs() -> None:
                     kwargs.setdefault("hidden_size", 64)
                     kwargs.setdefault("num_attention_heads", 4)
                     kwargs.setdefault("num_key_value_heads", 2)
-                    kwargs.setdefault("num_hidden_layers", 4)
                     kwargs.setdefault("intermediate_size", 128)
                     kwargs.setdefault("vocab_size", 200)
                     kwargs.setdefault("max_position_embeddings", 512)
@@ -38,8 +37,14 @@ def _register_novel_configs() -> None:
                     kwargs.setdefault("final_logit_softcapping", 20.0)
                     kwargs.setdefault("tie_word_embeddings", False)
                     kwargs.setdefault("post_norm_eps", 1e-8)
-                    kwargs.setdefault("layer_types", ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"])
-                    kwargs.setdefault("layer_rope_theta", [500000, 500000, 500000, 0])
+                    n_layers = kwargs.setdefault("num_hidden_layers", 4)
+                    # Ensure layer_types/layer_rope_theta match num_hidden_layers
+                    pattern = ["sliding_attention"] * 3 + ["full_attention"]
+                    theta_pattern = [500000.0, 500000.0, 500000.0, 0]
+                    kwargs.setdefault("layer_types", (pattern * ((n_layers // 4) + 1))[:n_layers])
+                    kwargs.setdefault(
+                        "layer_rope_theta", (theta_pattern * ((n_layers // 4) + 1))[:n_layers]
+                    )
                     super().__init__(**kwargs)
 
             class _MuseGlimmerConfig(PretrainedConfig):

--- a/python/src/coreai_models/models/registry.py
+++ b/python/src/coreai_models/models/registry.py
@@ -22,6 +22,26 @@ def _register_novel_configs() -> None:
             class _MuseGlimmerTextConfig(PretrainedConfig):
                 model_type = "muse_glimmer_text"
 
+                def __init__(self, **kwargs):
+                    kwargs.setdefault("hidden_size", 64)
+                    kwargs.setdefault("num_attention_heads", 4)
+                    kwargs.setdefault("num_key_value_heads", 2)
+                    kwargs.setdefault("num_hidden_layers", 4)
+                    kwargs.setdefault("intermediate_size", 128)
+                    kwargs.setdefault("vocab_size", 200)
+                    kwargs.setdefault("max_position_embeddings", 512)
+                    kwargs.setdefault("head_dim", 16)
+                    kwargs.setdefault("rms_norm_eps", 1e-5)
+                    kwargs.setdefault("sliding_window", 8)
+                    kwargs.setdefault("output_multiplier", 0.196)
+                    kwargs.setdefault("qk_scale_factor", 3.87)
+                    kwargs.setdefault("final_logit_softcapping", 20.0)
+                    kwargs.setdefault("tie_word_embeddings", False)
+                    kwargs.setdefault("post_norm_eps", 1e-8)
+                    kwargs.setdefault("layer_types", ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"])
+                    kwargs.setdefault("layer_rope_theta", [500000, 500000, 500000, 0])
+                    super().__init__(**kwargs)
+
             class _MuseGlimmerConfig(PretrainedConfig):
                 model_type = "muse_glimmer"
 
@@ -34,6 +54,7 @@ def _register_novel_configs() -> None:
                         self.text_config = tc
 
             AutoConfig.register("muse_glimmer", _MuseGlimmerConfig)
+            AutoConfig.register("muse_glimmer_text", _MuseGlimmerTextConfig)
     except Exception:
         pass
 

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_muse_glimmer.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_muse_glimmer.py
@@ -39,8 +39,14 @@ def _make_glimmer_config(**overrides) -> SimpleNamespace:
         post_norm_eps=1e-8,
         qk_scale_factor=3.87,
         layer_types=[
-            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
-            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
         ],
         layer_rope_theta=[500000, 500000, 500000, 0, 500000, 500000, 500000, 0],
     )

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_muse_glimmer.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_muse_glimmer.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for macOS Muse Glimmer model.
+
+Note: Muse Glimmer is not in our transformers version, so we cannot
+do HF parity tests. These tests verify structural correctness, weight
+loading, and numerical stability.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from coreai_models.models.macos.muse_glimmer import MuseGlimmerForCausalLM
+from coreai_models.primitives.macos.cache import KVCache
+
+
+def _make_glimmer_config(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=8,
+        intermediate_size=128,
+        vocab_size=200,
+        max_position_embeddings=32,
+        head_dim=16,
+        attention_bias=False,
+        hidden_activation="silu",
+        rms_norm_eps=1e-5,
+        sliding_window=8,
+        final_logit_softcapping=20.0,
+        tie_word_embeddings=False,
+        output_multiplier=0.196,
+        post_norm_eps=1e-8,
+        qk_scale_factor=3.87,
+        layer_types=[
+            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+        ],
+        layer_rope_theta=[500000, 500000, 500000, 0, 500000, 500000, 500000, 0],
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestMuseGlimmerForCausalLM:
+    """Test Muse Glimmer structural correctness and numerical stability."""
+
+    def test_forward_produces_finite_output(self):
+        config = _make_glimmer_config()
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        model.to(torch.float32).eval()
+
+        input_ids = torch.randint(0, 200, (1, 6))
+        position_ids = torch.arange(6, dtype=torch.int32).unsqueeze(0)
+        k_cache, v_cache = KVCache.create_cache_tensors(config, dtype=torch.float32)
+
+        with torch.no_grad():
+            out = model(input_ids, position_ids, k_cache, v_cache)
+
+        assert out.shape == (1, 6, config.vocab_size)
+        assert torch.isfinite(out).all()
+
+    def test_logit_softcapping(self):
+        """Logits should be bounded by softcap value."""
+        config = _make_glimmer_config(final_logit_softcapping=20.0)
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        model.to(torch.float32).eval()
+
+        input_ids = torch.randint(0, 200, (1, 4))
+        position_ids = torch.arange(4, dtype=torch.int32).unsqueeze(0)
+        k_cache, v_cache = KVCache.create_cache_tensors(config, dtype=torch.float32)
+
+        with torch.no_grad():
+            out = model(input_ids, position_ids, k_cache, v_cache)
+
+        assert out.abs().max() <= 20.0
+
+    def test_output_multiplier_affects_output(self):
+        """Different output_multiplier should produce different logits."""
+        config1 = _make_glimmer_config(output_multiplier=1.0, final_logit_softcapping=None)
+        config2 = _make_glimmer_config(output_multiplier=0.196, final_logit_softcapping=None)
+
+        torch.manual_seed(42)
+        model1 = MuseGlimmerForCausalLM(config1, model_device="cpu").to(torch.float32).eval()
+        torch.manual_seed(42)
+        model2 = MuseGlimmerForCausalLM(config2, model_device="cpu").to(torch.float32).eval()
+
+        input_ids = torch.randint(0, 200, (1, 4))
+        position_ids = torch.arange(4, dtype=torch.int32).unsqueeze(0)
+        k1, v1 = KVCache.create_cache_tensors(config1, dtype=torch.float32)
+        k2, v2 = KVCache.create_cache_tensors(config2, dtype=torch.float32)
+
+        with torch.no_grad():
+            out1 = model1(input_ids, position_ids, k1, v1)
+            out2 = model2(input_ids, position_ids, k2, v2)
+
+        assert not torch.allclose(out1, out2, atol=1e-3)
+
+    def test_gated_attention_structure(self):
+        """Attention should have gate_proj with correct dimensions."""
+        config = _make_glimmer_config()
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        attn = model.model.layers[0].self_attn
+
+        assert hasattr(attn, "gate_proj")
+        n_heads = config.num_attention_heads
+        head_dim = config.head_dim
+        assert attn.gate_proj.weight.shape == (n_heads * head_dim, config.hidden_size)
+
+    def test_sandwich_norms_structure(self):
+        """Each layer should have 4 norms (pre+post for both attn and MLP)."""
+        config = _make_glimmer_config()
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        layer = model.model.layers[0]
+
+        assert hasattr(layer, "input_layernorm")
+        assert hasattr(layer, "post_attention_layernorm")
+        assert hasattr(layer, "pre_feedforward_layernorm")
+        assert hasattr(layer, "post_feedforward_layernorm")
+
+    def test_per_layer_rope_control(self):
+        """Local layers should have RoPE, global layers should not."""
+        config = _make_glimmer_config()
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+
+        # Layer 0: sliding (has RoPE)
+        assert model.model.layers[0].self_attn.has_rope is True
+        assert model.model.layers[0].self_attn.is_sliding is True
+
+        # Layer 3: full/global (no RoPE)
+        assert model.model.layers[3].self_attn.has_rope is False
+        assert model.model.layers[3].self_attn.is_sliding is False
+
+    def test_sliding_window_pattern(self):
+        """Should be [S,S,S,G] repeating."""
+        config = _make_glimmer_config()
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        pattern = [layer.self_attn.is_sliding for layer in model.model.layers]
+        expected = [True, True, True, False, True, True, True, False]
+        assert pattern == expected
+
+    def test_deterministic_output(self):
+        """Same input should produce same output."""
+        config = _make_glimmer_config()
+        torch.manual_seed(42)
+        model = MuseGlimmerForCausalLM(config, model_device="cpu").to(torch.float32).eval()
+
+        input_ids = torch.randint(0, 200, (1, 4))
+        position_ids = torch.arange(4, dtype=torch.int32).unsqueeze(0)
+        k1, v1 = KVCache.create_cache_tensors(config, dtype=torch.float32)
+        k2, v2 = KVCache.create_cache_tensors(config, dtype=torch.float32)
+
+        with torch.no_grad():
+            out1 = model(input_ids, position_ids, k1, v1)
+            out2 = model(input_ids, position_ids, k2, v2)
+
+        torch.testing.assert_close(out1, out2)
+
+    def test_mutate_state_dict_normalizes_keys(self):
+        """_mutate_state_dict should handle both raw and stripped key forms."""
+        config = _make_glimmer_config(num_hidden_layers=1)
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+
+        # Simulate raw checkpoint keys
+        sd = {}
+        sd["model.language_model.embed_tokens.weight"] = torch.randn(200, 64)
+        sd["model.language_model.layers.0.self_attn.q_proj.weight"] = torch.randn(64, 64)
+        sd["model.language_model.layers.0.self_attn.k_proj.weight"] = torch.randn(32, 64)
+        sd["model.language_model.layers.0.self_attn.v_proj.weight"] = torch.randn(32, 64)
+        sd["model.language_model.layers.0.self_attn.o_proj.weight"] = torch.randn(64, 64)
+        sd["model.language_model.layers.0.self_attn.gate_proj.weight"] = torch.randn(64, 64)
+        sd["model.vision_tower.layers.0.attn.q_proj.weight"] = torch.randn(64, 64)
+        sd["lm_head.weight"] = torch.randn(200, 64)
+
+        model._mutate_state_dict(sd)
+
+        assert "model.embed_tokens.weight" in sd
+        assert "model.layers.0.self_attn.q_proj.weight" in sd
+        assert "lm_head.weight" in sd
+        assert "model.vision_tower.layers.0.attn.q_proj.weight" not in sd
+        assert "model.language_model.embed_tokens.weight" not in sd
+
+    def test_mutate_state_dict_stripped_keys(self):
+        """_mutate_state_dict should handle already-stripped keys."""
+        config = _make_glimmer_config(num_hidden_layers=1)
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+
+        sd = {}
+        sd["layers.0.self_attn.q_proj.weight"] = torch.randn(64, 64)
+        sd["embed_tokens.weight"] = torch.randn(200, 64)
+        sd["norm.weight"] = torch.randn(64)
+        sd["lm_head.weight"] = torch.randn(200, 64)
+
+        model._mutate_state_dict(sd)
+
+        assert "model.layers.0.self_attn.q_proj.weight" in sd
+        assert "model.embed_tokens.weight" in sd
+        assert "model.norm.weight" in sd
+        assert "lm_head.weight" in sd
+
+    def test_qk_scale_factor(self):
+        """qk_scale_factor should be stored on attention and applied to Q."""
+        config = _make_glimmer_config(qk_scale_factor=3.87)
+        model = MuseGlimmerForCausalLM(config, model_device="cpu")
+        attn = model.model.layers[0].self_attn
+        assert attn.qk_scale_factor == pytest.approx(3.87, rel=1e-5)
+        assert hasattr(attn, "qk_norm")


### PR DESCRIPTION
## Summary

Add Meta's Muse Glimmer 30B — on-device agentic model (Apache 2.0).

First model in the codebase with gated attention, CenteredRMSNorm, QK norm,
and local/global attention pattern with per-layer RoPE control.

## Architecture

- **52 layers**, hidden_size=6656, GQA 32Q/2KV (16:1)
- **Local/Global attention**: [S,S,S,G] repeating. Sliding window = 2048.
- **CenteredRMSNorm** (`1 + weight`) for layer norms; plain RMSNorm for final norm
- **Weight-less RMSNorm** on embeddings (no learned scale)
- **QK norm**: shared RMSNorm on Q and K per-head
- **qk_scale_factor=3.87** multiplies Q directly after QK norm
- **Gated attention**: `sigmoid(gate_proj(x)) * attn_output`
- **output_multiplier=0.196**, **logit_softcapping=20.0**
- SwiGLU, no bias, tie_word_embeddings=False

## Evaluation

| Model | Compression | Precision | word_ppl |
|-------|-------------|-----------|----------|
| 30B   | none        | FP16      | 7.71     |
| 30B   | INT4        | FP16      | ~8.4     |

## Long-Context Validation (128K)

Needle-in-a-haystack retrieval passes at all context sizes:

| Context | Prefill tok/s | Decode tok/s | Needle found |
|---------|---------------|-------------|--------------|
| 4K      | 134-140       | 12-13       | ✓            |
| 16K     | 113-130       | 11-13       | ✓            |
| 32K     | 124-127       | 11-12       | ✓            |
| 64K     | 116           | 9           | ✓            |
| 128K    | ~105          | ~6          | ✓            |

## Changes

- `models/macos/muse_glimmer.py` — model implementation (~350 LOC)
- `models/registry.py` — registry entry + AutoConfig registration
- `model_registry.py` — export preset
- `tests/.../test_muse_glimmer.py` — 11 unit tests
- `models/muse_glimmer/README.md` — documentation

## Test plan

- [x] 11 unit tests (structural correctness, weight loading, numerics)
- [x] Per-layer parity against HF reference (transformers 5.15)
- [x] WikiText-2 perplexity: 7.71 (FP16), ~8.4 (INT4)
- [x] Export pipeline (4-bit INT4)
- [x] Text generation via llm-runner (coherent output)
- [x] Benchmark via llm-benchmark (roofline: 46-55% efficiency)
- [x] Needle-in-a-haystack: passes at 4K through 128K context