### PR TITLE
Add tool calling support to LLM server

### DIFF
--- a/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
+++ b/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
@@ -18,14 +18,19 @@ public struct ChatCompletionRequest: Decodable, Sendable {
     public let stream: Bool?
     public let stop: [String]?
     public let responseFormat: ResponseFormat?
+    public let tools: [ToolDefinition]?
+    public let toolChoice: ToolChoice?
+    public let parallelToolCalls: Bool?
 
     enum CodingKeys: String, CodingKey {
-        case model, messages, temperature, stream, stop
+        case model, messages, temperature, stream, stop, tools
         case maxTokens = "max_tokens"
         case maxCompletionTokens = "max_completion_tokens"
         case topP = "top_p"
         case topK = "top_k"
         case responseFormat = "response_format"
+        case toolChoice = "tool_choice"
+        case parallelToolCalls = "parallel_tool_calls"
     }
 
     public init(from decoder: Decoder) throws {
@@ -39,6 +44,9 @@ public struct ChatCompletionRequest: Decodable, Sendable {
         topK = try container.decodeIfPresent(Int.self, forKey: .topK)
         stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
         responseFormat = try container.decodeIfPresent(ResponseFormat.self, forKey: .responseFormat)
+        tools = try container.decodeIfPresent([ToolDefinition].self, forKey: .tools)
+        toolChoice = try container.decodeIfPresent(ToolChoice.self, forKey: .toolChoice)
+        parallelToolCalls = try container.decodeIfPresent(Bool.self, forKey: .parallelToolCalls)
 
         if let arr = try? container.decode([String].self, forKey: .stop) {
             stop = arr
@@ -123,6 +131,17 @@ public enum JSONValue: Codable, Sendable {
         case .null: try container.encodeNil()
         }
     }
+
+    public func asJSONObject() -> Any {
+        switch self {
+        case .string(let s): return s
+        case .number(let n): return n
+        case .bool(let b): return b
+        case .null: return NSNull()
+        case .object(let obj): return obj.mapValues { $0.asJSONObject() }
+        case .array(let arr): return arr.map { $0.asJSONObject() }
+        }
+    }
 }
 
 // MARK: - Chat Message
@@ -130,14 +149,22 @@ public enum JSONValue: Codable, Sendable {
 public struct ChatMessage: Decodable, Sendable {
     public let role: String
     public let content: MessageContent
+    public let toolCalls: [ToolCall]?
+    public let toolCallId: String?
+    public let name: String?
 
     enum CodingKeys: String, CodingKey {
-        case role, content
+        case role, content, name
+        case toolCalls = "tool_calls"
+        case toolCallId = "tool_call_id"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         role = try container.decode(String.self, forKey: .role)
+        toolCalls = try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
+        toolCallId = try container.decodeIfPresent(String.self, forKey: .toolCallId)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
 
         if let text = try? container.decode(String.self, forKey: .content) {
             content = .text(text)
@@ -247,10 +274,22 @@ public struct ChatCompletionResponse: Encodable, Sendable {
 
     public struct ResponseMessage: Encodable, Sendable {
         public let role: String
-        public let content: String
-        public init(role: String, content: String) {
+        public let content: String?
+        public let toolCalls: [ToolCall]?
+        public init(role: String, content: String?, toolCalls: [ToolCall]? = nil) {
             self.role = role
             self.content = content
+            self.toolCalls = toolCalls
+        }
+        enum CodingKeys: String, CodingKey {
+            case role, content
+            case toolCalls = "tool_calls"
+        }
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(role, forKey: .role)
+            try container.encode(content, forKey: .content)
+            try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
         }
     }
 
@@ -310,9 +349,21 @@ public struct ChatCompletionChunk: Encodable, Sendable {
     public struct Delta: Encodable, Sendable {
         public let role: String?
         public let content: String?
-        public init(role: String? = nil, content: String? = nil) {
+        public let toolCalls: [ToolCallDelta]?
+        public init(role: String? = nil, content: String? = nil, toolCalls: [ToolCallDelta]? = nil) {
             self.role = role
             self.content = content
+            self.toolCalls = toolCalls
+        }
+        enum CodingKeys: String, CodingKey {
+            case role, content
+            case toolCalls = "tool_calls"
+        }
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(role, forKey: .role)
+            try container.encode(content, forKey: .content)
+            try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
         }
     }
 }
@@ -372,5 +423,125 @@ public struct ErrorResponse: Encodable, Sendable {
             self.type = type
             self.code = code
         }
+    }
+}
+
+// MARK: - Tool Calling Types
+
+public struct ToolDefinition: Codable, Sendable {
+    public let type: String
+    public let function: FunctionDefinition
+
+    public init(type: String = "function", function: FunctionDefinition) {
+        self.type = type
+        self.function = function
+    }
+}
+
+public struct FunctionDefinition: Codable, Sendable {
+    public let name: String
+    public let description: String?
+    public let parameters: JSONValue?
+    public let strict: Bool?
+
+    public init(name: String, description: String? = nil, parameters: JSONValue? = nil, strict: Bool? = nil) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.strict = strict
+    }
+}
+
+public enum ToolChoice: Sendable, Equatable {
+    case auto
+    case none
+    case required
+    case function(name: String)
+}
+
+extension ToolChoice: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            switch str {
+            case "auto": self = .auto
+            case "none": self = .none
+            case "required": self = .required
+            default: self = .auto
+            }
+        } else {
+            let obj = try container.decode(ToolChoiceObject.self)
+            self = .function(name: obj.function.name)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .auto: try container.encode("auto")
+        case .none: try container.encode("none")
+        case .required: try container.encode("required")
+        case .function(let name):
+            try container.encode(ToolChoiceObject(function: ToolChoiceFunctionName(name: name)))
+        }
+    }
+
+    private struct ToolChoiceObject: Codable {
+        let type: String
+        let function: ToolChoiceFunctionName
+        init(function: ToolChoiceFunctionName) {
+            self.type = "function"
+            self.function = function
+        }
+    }
+
+    private struct ToolChoiceFunctionName: Codable {
+        let name: String
+    }
+}
+
+public struct ToolCall: Codable, Sendable {
+    public let id: String
+    public let type: String
+    public let function: ToolCallFunction
+
+    public init(id: String, type: String = "function", function: ToolCallFunction) {
+        self.id = id
+        self.type = type
+        self.function = function
+    }
+}
+
+public struct ToolCallFunction: Codable, Sendable {
+    public let name: String
+    public let arguments: String
+
+    public init(name: String, arguments: String) {
+        self.name = name
+        self.arguments = arguments
+    }
+}
+
+public struct ToolCallDelta: Encodable, Sendable {
+    public let index: Int
+    public let id: String?
+    public let type: String?
+    public let function: ToolCallFunctionDelta?
+
+    public init(index: Int, id: String? = nil, type: String? = nil, function: ToolCallFunctionDelta? = nil) {
+        self.index = index
+        self.id = id
+        self.type = type
+        self.function = function
+    }
+}
+
+public struct ToolCallFunctionDelta: Encodable, Sendable {
+    public let name: String?
+    public let arguments: String?
+
+    public init(name: String? = nil, arguments: String? = nil) {
+        self.name = name
+        self.arguments = arguments
     }
 }

--- a/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
+++ b/swift/Sources/CoreAILanguageModels/ToolCallParser.swift
@@ -4,10 +4,11 @@
 // be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
 import Foundation
+import Tokenizers
 
 /// Streaming parser that detects tool call blocks in the model's token stream.
-struct ToolCallParser {
-    enum Event {
+public struct ToolCallParser: Sendable {
+    public enum Event {
         case text(String)
         case toolCall(id: String, name: String, argsJSON: String)
     }
@@ -17,12 +18,12 @@ struct ToolCallParser {
     private var buffer: String = ""
     private var isInsideToolCall: Bool = false
 
-    init(openMarker: String = "<tool_call>", closeMarker: String = "</tool_call>") {
+    public init(openMarker: String = "<tool_call>", closeMarker: String = "</tool_call>") {
         self.openMarker = openMarker
         self.closeMarker = closeMarker
     }
 
-    mutating func consume(_ delta: String) -> [Event] {
+    public mutating func consume(_ delta: String) -> [Event] {
         buffer.append(delta)
         return drain(isFinal: false)
     }
@@ -34,7 +35,7 @@ struct ToolCallParser {
     /// at EOS is dropped (malformed JSON is not useful to surface as text).
     /// Exception: newline-terminated formats (e.g. Mistral's `[TOOL_CALLS]`)
     /// have no trailing close token, so the buffered content is parsed on EOS.
-    mutating func flush() -> [Event] {
+    public mutating func flush() -> [Event] {
         drain(isFinal: true)
     }
 
@@ -111,6 +112,28 @@ struct ToolCallParser {
             argsJSON = "{}"
         }
 
-        return .toolCall(id: UUID().uuidString, name: name, argsJSON: argsJSON)
+        let callId = "call_\(UUID().uuidString.prefix(8).lowercased())"
+        return .toolCall(id: callId, name: name, argsJSON: argsJSON)
     }
+}
+
+// MARK: - Tool Call Marker Detection
+
+/// Probes a tokenizer's vocabulary for known tool-call special tokens.
+/// Returns the (open, close) marker pair if the model supports tool calling, nil otherwise.
+public func detectToolCallMarkers(using tokenizer: any Tokenizer) -> (open: String, close: String)? {
+    let tagPairs: [(open: String, close: String)] = [
+        ("<tool_call>", "</tool_call>"),
+        ("<function_calls>", "</function_calls>"),
+    ]
+    for pair in tagPairs
+    where tokenizer.convertTokenToId(pair.open) != nil
+        && tokenizer.convertTokenToId(pair.close) != nil
+    {
+        return pair
+    }
+    if tokenizer.convertTokenToId("[TOOL_CALLS]") != nil {
+        return (open: "[TOOL_CALLS]", close: "\n")
+    }
+    return nil
 }

--- a/swift/Sources/Tools/llm-server/ChatHandler.swift
+++ b/swift/Sources/Tools/llm-server/ChatHandler.swift
@@ -164,7 +164,7 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
         minP: nil
     )
 
-    let promptTokens = tokenizeMessages(chatRequest.messages, state: state)
+    let promptTokens = tokenizeMessages(chatRequest.messages, tools: chatRequest.tools, state: state)
     let stopSequences = buildStopSequences(from: chatRequest, state: state)
     let input: Input = .tokens(promptTokens)
 
@@ -212,15 +212,48 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
     let elapsed = SuspendingClock().now - t0
     let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
     let cleaned = stripThinkingTags(text)
-    let finishReason = genTokenCount >= requestMaxTokens ? "length" : "stop"
+
+    // Parse tool calls if the model supports them and tools were requested
+    var responseContent: String? = cleaned
+    var responseToolCalls: [ToolCall]? = nil
+    var finishReason = genTokenCount >= requestMaxTokens ? "length" : "stop"
+
+    if chatRequest.tools != nil, var parser = state.makeToolCallParser() {
+        let events = parser.consume(cleaned) + parser.flush()
+        var textParts: [String] = []
+        var toolCalls: [ToolCall] = []
+        for event in events {
+            switch event {
+            case .text(let t):
+                textParts.append(t)
+            case .toolCall(let id, let name, let argsJSON):
+                toolCalls.append(ToolCall(id: id, function: .init(name: name, arguments: argsJSON)))
+            }
+        }
+        if !toolCalls.isEmpty {
+            responseToolCalls = toolCalls
+            if finishReason != "length" {
+                finishReason = "tool_calls"
+            }
+            let remaining = textParts.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+            responseContent = remaining.isEmpty ? nil : remaining
+            state.recordToolCalls(toolCalls.map(\.function.name))
+        }
+    }
 
     let tokPerSec = seconds > 0 ? Double(genTokenCount) / seconds : 0
-    print(
-        "[\(requestID)] \(promptTokens.count)t → \(genTokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s)"
-    )
+    var logLine =
+        "\(ts()) [\(requestID)] \(promptTokens.count)t → \(genTokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s)"
+    if let calls = responseToolCalls {
+        logLine += " → \(calls.count) tool call(s)"
+        if CLILogger.level > 0 {
+            logLine += ": \(calls.map(\.function.name).joined(separator: ", "))"
+        }
+    }
+    print(logLine)
     state.stats.record(
         promptTokens: promptTokens.count, genTokens: genTokenCount, promptSeconds: 0, genSeconds: seconds,
-        totalSeconds: seconds)
+        totalSeconds: seconds, toolCalls: responseToolCalls?.count ?? 0)
     state.recordPromptTokens(promptTokensInt32)
 
     let response = ChatCompletionResponse(
@@ -231,7 +264,7 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
         choices: [
             .init(
                 index: 0,
-                message: .init(role: "assistant", content: cleaned),
+                message: .init(role: "assistant", content: responseContent, toolCalls: responseToolCalls),
                 finishReason: finishReason
             )
         ],
@@ -269,7 +302,7 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
         minP: nil
     )
 
-    let promptTokens = tokenizeMessages(chatRequest.messages, state: state)
+    let promptTokens = tokenizeMessages(chatRequest.messages, tools: chatRequest.tools, state: state)
     let stopSequences = buildStopSequences(from: chatRequest, state: state)
     let input: Input = .tokens(promptTokens)
 
@@ -319,41 +352,79 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             )
 
             var thinkParser = ThinkTagParser()
+            var toolParser = state.makeToolCallParser()
             var tokenCount = 0
+            var hasToolCalls = false
+            var toolCallIndex = 0
+            var toolCallNames: [String] = []
+
+            // Emit a single SSE chunk (text content or tool call delta)
+            func emitChunk(_ delta: ChatCompletionChunk.Delta) async throws {
+                let chunk = ChatCompletionChunk(
+                    id: requestID, object: "chat.completion.chunk", created: created,
+                    model: state.config.modelName,
+                    choices: [.init(index: 0, delta: delta, finishReason: nil)])
+                if let data = try? encoder.encode(chunk),
+                    let json = String(data: data, encoding: .utf8)
+                {
+                    try await writer.write(ByteBuffer(string: "data: \(json)\n\n"))
+                }
+            }
+
+            // Process tool parser events: emit text as content, tool calls as deltas
+            func emitToolEvents(_ events: [ToolCallParser.Event]) async throws {
+                for event in events {
+                    switch event {
+                    case .text(let t) where !t.isEmpty:
+                        try await emitChunk(.init(role: nil, content: t))
+                    case .toolCall(let id, let name, let argsJSON):
+                        hasToolCalls = true
+                        toolCallNames.append(name)
+                        let tcDelta = ToolCallDelta(
+                            index: toolCallIndex, id: id, type: "function",
+                            function: .init(name: name, arguments: argsJSON))
+                        try await emitChunk(.init(role: nil, content: nil, toolCalls: [tcDelta]))
+                        toolCallIndex += 1
+                    default: break
+                    }
+                }
+            }
+
+            // Process text through the tool parser (or emit directly if no tool support)
+            func emitText(_ text: String) async throws {
+                guard !text.isEmpty else { return }
+                if var tp = toolParser {
+                    let events = tp.consume(text)
+                    toolParser = tp
+                    try await emitToolEvents(events)
+                } else {
+                    try await emitChunk(.init(role: nil, content: text))
+                }
+            }
 
             for try await result in tokenStream {
                 tokenCount += 1
-                let events = thinkParser.consume(result.text)
-                for event in events {
-                    if case .text(let delta) = event, !delta.isEmpty {
-                        let chunk = ChatCompletionChunk(
-                            id: requestID, object: "chat.completion.chunk", created: created,
-                            model: state.config.modelName,
-                            choices: [.init(index: 0, delta: .init(role: nil, content: delta), finishReason: nil)]
-                        )
-                        if let data = try? encoder.encode(chunk), let json = String(data: data, encoding: .utf8) {
-                            try await writer.write(ByteBuffer(string: "data: \(json)\n\n"))
-                        }
+                for event in thinkParser.consume(result.text) {
+                    if case .text(let delta) = event {
+                        try await emitText(delta)
                     }
                 }
             }
 
-            // Flush any remaining buffered text
-            let finalEvents = thinkParser.flush()
-            for event in finalEvents {
-                if case .text(let delta) = event, !delta.isEmpty {
-                    let chunk = ChatCompletionChunk(
-                        id: requestID, object: "chat.completion.chunk", created: created,
-                        model: state.config.modelName,
-                        choices: [.init(index: 0, delta: .init(role: nil, content: delta), finishReason: nil)]
-                    )
-                    if let data = try? encoder.encode(chunk), let json = String(data: data, encoding: .utf8) {
-                        try await writer.write(ByteBuffer(string: "data: \(json)\n\n"))
-                    }
+            // Flush think parser
+            for event in thinkParser.flush() {
+                if case .text(let delta) = event {
+                    try await emitText(delta)
                 }
             }
 
-            let finishReason = tokenCount >= requestMaxTokens ? "length" : "stop"
+            // Flush tool parser
+            if var tp = toolParser {
+                try await emitToolEvents(tp.flush())
+                toolParser = tp
+            }
+
+            let finishReason = tokenCount >= requestMaxTokens ? "length" : (hasToolCalls ? "tool_calls" : "stop")
             let doneChunk = ChatCompletionChunk(
                 id: requestID, object: "chat.completion.chunk", created: created, model: state.config.modelName,
                 choices: [.init(index: 0, delta: .init(role: nil, content: nil), finishReason: finishReason)]
@@ -366,17 +437,26 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             let elapsed = SuspendingClock().now - genStart
             let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
             let tokPerSec = seconds > 0 ? Double(tokenCount) / seconds : 0
-            print(
-                "[\(requestID)] stream: \(promptTokens.count)t → \(tokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s) [\(finishReason)]"
-            )
+            var logLine =
+                "\(ts()) [\(requestID)] stream: \(promptTokens.count)t → \(tokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s) [\(finishReason)]"
+            if !toolCallNames.isEmpty {
+                logLine += " → \(toolCallNames.count) tool call(s)"
+                if CLILogger.level > 0 {
+                    logLine += ": \(toolCallNames.joined(separator: ", "))"
+                }
+            }
+            print(logLine)
             state.stats.record(
                 promptTokens: promptTokens.count, genTokens: tokenCount, promptSeconds: 0, genSeconds: seconds,
-                totalSeconds: seconds)
+                totalSeconds: seconds, toolCalls: toolCallNames.count)
             state.recordPromptTokens(promptTokensInt32)
+            if !toolCallNames.isEmpty {
+                state.recordToolCalls(toolCallNames)
+            }
 
             try await writer.finish(nil)
         } catch {
-            print("[\(requestID)] stream error: \(error)")
+            print("\(ts()) [\(requestID)] stream error: \(error)")
             try? await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
             try? await writer.finish(nil)
         }
@@ -395,26 +475,80 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
 
 // MARK: - Helpers
 
-private func tokenizeMessages(_ messages: [ChatMessage], state: ServerState) -> [Int] {
+private func tokenizeMessages(
+    _ messages: [ChatMessage], tools: [ToolDefinition]? = nil, state: ServerState
+) -> [Int] {
     var templateMessages: [[String: any Sendable]] = []
     for msg in messages {
-        var content = msg.content.textContent
-        if msg.role == "system" && state.config.noThinking {
-            content += "\n/no_think"
+        var dict: [String: any Sendable] = ["role": msg.role]
+
+        if msg.role == "tool" {
+            dict["content"] = msg.content.textContent
+            if let id = msg.toolCallId { dict["tool_call_id"] = id }
+        } else if msg.role == "assistant", let calls = msg.toolCalls, !calls.isEmpty {
+            let callDicts: [[String: any Sendable]] = calls.map { call in
+                [
+                    "id": call.id,
+                    "type": "function",
+                    "function": [
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    ] as [String: any Sendable],
+                ]
+            }
+            dict["tool_calls"] = callDicts
+            dict["content"] = msg.content.textContent
+        } else {
+            var content = msg.content.textContent
+            if msg.role == "system" && state.config.noThinking {
+                content += "\n/no_think"
+            }
+            dict["content"] = content
         }
-        templateMessages.append(["role": msg.role, "content": content])
+        templateMessages.append(dict)
     }
 
     if state.config.noThinking && !messages.contains(where: { $0.role == "system" }) {
         templateMessages.insert(["role": "system", "content": "/no_think"], at: 0)
     }
 
-    if let tokens = try? state.tokenizer.applyChatTemplate(messages: templateMessages) {
-        return tokens
+    let toolSpecs: [[String: any Sendable]]? = tools?.map { tool in
+        var funcDict: [String: any Sendable] = [
+            "name": tool.function.name,
+            "description": tool.function.description ?? "",
+        ]
+        if let params = tool.function.parameters {
+            funcDict["parameters"] = jsonValueToSendable(params)
+        }
+        let spec: [String: any Sendable] = [
+            "type": tool.type,
+            "function": funcDict,
+        ]
+        return spec
     }
 
-    let text = templateMessages.map { "\($0["role"] ?? "user"): \($0["content"] ?? "")" }.joined(separator: "\n")
+    do {
+        let tokens = try state.tokenizer.applyChatTemplate(
+            messages: templateMessages, tools: toolSpecs)
+        return tokens
+    } catch {
+        CLILogger.log("applyChatTemplate failed: \(error)", component: "Server")
+    }
+
+    let text = templateMessages.map { "\($0["role"] ?? "user"): \($0["content"] ?? "")" }
+        .joined(separator: "\n")
     return state.tokenizer.encode(text: text)
+}
+
+private func jsonValueToSendable(_ value: JSONValue) -> any Sendable {
+    switch value {
+    case .string(let s): return s
+    case .number(let n): return n
+    case .bool(let b): return b
+    case .null: return Optional<String>.none as any Sendable
+    case .object(let obj): return obj.mapValues { jsonValueToSendable($0) } as [String: any Sendable]
+    case .array(let arr): return arr.map { jsonValueToSendable($0) } as [any Sendable]
+    }
 }
 
 private func buildStopSequences(from request: ChatCompletionRequest, state: ServerState) -> StopSequences {
@@ -436,4 +570,13 @@ private func buildStopSequences(from request: ChatCompletionRequest, state: Serv
 
 private func stripThinkingTags(_ text: String) -> String {
     ThinkTagParser.stripCompleted(from: text)
+}
+
+private func ts() -> String {
+    let now = Date()
+    let calendar = Calendar.current
+    let h = calendar.component(.hour, from: now)
+    let m = calendar.component(.minute, from: now)
+    let s = calendar.component(.second, from: now)
+    return String(format: "%02d:%02d:%02d", h, m, s)
 }

--- a/swift/Sources/Tools/llm-server/ServerState.swift
+++ b/swift/Sources/Tools/llm-server/ServerState.swift
@@ -37,11 +37,15 @@ final class ServerStats: @unchecked Sendable {
         var totalPromptSeconds: Double = 0
         var totalGenSeconds: Double = 0
         var totalSeconds: Double = 0
+        var totalToolCalls: Int = 0
         var lastPrintTime: ContinuousClock.Instant = .now
         var requestsSinceLastPrint: Int = 0
     }
 
-    func record(promptTokens: Int, genTokens: Int, promptSeconds: Double, genSeconds: Double, totalSeconds: Double) {
+    func record(
+        promptTokens: Int, genTokens: Int, promptSeconds: Double, genSeconds: Double, totalSeconds: Double,
+        toolCalls: Int = 0
+    ) {
         let shouldPrint = lock.withLock { s -> Bool in
             s.totalRequests += 1
             s.totalPromptTokens += promptTokens
@@ -49,6 +53,7 @@ final class ServerStats: @unchecked Sendable {
             s.totalPromptSeconds += promptSeconds
             s.totalGenSeconds += genSeconds
             s.totalSeconds += totalSeconds
+            s.totalToolCalls += toolCalls
             s.requestsSinceLastPrint += 1
 
             let elapsed = ContinuousClock.now - s.lastPrintTime
@@ -70,6 +75,7 @@ final class ServerStats: @unchecked Sendable {
         let avgGenTokPerSec = s.totalGenSeconds > 0 ? Double(s.totalGenTokens) / s.totalGenSeconds : 0
         let avgPromptTokPerSec = s.totalPromptSeconds > 0 ? Double(s.totalPromptTokens) / s.totalPromptSeconds : 0
         let overhead = s.totalSeconds - s.totalPromptSeconds - s.totalGenSeconds
+        let toolLine = s.totalToolCalls > 0 ? "\nTool calls: \(s.totalToolCalls)" : ""
 
         print(
             """
@@ -78,12 +84,15 @@ final class ServerStats: @unchecked Sendable {
             ==================================================
             Prefill:    \(s.totalPromptTokens) tokens, \(String(format: "%.1f", s.totalPromptSeconds))s (\(String(format: "%.1f", avgPromptTokPerSec)) tok/s)
             Generation: \(s.totalGenTokens) tokens, \(String(format: "%.1f", s.totalGenSeconds))s (\(String(format: "%.1f", avgGenTokPerSec)) tok/s)
-            Overhead:   \(String(format: "%.1f", overhead))s (\(String(format: "%.1f", overhead / Double(max(1, s.totalRequests))))s/req)
+            Overhead:   \(String(format: "%.1f", overhead))s (\(String(format: "%.1f", overhead / Double(max(1, s.totalRequests))))s/req)\(toolLine)
             ==================================================
             """)
     }
 
-    func buildResponse(prefixHitRate: Double, prefixHits: Int, prefixMisses: Int) -> StatsResponse {
+    func buildResponse(
+        prefixHitRate: Double, prefixHits: Int, prefixMisses: Int,
+        totalToolCalls: Int, topTools: [ToolCallStat]
+    ) -> StatsResponse {
         let s = lock.withLock { $0 }
         return StatsResponse(
             totalRequests: s.totalRequests,
@@ -93,7 +102,9 @@ final class ServerStats: @unchecked Sendable {
             avgDecodeTokPerSec: s.totalGenSeconds > 0 ? Double(s.totalGenTokens) / s.totalGenSeconds : 0,
             prefixHitRate: prefixHitRate,
             prefixHits: prefixHits,
-            prefixMisses: prefixMisses
+            prefixMisses: prefixMisses,
+            totalToolCalls: totalToolCalls,
+            topTools: topTools.isEmpty ? nil : topTools
         )
     }
 }
@@ -105,6 +116,7 @@ final class ServerState: @unchecked Sendable {
     let tokenizer: any Tokenizer
     let config: ServerConfig
     let stats = ServerStats()
+    let toolCallMarkers: (open: String, close: String)?
     private let _state = Mutex<InternalState>(InternalState())
 
     private struct InternalState {
@@ -113,12 +125,22 @@ final class ServerState: @unchecked Sendable {
         var lastPromptTokens: [Int32] = []
         var prefixHits: Int = 0
         var prefixMisses: Int = 0
+        var toolCallCounts: [String: Int] = [:]
+        var totalToolCalls: Int = 0
     }
 
     init(engine: any InferenceEngine, tokenizer: any Tokenizer, config: ServerConfig) {
         self.engine = engine
         self.tokenizer = tokenizer
         self.config = config
+        self.toolCallMarkers = detectToolCallMarkers(using: tokenizer)
+    }
+
+    var supportsToolCalling: Bool { toolCallMarkers != nil }
+
+    func makeToolCallParser() -> ToolCallParser? {
+        guard let markers = toolCallMarkers else { return nil }
+        return ToolCallParser(openMarker: markers.open, closeMarker: markers.close)
     }
 
     func tryAcquire() -> Bool {
@@ -172,14 +194,31 @@ final class ServerState: @unchecked Sendable {
         _state.withLock { $0.lastPromptTokens = tokens }
     }
 
+    /// Record tool calls made in a response.
+    func recordToolCalls(_ names: [String]) {
+        _state.withLock { s in
+            s.totalToolCalls += names.count
+            for name in names {
+                s.toolCallCounts[name, default: 0] += 1
+            }
+        }
+    }
+
     /// Stats snapshot for /v1/stats endpoint.
     func statsSnapshot() -> StatsResponse {
         let s = _state.withLock { s in
-            (prefixHits: s.prefixHits, prefixMisses: s.prefixMisses)
+            (
+                prefixHits: s.prefixHits, prefixMisses: s.prefixMisses,
+                toolCallCounts: s.toolCallCounts, totalToolCalls: s.totalToolCalls
+            )
         }
         let hitTotal = s.prefixHits + s.prefixMisses
         let hitRate = hitTotal > 0 ? Double(s.prefixHits) / Double(hitTotal) : 0
-        return stats.buildResponse(prefixHitRate: hitRate, prefixHits: s.prefixHits, prefixMisses: s.prefixMisses)
+        let topTools = s.toolCallCounts.sorted { $0.value > $1.value }.prefix(5)
+            .map { ToolCallStat(name: $0.key, count: $0.value) }
+        return stats.buildResponse(
+            prefixHitRate: hitRate, prefixHits: s.prefixHits, prefixMisses: s.prefixMisses,
+            totalToolCalls: s.totalToolCalls, topTools: topTools)
     }
 
     private enum PrepareAction {
@@ -248,6 +287,8 @@ struct StatsResponse: Codable, Sendable {
     let prefixHitRate: Double
     let prefixHits: Int
     let prefixMisses: Int
+    let totalToolCalls: Int
+    let topTools: [ToolCallStat]?
 
     enum CodingKeys: String, CodingKey {
         case totalRequests = "total_requests"
@@ -258,5 +299,12 @@ struct StatsResponse: Codable, Sendable {
         case prefixHitRate = "prefix_hit_rate"
         case prefixHits = "prefix_hits"
         case prefixMisses = "prefix_misses"
+        case totalToolCalls = "total_tool_calls"
+        case topTools = "top_tools"
     }
+}
+
+struct ToolCallStat: Codable, Sendable {
+    let name: String
+    let count: Int
 }

--- a/swift/Tests/CoreAILMCommonTests/ToolCallingTypesTests.swift
+++ b/swift/Tests/CoreAILMCommonTests/ToolCallingTypesTests.swift
@@ -1,0 +1,118 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+import Foundation
+import Testing
+
+@testable import CoreAILMCommon
+
+@Suite("Tool Calling Types")
+struct ToolCallingTypesTests {
+    @Test("Request with tools decodes")
+    func requestWithTools() throws {
+        let json = """
+            {
+                "messages": [{"role": "user", "content": "What is the weather?"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {"type": "object", "properties": {"location": {"type": "string"}}}
+                    }
+                }],
+                "tool_choice": "auto"
+            }
+            """.data(using: .utf8)!
+        let request = try JSONDecoder().decode(ChatCompletionRequest.self, from: json)
+        #expect(request.tools?.count == 1)
+        #expect(request.tools?[0].function.name == "get_weather")
+        #expect(request.toolChoice == .auto)
+    }
+
+    @Test("ToolChoice decodes all variants")
+    func toolChoiceVariants() throws {
+        let cases: [(String, ToolChoice)] = [
+            ("\"auto\"", .auto),
+            ("\"none\"", .none),
+            ("\"required\"", .required),
+            ("{\"type\":\"function\",\"function\":{\"name\":\"foo\"}}", .function(name: "foo")),
+        ]
+        for (json, expected) in cases {
+            let decoded = try JSONDecoder().decode(ToolChoice.self, from: json.data(using: .utf8)!)
+            #expect(decoded == expected)
+        }
+    }
+
+    @Test("ToolChoice round-trips through encode/decode")
+    func toolChoiceRoundTrip() throws {
+        let choices: [ToolChoice] = [.auto, .none, .required, .function(name: "bar")]
+        for choice in choices {
+            let data = try JSONEncoder().encode(choice)
+            let decoded = try JSONDecoder().decode(ToolChoice.self, from: data)
+            #expect(decoded == choice)
+        }
+    }
+
+    @Test("Assistant message with tool_calls decodes")
+    func messageWithToolCalls() throws {
+        let json = """
+            {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\\"location\\":\\"SF\\"}"}
+                }]
+            }
+            """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        #expect(msg.role == "assistant")
+        #expect(msg.toolCalls?.count == 1)
+        #expect(msg.toolCalls?[0].function.name == "get_weather")
+        #expect(msg.toolCalls?[0].id == "call_abc123")
+    }
+
+    @Test("Tool result message decodes")
+    func toolResultMessage() throws {
+        let json = """
+            {"role": "tool", "content": "72 degrees", "tool_call_id": "call_abc123"}
+            """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        #expect(msg.role == "tool")
+        #expect(msg.content.textContent == "72 degrees")
+        #expect(msg.toolCallId == "call_abc123")
+    }
+
+    @Test("ResponseMessage encodes null content explicitly")
+    func responseMessageNullContent() throws {
+        let msg = ChatCompletionResponse.ResponseMessage(
+            role: "assistant", content: nil,
+            toolCalls: [ToolCall(id: "call_1", function: .init(name: "foo", arguments: "{}"))])
+        let data = try JSONEncoder().encode(msg)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(obj.keys.contains("content"))
+        #expect(obj["content"] is NSNull)
+        let calls = obj["tool_calls"] as? [[String: Any]]
+        #expect(calls?.count == 1)
+    }
+
+    @Test("Streaming delta with tool_calls encodes")
+    func streamingToolCallDelta() throws {
+        let delta = ChatCompletionChunk.Delta(
+            role: nil, content: nil,
+            toolCalls: [
+                ToolCallDelta(
+                    index: 0, id: "call_1", type: "function",
+                    function: .init(name: "get_weather", arguments: nil))
+            ])
+        let data = try JSONEncoder().encode(delta)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let calls = obj["tool_calls"] as? [[String: Any]]
+        #expect(calls?.count == 1)
+        #expect(calls?[0]["index"] as? Int == 0)
+    }
+}


### PR DESCRIPTION
Implements OpenAI-compatible function calling for the llm-server:

API types (ServerAPITypes.swift):
- ToolDefinition, FunctionDefinition, ToolCall, ToolCallFunction
- ToolChoice (auto/none/required/function) with Codable conformance
- ToolCallDelta/ToolCallFunctionDelta for streaming
- ChatMessage: add tool_calls, tool_call_id, name fields
- ResponseMessage: tool_calls field, explicit null encoding for content
- Delta: tool_calls field for streaming chunks

Server integration (ChatHandler.swift):
- tokenizeMessages forwards tools to applyChatTemplate (model template handles injection into system prompt)
- Assistant messages with tool_calls serialized with full OpenAI structure (id + function wrapper) for template compatibility
- Non-streaming: ToolCallParser detects tool call markers in output, returns structured tool_calls with finish_reason="tool_calls"
- Streaming: ThinkTagParser -> ToolCallParser pipeline emits content deltas for text and tool_calls deltas for tool invocations

Auto-detection (ServerState.swift):
- detectToolCallMarkers probes tokenizer vocab at init
- Models without tool tokens gracefully skip parsing

Supported models: Qwen3 (all sizes), Mistral 7B.
Tested end-to-end with Qwen3-4B producing correct tool calls.