### PR TITLE
expand coverage for activation quantization unit tests to MoEs

### DIFF
--- a/python/src/coreai_models/models/macos/qwen3_moe.py
+++ b/python/src/coreai_models/models/macos/qwen3_moe.py
@@ -210,6 +210,8 @@ class Qwen3MoeForCausalLM(BaseForCausalLM):
     def _init_model(self, config: Qwen3MoeConfig) -> None:
         self.model = Qwen3MoeModel(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     @BaseForCausalLM.cast_logits_bfloat16_to_float16
     def forward(
@@ -330,3 +332,8 @@ class Qwen3MoeForCausalLM(BaseForCausalLM):
                     output[0, e] = expert_weight
 
                 state_dict[f"{prefix}.switch_mlp.{proj}.weight"] = output
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        super().load_state_dict(state_dict, strict=strict, assign=assign)
+        if self.config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight

--- a/python/tests/_runner_infra/testing_utils.py
+++ b/python/tests/_runner_infra/testing_utils.py
@@ -1007,6 +1007,21 @@ class ForCausalLMTestBase:
             if is_gemma
             else "coreai_models.primitives.macos.rms_norm.RMSNorm"
         )
+        moe_switch_linear_spec = {
+            "module_state_spec": {
+                "weight": {
+                    "dtype": "int4",
+                    "qscheme": "symmetric_with_clipping",
+                    "granularity": {
+                        "type": "per_block",
+                        "block_size": [1, 1, 1, 8],
+                        "axis": None,
+                    },
+                },
+            },
+            "op_input_spec": None,
+            "op_output_spec": None,
+        }
         torch_quantization_config = {
             "global_config": {
                 "op_state_spec": weight_qspec_dict,
@@ -1017,6 +1032,7 @@ class ForCausalLMTestBase:
                 "coreai_models.primitives.macos.sdpa.SDPA": None,
                 "coreai_models.primitives.macos.rope.RoPE": None,
                 rms_norm_cls: None,
+                "coreai_models.primitives.macos.switch.SwitchLinear": moe_switch_linear_spec,
             },
             "execution_mode": quantization_mode,
             "calibrate_activations": activation_quantization,

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_mixtral.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_mixtral.py
@@ -1182,3 +1182,6 @@ class TestMixtralLayers:
 class TestMixtralForCausalLM(ForCausalLMTestBase):
     _toy_model_id = "yujiepan/mixtral-8xtiny-random"
     _model_class = CoreaiTorchMixtralForCausalLM
+    _test_weight_activation_quantization = True
+    # enable once the fix in https://github.com/apple/coreai-optimization/pull/78 is released
+    _test_eager_activation_quantization = False

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_qwen2.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_qwen2.py
@@ -872,5 +872,5 @@ class TestQwen2ForCausalLM(ForCausalLMTestBase):
     _model_class = CoreaiTorchQwen2ForCausalLM
     _test_weights_tying = True
     _test_weight_activation_quantization = True
-    # opt out of eager mode quantization for toy qwen2 model
+    # enable once the fix in https://github.com/apple/coreai-optimization/pull/78 is released
     _test_eager_activation_quantization = False

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_qwen3_moe.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_qwen3_moe.py
@@ -1546,3 +1546,4 @@ class TestQwen3MoeLayers:
 class TestQwen3MoeForCausalLM(ForCausalLMTestBase):
     _toy_model_id = "yujiepan/qwen3-moe-tiny-random"
     _model_class = CoreaiTorchQwen3MoeForCausalLM
+    _test_weight_activation_quantization = True


### PR DESCRIPTION
Follow-up to #200.

This PR extends the same test to the two MoE classes, `TestMixtralForCausalLM` and `TestQwen3MoeForCausalLM`, so the `4-bit` weight and `int8` activation export path is covered for `SwitchGLU` models in both eager- and graph-mode quantization.

Total time of tests added in this and #200 is `82s`.

**Notes**:

- the expert weights need their own quantization spec
- `qwen3_moe` never implemented weight tying, so this PR includes that support similar to how other models have it already.

**Why there is a `python/src/` change in a test PR?**

- `qwen3_moe.py` needs support for lm_head and embedding weight tying that every other macOS `ForCausalLM` already has. This was never really tested since [Qwen3-Coder-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct/blob/main/config.json#L32) we use off of HF doesn't tie the weights while the unit test does.
