### PR TITLE
Add server stats and /ready endpoint

### DIFF
--- a/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
+++ b/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
@@ -545,3 +545,107 @@ public struct ToolCallFunctionDelta: Encodable, Sendable {
         self.arguments = arguments
     }
 }
+
+// MARK: - Stats Response
+
+public struct StatsResponse: Codable, Sendable {
+    public let totalRequests: Int
+    public let totalPromptTokens: Int
+    public let totalGenTokens: Int
+    public let avgPrefillTokPerSec: Double
+    public let avgDecodeTokPerSec: Double
+    public let prefixHitRate: Double
+    public let prefixHits: Int
+    public let prefixMisses: Int
+    public let totalToolCalls: Int
+    public let topTools: [ToolCallStat]?
+
+    public init(
+        totalRequests: Int, totalPromptTokens: Int, totalGenTokens: Int,
+        avgPrefillTokPerSec: Double, avgDecodeTokPerSec: Double,
+        prefixHitRate: Double, prefixHits: Int, prefixMisses: Int,
+        totalToolCalls: Int = 0, topTools: [ToolCallStat]? = nil
+    ) {
+        self.totalRequests = totalRequests
+        self.totalPromptTokens = totalPromptTokens
+        self.totalGenTokens = totalGenTokens
+        self.avgPrefillTokPerSec = avgPrefillTokPerSec
+        self.avgDecodeTokPerSec = avgDecodeTokPerSec
+        self.prefixHitRate = prefixHitRate
+        self.prefixHits = prefixHits
+        self.prefixMisses = prefixMisses
+        self.totalToolCalls = totalToolCalls
+        self.topTools = topTools
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case totalRequests = "total_requests"
+        case totalPromptTokens = "total_prompt_tokens"
+        case totalGenTokens = "total_gen_tokens"
+        case avgPrefillTokPerSec = "avg_prefill_tok_per_sec"
+        case avgDecodeTokPerSec = "avg_decode_tok_per_sec"
+        case prefixHitRate = "prefix_hit_rate"
+        case prefixHits = "prefix_hits"
+        case prefixMisses = "prefix_misses"
+        case totalToolCalls = "total_tool_calls"
+        case topTools = "top_tools"
+    }
+}
+
+public struct ToolCallStat: Codable, Sendable {
+    public let name: String
+    public let count: Int
+
+    public init(name: String, count: Int) {
+        self.name = name
+        self.count = count
+    }
+}
+
+// MARK: - Ready Response
+
+public struct ReadyResponse: Codable, Sendable {
+    public let status: String
+    public let model: String
+    public let maxContextLength: Int
+    public let busy: Bool
+    public let cache: CacheStatus
+    public let toolCalling: Bool
+
+    public init(
+        status: String, model: String, maxContextLength: Int,
+        busy: Bool, cache: CacheStatus, toolCalling: Bool
+    ) {
+        self.status = status
+        self.model = model
+        self.maxContextLength = maxContextLength
+        self.busy = busy
+        self.cache = cache
+        self.toolCalling = toolCalling
+    }
+
+    public struct CacheStatus: Codable, Sendable {
+        public let usedTokens: Int
+        public let maxTokens: Int
+        public let utilization: Double
+
+        public init(usedTokens: Int, maxTokens: Int, utilization: Double) {
+            self.usedTokens = usedTokens
+            self.maxTokens = maxTokens
+            self.utilization = utilization
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case usedTokens = "used_tokens"
+            case maxTokens = "max_tokens"
+            case utilization
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status, model
+        case maxContextLength = "max_context_length"
+        case busy, cache
+        case toolCalling = "tool_calling"
+    }
+}

--- a/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
+++ b/swift/Sources/CoreAILMCommon/ServerAPITypes.swift
@@ -548,7 +548,7 @@ public struct ToolCallFunctionDelta: Encodable, Sendable {
 
 // MARK: - Stats Response
 
-public struct StatsResponse: Codable, Sendable {
+public struct ServerStatsResponse: Codable, Sendable {
     public let totalRequests: Int
     public let totalPromptTokens: Int
     public let totalGenTokens: Int

--- a/swift/Sources/Tools/llm-server/ChatHandler.swift
+++ b/swift/Sources/Tools/llm-server/ChatHandler.swift
@@ -203,14 +203,20 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
 
     var genTokenCount = 0
     var parts: [String] = []
+    var promptSeconds: Double = 0
     for try await result in stream {
+        if genTokenCount == 0 {
+            let ttft = SuspendingClock().now - t0
+            promptSeconds = Double(ttft.components.seconds) + Double(ttft.components.attoseconds) / 1e18
+        }
         parts.append(result.text)
         genTokenCount += 1
     }
     let text = parts.joined()
 
     let elapsed = SuspendingClock().now - t0
-    let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
+    let totalSeconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
+    let genSeconds = totalSeconds - promptSeconds
     let cleaned = stripThinkingTags(text)
 
     // Parse tool calls if the model supports them and tools were requested
@@ -241,9 +247,10 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
         }
     }
 
-    let tokPerSec = seconds > 0 ? Double(genTokenCount) / seconds : 0
+    let prefillTps = promptSeconds > 0 ? Double(promptTokens.count) / promptSeconds : 0
+    let genTps = genSeconds > 0 ? Double(genTokenCount) / genSeconds : 0
     var logLine =
-        "\(ts()) [\(requestID)] \(promptTokens.count)t → \(genTokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s)"
+        "\(ts()) [\(requestID)] \(promptTokens.count)t prefill \(String(format: "%.1f", prefillTps)) t/s, \(genTokenCount)t gen \(String(format: "%.1f", genTps)) t/s (\(String(format: "%.2f", totalSeconds))s)"
     if let calls = responseToolCalls {
         logLine += " → \(calls.count) tool call(s)"
         if CLILogger.level > 0 {
@@ -252,8 +259,8 @@ private func handleNonStreamingRequest(chatRequest: ChatCompletionRequest, state
     }
     print(logLine)
     state.stats.record(
-        promptTokens: promptTokens.count, genTokens: genTokenCount, promptSeconds: 0, genSeconds: seconds,
-        totalSeconds: seconds, toolCalls: responseToolCalls?.count ?? 0)
+        promptTokens: promptTokens.count, genTokens: genTokenCount, promptSeconds: promptSeconds,
+        genSeconds: genSeconds, totalSeconds: totalSeconds, toolCalls: responseToolCalls?.count ?? 0)
     state.recordPromptTokens(promptTokensInt32)
 
     let response = ChatCompletionResponse(
@@ -357,6 +364,7 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             var hasToolCalls = false
             var toolCallIndex = 0
             var toolCallNames: [String] = []
+            var promptSeconds: Double = 0
 
             // Emit a single SSE chunk (text content or tool call delta)
             func emitChunk(_ delta: ChatCompletionChunk.Delta) async throws {
@@ -403,6 +411,10 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             }
 
             for try await result in tokenStream {
+                if tokenCount == 0 {
+                    let ttft = SuspendingClock().now - genStart
+                    promptSeconds = Double(ttft.components.seconds) + Double(ttft.components.attoseconds) / 1e18
+                }
                 tokenCount += 1
                 for event in thinkParser.consume(result.text) {
                     if case .text(let delta) = event {
@@ -435,10 +447,12 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             try await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
 
             let elapsed = SuspendingClock().now - genStart
-            let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
-            let tokPerSec = seconds > 0 ? Double(tokenCount) / seconds : 0
+            let totalSeconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
+            let genSeconds = totalSeconds - promptSeconds
+            let prefillTps = promptSeconds > 0 ? Double(promptTokens.count) / promptSeconds : 0
+            let genTps = genSeconds > 0 ? Double(tokenCount) / genSeconds : 0
             var logLine =
-                "\(ts()) [\(requestID)] stream: \(promptTokens.count)t → \(tokenCount)t in \(String(format: "%.2f", seconds))s (\(String(format: "%.1f", tokPerSec)) tok/s) [\(finishReason)]"
+                "\(ts()) [\(requestID)] stream: \(promptTokens.count)t prefill \(String(format: "%.1f", prefillTps)) t/s, \(tokenCount)t gen \(String(format: "%.1f", genTps)) t/s (\(String(format: "%.2f", totalSeconds))s) [\(finishReason)]"
             if !toolCallNames.isEmpty {
                 logLine += " → \(toolCallNames.count) tool call(s)"
                 if CLILogger.level > 0 {
@@ -447,8 +461,8 @@ private func handleStreamingRequest(chatRequest: ChatCompletionRequest, state: S
             }
             print(logLine)
             state.stats.record(
-                promptTokens: promptTokens.count, genTokens: tokenCount, promptSeconds: 0, genSeconds: seconds,
-                totalSeconds: seconds, toolCalls: toolCallNames.count)
+                promptTokens: promptTokens.count, genTokens: tokenCount, promptSeconds: promptSeconds,
+                genSeconds: genSeconds, totalSeconds: totalSeconds, toolCalls: toolCallNames.count)
             state.recordPromptTokens(promptTokensInt32)
             if !toolCallNames.isEmpty {
                 state.recordToolCalls(toolCallNames)

--- a/swift/Sources/Tools/llm-server/ChatHandler.swift
+++ b/swift/Sources/Tools/llm-server/ChatHandler.swift
@@ -56,6 +56,16 @@ func startServer(state: ServerState, port: Int) async throws {
         try await handleCompletionsRoute(request: request, state: state)
     }
 
+    router.get("/ready") { _, _ in
+        let ready = state.readySnapshot()
+        let data = try JSONEncoder().encode(ready)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+
     router.get("/v1/stats") { _, _ in
         let stats = state.statsSnapshot()
         let data = try JSONEncoder().encode(stats)

--- a/swift/Sources/Tools/llm-server/LLMServerMain.swift
+++ b/swift/Sources/Tools/llm-server/LLMServerMain.swift
@@ -181,7 +181,9 @@ struct LLMServer: AsyncParsableCommand {
                 print("  POST /v1/completions        (loglikelihood)")
             }
             print("  GET  /v1/models")
+            print("  GET  /v1/stats")
             print("  GET  /health")
+            print("  GET  /ready")
         }
         print("")
 

--- a/swift/Sources/Tools/llm-server/ServerState.swift
+++ b/swift/Sources/Tools/llm-server/ServerState.swift
@@ -93,9 +93,9 @@ final class ServerStats: @unchecked Sendable {
     func buildResponse(
         prefixHitRate: Double, prefixHits: Int, prefixMisses: Int,
         totalToolCalls: Int, topTools: [ToolCallStat]
-    ) -> StatsResponse {
+    ) -> ServerStatsResponse {
         let s = lock.withLock { $0 }
-        return StatsResponse(
+        return ServerStatsResponse(
             totalRequests: s.totalRequests,
             totalPromptTokens: s.totalPromptTokens,
             totalGenTokens: s.totalGenTokens,
@@ -206,7 +206,7 @@ final class ServerState: @unchecked Sendable {
     }
 
     /// Stats snapshot for /v1/stats endpoint.
-    func statsSnapshot() -> StatsResponse {
+    func statsSnapshot() -> ServerStatsResponse {
         let s = _state.withLock { s in
             (
                 prefixHits: s.prefixHits, prefixMisses: s.prefixMisses,

--- a/swift/Sources/Tools/llm-server/ServerState.swift
+++ b/swift/Sources/Tools/llm-server/ServerState.swift
@@ -226,6 +226,26 @@ final class ServerState: @unchecked Sendable {
         case reuse(prefixLength: Int)
     }
 
+    /// Readiness snapshot for /ready endpoint.
+    func readySnapshot() -> ReadyResponse {
+        let busy = _state.withLock { $0.generating }
+        let usedTokens = engine.processedTokenCount
+        let maxTokens = config.maxContextLength
+        let utilization = maxTokens > 0 ? Double(usedTokens) / Double(maxTokens) : 0
+        return ReadyResponse(
+            status: "ready",
+            model: config.modelName,
+            maxContextLength: maxTokens,
+            busy: busy,
+            cache: .init(
+                usedTokens: usedTokens,
+                maxTokens: maxTokens,
+                utilization: utilization
+            ),
+            toolCalling: supportsToolCalling
+        )
+    }
+
     func makeSamplingConfig(
         temperature: Double?,
         topP: Double?,
@@ -307,4 +327,34 @@ struct StatsResponse: Codable, Sendable {
 struct ToolCallStat: Codable, Sendable {
     let name: String
     let count: Int
+}
+
+// MARK: - Ready Response
+
+struct ReadyResponse: Codable, Sendable {
+    let status: String
+    let model: String
+    let maxContextLength: Int
+    let busy: Bool
+    let cache: CacheStatus
+    let toolCalling: Bool
+
+    struct CacheStatus: Codable, Sendable {
+        let usedTokens: Int
+        let maxTokens: Int
+        let utilization: Double
+
+        enum CodingKeys: String, CodingKey {
+            case usedTokens = "used_tokens"
+            case maxTokens = "max_tokens"
+            case utilization
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status, model
+        case maxContextLength = "max_context_length"
+        case busy, cache
+        case toolCalling = "tool_calling"
+    }
 }

--- a/swift/Sources/Tools/llm-server/ServerState.swift
+++ b/swift/Sources/Tools/llm-server/ServerState.swift
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-3-clause license that can
 // be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
+import CoreAILMCommon
 import CoreAILanguageModels
 import CoreAIShared
 import Foundation
@@ -293,68 +294,5 @@ enum ServerError: Error, LocalizedError {
         switch self {
         case .badRequest(let msg): return msg
         }
-    }
-}
-
-// MARK: - Stats Response
-
-struct StatsResponse: Codable, Sendable {
-    let totalRequests: Int
-    let totalPromptTokens: Int
-    let totalGenTokens: Int
-    let avgPrefillTokPerSec: Double
-    let avgDecodeTokPerSec: Double
-    let prefixHitRate: Double
-    let prefixHits: Int
-    let prefixMisses: Int
-    let totalToolCalls: Int
-    let topTools: [ToolCallStat]?
-
-    enum CodingKeys: String, CodingKey {
-        case totalRequests = "total_requests"
-        case totalPromptTokens = "total_prompt_tokens"
-        case totalGenTokens = "total_gen_tokens"
-        case avgPrefillTokPerSec = "avg_prefill_tok_per_sec"
-        case avgDecodeTokPerSec = "avg_decode_tok_per_sec"
-        case prefixHitRate = "prefix_hit_rate"
-        case prefixHits = "prefix_hits"
-        case prefixMisses = "prefix_misses"
-        case totalToolCalls = "total_tool_calls"
-        case topTools = "top_tools"
-    }
-}
-
-struct ToolCallStat: Codable, Sendable {
-    let name: String
-    let count: Int
-}
-
-// MARK: - Ready Response
-
-struct ReadyResponse: Codable, Sendable {
-    let status: String
-    let model: String
-    let maxContextLength: Int
-    let busy: Bool
-    let cache: CacheStatus
-    let toolCalling: Bool
-
-    struct CacheStatus: Codable, Sendable {
-        let usedTokens: Int
-        let maxTokens: Int
-        let utilization: Double
-
-        enum CodingKeys: String, CodingKey {
-            case usedTokens = "used_tokens"
-            case maxTokens = "max_tokens"
-            case utilization
-        }
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case status, model
-        case maxContextLength = "max_context_length"
-        case busy, cache
-        case toolCalling = "tool_calling"
     }
 }

--- a/swift/Tests/CoreAILMCommonTests/ServerAPITypesTests.swift
+++ b/swift/Tests/CoreAILMCommonTests/ServerAPITypesTests.swift
@@ -123,4 +123,107 @@ struct ServerAPITypesTests {
         let err = obj["error"] as! [String: Any]
         #expect(err["message"] as? String == "bad request")
     }
+
+    // MARK: - Stats Response
+
+    @Test("StatsResponse encodes snake_case keys")
+    func statsResponseEncodes() throws {
+        let stats = StatsResponse(
+            totalRequests: 10, totalPromptTokens: 500, totalGenTokens: 200,
+            avgPrefillTokPerSec: 1000.0, avgDecodeTokPerSec: 50.0,
+            prefixHitRate: 0.8, prefixHits: 8, prefixMisses: 2,
+            totalToolCalls: 3, topTools: [ToolCallStat(name: "get_weather", count: 3)]
+        )
+        let data = try JSONEncoder().encode(stats)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(obj["total_requests"] as? Int == 10)
+        #expect(obj["avg_prefill_tok_per_sec"] as? Double == 1000.0)
+        #expect(obj["prefix_hit_rate"] as? Double == 0.8)
+        #expect(obj["total_tool_calls"] as? Int == 3)
+        let tools = obj["top_tools"] as? [[String: Any]]
+        #expect(tools?.count == 1)
+        #expect(tools?[0]["name"] as? String == "get_weather")
+    }
+
+    @Test("StatsResponse round-trips through JSON")
+    func statsResponseRoundTrip() throws {
+        let stats = StatsResponse(
+            totalRequests: 5, totalPromptTokens: 100, totalGenTokens: 50,
+            avgPrefillTokPerSec: 500.0, avgDecodeTokPerSec: 25.0,
+            prefixHitRate: 0.6, prefixHits: 3, prefixMisses: 2
+        )
+        let data = try JSONEncoder().encode(stats)
+        let decoded = try JSONDecoder().decode(StatsResponse.self, from: data)
+        #expect(decoded.totalRequests == 5)
+        #expect(decoded.prefixHitRate == 0.6)
+        #expect(decoded.totalToolCalls == 0)
+        #expect(decoded.topTools == nil)
+    }
+
+    @Test("StatsResponse decodes from external JSON")
+    func statsResponseDecodes() throws {
+        let json = """
+            {"total_requests":3,"total_prompt_tokens":100,"total_gen_tokens":50,
+             "avg_prefill_tok_per_sec":500,"avg_decode_tok_per_sec":25,
+             "prefix_hit_rate":0.5,"prefix_hits":1,"prefix_misses":1,
+             "total_tool_calls":0}
+            """.data(using: .utf8)!
+        let stats = try JSONDecoder().decode(StatsResponse.self, from: json)
+        #expect(stats.totalRequests == 3)
+        #expect(stats.avgDecodeTokPerSec == 25.0)
+    }
+
+    // MARK: - Ready Response
+
+    @Test("ReadyResponse encodes with nested cache status")
+    func readyResponseEncodes() throws {
+        let ready = ReadyResponse(
+            status: "ready", model: "qwen3-4b", maxContextLength: 32768,
+            busy: false,
+            cache: .init(usedTokens: 1024, maxTokens: 32768, utilization: 0.03125),
+            toolCalling: true
+        )
+        let data = try JSONEncoder().encode(ready)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(obj["status"] as? String == "ready")
+        #expect(obj["model"] as? String == "qwen3-4b")
+        #expect(obj["max_context_length"] as? Int == 32768)
+        #expect(obj["busy"] as? Bool == false)
+        #expect(obj["tool_calling"] as? Bool == true)
+        let cache = obj["cache"] as? [String: Any]
+        #expect(cache?["used_tokens"] as? Int == 1024)
+        #expect(cache?["max_tokens"] as? Int == 32768)
+        #expect(cache?["utilization"] as? Double == 0.03125)
+    }
+
+    @Test("ReadyResponse round-trips through JSON")
+    func readyResponseRoundTrip() throws {
+        let ready = ReadyResponse(
+            status: "ready", model: "test-model", maxContextLength: 4096,
+            busy: true,
+            cache: .init(usedTokens: 2048, maxTokens: 4096, utilization: 0.5),
+            toolCalling: false
+        )
+        let data = try JSONEncoder().encode(ready)
+        let decoded = try JSONDecoder().decode(ReadyResponse.self, from: data)
+        #expect(decoded.status == "ready")
+        #expect(decoded.busy == true)
+        #expect(decoded.cache.usedTokens == 2048)
+        #expect(decoded.cache.utilization == 0.5)
+        #expect(decoded.toolCalling == false)
+    }
+
+    @Test("ReadyResponse decodes from external JSON")
+    func readyResponseDecodes() throws {
+        let json = """
+            {"status":"ready","model":"qwen3","max_context_length":8192,
+             "busy":false,"cache":{"used_tokens":0,"max_tokens":8192,"utilization":0.0},
+             "tool_calling":true}
+            """.data(using: .utf8)!
+        let ready = try JSONDecoder().decode(ReadyResponse.self, from: json)
+        #expect(ready.model == "qwen3")
+        #expect(ready.maxContextLength == 8192)
+        #expect(ready.cache.usedTokens == 0)
+        #expect(ready.toolCalling == true)
+    }
 }

--- a/swift/Tests/CoreAILMCommonTests/ServerAPITypesTests.swift
+++ b/swift/Tests/CoreAILMCommonTests/ServerAPITypesTests.swift
@@ -126,9 +126,9 @@ struct ServerAPITypesTests {
 
     // MARK: - Stats Response
 
-    @Test("StatsResponse encodes snake_case keys")
+    @Test("ServerStatsResponse encodes snake_case keys")
     func statsResponseEncodes() throws {
-        let stats = StatsResponse(
+        let stats = ServerStatsResponse(
             totalRequests: 10, totalPromptTokens: 500, totalGenTokens: 200,
             avgPrefillTokPerSec: 1000.0, avgDecodeTokPerSec: 50.0,
             prefixHitRate: 0.8, prefixHits: 8, prefixMisses: 2,
@@ -145,22 +145,22 @@ struct ServerAPITypesTests {
         #expect(tools?[0]["name"] as? String == "get_weather")
     }
 
-    @Test("StatsResponse round-trips through JSON")
+    @Test("ServerStatsResponse round-trips through JSON")
     func statsResponseRoundTrip() throws {
-        let stats = StatsResponse(
+        let stats = ServerStatsResponse(
             totalRequests: 5, totalPromptTokens: 100, totalGenTokens: 50,
             avgPrefillTokPerSec: 500.0, avgDecodeTokPerSec: 25.0,
             prefixHitRate: 0.6, prefixHits: 3, prefixMisses: 2
         )
         let data = try JSONEncoder().encode(stats)
-        let decoded = try JSONDecoder().decode(StatsResponse.self, from: data)
+        let decoded = try JSONDecoder().decode(ServerStatsResponse.self, from: data)
         #expect(decoded.totalRequests == 5)
         #expect(decoded.prefixHitRate == 0.6)
         #expect(decoded.totalToolCalls == 0)
         #expect(decoded.topTools == nil)
     }
 
-    @Test("StatsResponse decodes from external JSON")
+    @Test("ServerStatsResponse decodes from external JSON")
     func statsResponseDecodes() throws {
         let json = """
             {"total_requests":3,"total_prompt_tokens":100,"total_gen_tokens":50,
@@ -168,7 +168,7 @@ struct ServerAPITypesTests {
              "prefix_hit_rate":0.5,"prefix_hits":1,"prefix_misses":1,
              "total_tool_calls":0}
             """.data(using: .utf8)!
-        let stats = try JSONDecoder().decode(StatsResponse.self, from: json)
+        let stats = try JSONDecoder().decode(ServerStatsResponse.self, from: json)
         #expect(stats.totalRequests == 3)
         #expect(stats.avgDecodeTokPerSec == 25.0)
     }


### PR DESCRIPTION
## Summary

- **Separate prefill and generation timing**: Measure TTFT (time-to-first-token) to split prefill throughput from generation throughput in per-request logs and the `/v1/stats` endpoint. Previously, prefill was reported as 0.0 tok/s.
- **Add `/ready` endpoint**: Returns model name, context length, KV cache utilization (`used_tokens` / `max_tokens`), busy status, and tool calling capability. Useful for agentic clients that need to poll server readiness before sending requests.
- **Move response types to `CoreAILMCommon`**: `StatsResponse`, `ReadyResponse`, and `ToolCallStat` are now in the shared module for testability.
- **Add 7 unit tests**: Encode, decode, and round-trip tests for `StatsResponse` and `ReadyResponse`.

### Example: per-request log output

```
12:34:56 [coreai-1] 148t prefill 1500.0 t/s, 24t gen 45.2 t/s (1.83s)
```

### Example: `GET /ready`

```json
{
  "status": "ready",
  "model": "qwen3-4b",
  "max_context_length": 32768,
  "busy": false,
  "cache": {
    "used_tokens": 1024,
    "max_tokens": 32768,
    "utilization": 0.03125
  },
  "tool_calling": true
}
```

### Example: `GET /v1/stats`

```json
{
  "total_requests": 10,
  "total_prompt_tokens": 500,
  "total_gen_tokens": 200,
  "avg_prefill_tok_per_sec": 1500.0,
  "avg_decode_tok_per_sec": 45.2,
  "prefix_hit_rate": 0.8,
  "prefix_hits": 8,
  "prefix_misses": 2,
  "total_tool_calls": 3,
  "top_tools": [{"name": "get_weather", "count": 3}]
}
```

## Test plan

- [x] Build passes (`swift build --product llm-server --disable-sandbox`)
- [x] All 22 unit tests pass (`ServerAPITypesTests` + `ToolCallingTypesTests`)
- [x] CI