### PR TITLE
Add Qwen3-1.7B macOS and iOS export support

### DIFF
--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -7,7 +7,7 @@ Alibaba's Qwen3 models for on-device inference via Core AI.
 | Model      | Parameters | macOS | iOS |
 | ---------- | ---------- | ----- | --- |
 | Qwen3 0.6B | 0.6B       | Yes   | Yes |
-| Qwen3 1.7B | 1.7B       | Yes   | No  |
+| Qwen3 1.7B | 1.7B       | Yes   | Yes |
 | Qwen3 4B   | 4.0B       | Yes   | Yes |
 | Qwen3 8B   | 8.0B       | Yes   | No  |
 
@@ -84,6 +84,7 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | Qwen3 0.6B | [Mixed 4-bit/8-bit palettized][mixed-4bit-8bit-yaml] | 5.71\*                | iOS      | 30.90            |
 | Qwen3 1.7B | none (`float16`)                                     | 16.00                 | macOS    | 20.96            |
 | Qwen3 1.7B | [4-bit quantized][presets-info]                      | 4.50                  | macOS    | 21.19            |
+| Qwen3 1.7B | [6-bit palettized][qwen3-1.7b-6bit-yaml]             | 6.00                  | iOS      | —                |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | macOS    | 16.41            |
 | Qwen3 4B   | [4-bit quantized][presets-info]                      | 4.50                  | macOS    | 18.33            |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | iOS      | 16.41            |
@@ -96,3 +97,4 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 [presets-info]: ../README.md#quantization-options
 [mixed-4bit-8bit-yaml]: qwen3_0_6b_mixed_4bit_8bit.yaml
 [qwen3-4b-mixed-yaml]: qwen3_4b_mixed_4bit_8bit.yaml
+[qwen3-1.7b-6bit-yaml]: qwen3_1_7b_6bit.yaml

--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -7,6 +7,7 @@ Alibaba's Qwen3 models for on-device inference via Core AI.
 | Model      | Parameters | macOS | iOS |
 | ---------- | ---------- | ----- | --- |
 | Qwen3 0.6B | 0.6B       | Yes   | Yes |
+| Qwen3 1.7B | 1.7B       | Yes   | No  |
 | Qwen3 4B   | 4.0B       | Yes   | Yes |
 | Qwen3 8B   | 8.0B       | Yes   | No  |
 
@@ -81,6 +82,8 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | ---------- | ---------------------------------------------------- | --------------------- | -------- | ---------------- |
 | Qwen3 0.6B | none (`float16`)                                     | 16.00                 | iOS      | 26.16            |
 | Qwen3 0.6B | [Mixed 4-bit/8-bit palettized][mixed-4bit-8bit-yaml] | 5.71\*                | iOS      | 30.90            |
+| Qwen3 1.7B | none (`float16`)                                     | 16.00                 | macOS    | 20.96            |
+| Qwen3 1.7B | [4-bit quantized][presets-info]                      | 4.50                  | macOS    | 21.19            |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | macOS    | 16.41            |
 | Qwen3 4B   | [4-bit quantized][presets-info]                      | 4.50                  | macOS    | 18.33            |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | iOS      | 16.41            |

--- a/models/qwen3/qwen3_1_7b_6bit.yaml
+++ b/models/qwen3/qwen3_1_7b_6bit.yaml
@@ -1,0 +1,14 @@
+# 6-bit palettization for Qwen3-1.7B iOS.
+# 64 centroids — good quality/speed tradeoff for ~1.7B-parameter models.
+kmeans_palettization_config:
+  global_config:
+    op_state_spec:
+      weight:
+        n_bits: 6
+        granularity:
+          type: per_grouped_channel
+          axis: 0
+          group_size: 8
+  module_type_configs:
+    torch.nn.modules.sparse.Embedding: null
+    coreai_models.primitives.ios.embedding.LoadEmbeddings: null

--- a/models/qwen3/qwen3_1_7b_6bit.yaml
+++ b/models/qwen3/qwen3_1_7b_6bit.yaml
@@ -1,5 +1,4 @@
 # 6-bit palettization for Qwen3-1.7B iOS.
-# 64 centroids — good quality/speed tradeoff for ~1.7B-parameter models.
 kmeans_palettization_config:
   global_config:
     op_state_spec:

--- a/python/src/coreai_models/export/metadata.py
+++ b/python/src/coreai_models/export/metadata.py
@@ -52,6 +52,14 @@ _METADATA: dict[str, AIModelMetadataFields] = {
             "family. Source: https://huggingface.co/Qwen/Qwen3-0.6B"
         ),
     ),
+    "Qwen/Qwen3-1.7B": AIModelMetadataFields(
+        author="Qwen Team",
+        license="Apache-2.0",
+        model_description=(
+            "Qwen3-1.7B is a 1.7B-parameter causal language model from the Qwen3 "
+            "family. Source: https://huggingface.co/Qwen/Qwen3-1.7B"
+        ),
+    ),
     "Qwen/Qwen3-4B": AIModelMetadataFields(
         author="Qwen Team",
         license="Apache-2.0",

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -198,6 +198,17 @@ LLM_PRESETS: list[ModelPreset] = [
         IOS_DEFAULT_MAX_CONTEXT_LENGTH,
     ),
     ModelPreset(
+        "qwen3-1.7b",
+        "Qwen/Qwen3-1.7B",
+        "qwen3",
+        "llm",
+        "iOS",
+        "none",
+        "float16",
+        IOS_DEFAULT_MAX_CONTEXT_LENGTH,
+        compression_config="models/qwen3/qwen3_1_7b_6bit.yaml",
+    ),
+    ModelPreset(
         "qwen3-4b",
         "Qwen/Qwen3-4B",
         "qwen3",

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -83,6 +83,7 @@ LLM_PRESETS: list[ModelPreset] = [
         32768,
     ),
     ModelPreset("qwen3-0.6b", "Qwen/Qwen3-0.6B", "qwen3", "llm", "macOS", "4bit", "float16", 8192),
+    ModelPreset("qwen3-1.7b", "Qwen/Qwen3-1.7B", "qwen3", "llm", "macOS", "4bit", "float16", 32768),
     ModelPreset("qwen3-4b", "Qwen/Qwen3-4B", "qwen3", "llm", "macOS", "4bit", "float16", 40960),
     ModelPreset("qwen3-8b", "Qwen/Qwen3-8B", "qwen3", "llm", "macOS", "4bit", "float16", 40960),
     ModelPreset(


### PR DESCRIPTION
Register Qwen3-1.7B in the model registry for macOS (4-bit quantized, 32K context). Add HuggingFace metadata entry and README with perplexity results (20.96 float16, 21.19 4-bit).

Closes #116