### PR TITLE
Add timing to model preparation and warm up for llm-benchmark

### DIFF
--- a/swift/Sources/Tools/benchmark/BenchmarkMain.swift
+++ b/swift/Sources/Tools/benchmark/BenchmarkMain.swift
@@ -87,18 +87,25 @@ struct LLMBenchmark: AsyncParsableCommand {
         let configData = try JSONEncoder().encode(engineConfig)
         print("\n⏳ Preparing AI asset...", terminator: "")
         fflush(stdout)
+        let prepareStart = SuspendingClock.now
         let engine = try await EngineFactory.createEngine(
             config: configData,
             modelURL: modelURL
         )
-        print(cacheHit ? " done (cache hit)" : " done")
+        let prepareSeconds = (SuspendingClock.now - prepareStart).inSeconds
+        let cacheSuffix = cacheHit ? " (cache hit)" : ""
+        print(" done in \(fmt(prepareSeconds))s\(cacheSuffix)")
 
         let prompt = randomPrompt(vocabSize: vocabSize, count: promptTokens, seed: seed)
         let sampling = SamplingConfiguration(temperature: 0)
 
         // Warmup
-        print("\n⚙️  Warming up engine...")
+        print("\n⚙️  Warming up engine...", terminator: "")
+        fflush(stdout)
+        let warmupStart = SuspendingClock.now
         _ = try await runTrial(engine: engine, prompt: prompt, sampling: sampling)
+        let warmupSeconds = (SuspendingClock.now - warmupStart).inSeconds
+        print(" done in \(fmt(warmupSeconds))s")
 
         // Timed trials
         print("\n🔄 Benchmarking with \(promptTokens) prompt tokens, \(generationTokens) generation tokens\n")
@@ -118,6 +125,8 @@ struct LLMBenchmark: AsyncParsableCommand {
         let avgGen = trials.map(\.genTps).reduce(0, +) / n
         print("\n📊 Benchmark Summary:")
         print(String(repeating: "=", count: 50))
+        print("Prepare:    \(fmt(prepareSeconds))s\(cacheSuffix)")
+        print("Warmup:     \(fmt(warmupSeconds))s")
         print("Prompt:     \(fmt(avgPrompt)) tokens/sec")
         print("Generation: \(fmt(avgGen)) tokens/sec")
         print(String(repeating: "=", count: 50))
@@ -128,6 +137,9 @@ struct LLMBenchmark: AsyncParsableCommand {
                 promptTokens: promptTokens,
                 generationTokens: generationTokens,
                 numTrials: numTrials,
+                prepareSeconds: prepareSeconds,
+                cacheHit: cacheHit,
+                warmupSeconds: warmupSeconds,
                 trials: trials,
                 averages: BenchmarkReport.Averages(
                     promptTps: avgPrompt, generationTps: avgGen)
@@ -193,9 +205,7 @@ struct LLMBenchmark: AsyncParsableCommand {
     }
 
     private func seconds(from start: SuspendingClock.Instant, to end: SuspendingClock.Instant) -> Double {
-        let d = end - start
-        let (secs, atto) = d.components
-        return Double(secs) + Double(atto) / 1e18
+        (end - start).inSeconds
     }
 
     private func fmt(_ v: Double) -> String {
@@ -229,6 +239,9 @@ struct BenchmarkReport: Codable {
     let promptTokens: Int
     let generationTokens: Int
     let numTrials: Int
+    let prepareSeconds: Double
+    let cacheHit: Bool
+    let warmupSeconds: Double
     let trials: [TrialResult]
     let averages: Averages
 


### PR DESCRIPTION
```
➜  coreai-models git:(main) ✗ swift run -c release llm-benchmark --model exports/qwen3_0_6b_mixed_4bit_8bit_static
Building for production...
[1 / 33] Models

Build complete! (1.70 sec)

⏳ Preparing AI asset... done in 0.045s (cache hit)

⚙️  Warming up engine... done in 14.317s

🔄 Benchmarking with 512 prompt tokens, 1024 generation tokens

🧪 Trial 1
⚡ Prompt:     2901.243 tokens/sec
🏃 Generation: 91.095 tokens/sec

🧪 Trial 2
⚡ Prompt:     2511.185 tokens/sec
🏃 Generation: 91.482 tokens/sec

🧪 Trial 3
⚡ Prompt:     2939.403 tokens/sec
🏃 Generation: 91.623 tokens/sec

🧪 Trial 4
⚡ Prompt:     2790.124 tokens/sec
🏃 Generation: 91.086 tokens/sec

🧪 Trial 5
⚡ Prompt:     2215.463 tokens/sec
🏃 Generation: 91.329 tokens/sec

📊 Benchmark Summary:
==================================================
Prepare:    0.045s (cache hit)
Warmup:     14.317s
Prompt:     2671.484 tokens/sec
Generation: 91.323 tokens/sec
==================================================
```