### PR TITLE
Add Mistral-7B iOS export preset (INT4 palettized group-8)

### DIFF
--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -84,7 +84,7 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | Mistral 7B Instruct | none (`float16`)                           | 16.00                 | macOS    | 8.29             |
 | Mistral 7B Instruct | [4-bit quantized][p-4bit]                  | 4.50                  | macOS    | 8.41             |
 | Mistral 7B Instruct | none (`float16`)                           | 16.00                 | iOS      | 8.29             |
-| Mistral 7B Instruct | [4-bit palettized (group size 32)][p-4bit] | 4.10\*                | iOS      | 10.46            |
+| Mistral 7B Instruct | [4-bit palettized (group size 8)][p-4bit]  | 4.11\*                | iOS      | 9.81             |
 
 \* BPW computed from exported asset size (`.mlirb` bits ÷ parameter count) and includes the INT8 per-tensor embedding.
 

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -54,7 +54,7 @@ let response = try await session.respond(to: "What is quantum computing?")
 print(response)
 ```
 
-> **iOS memory requirement:** This model may exceed memory limit when running from an iOS app. If that's the case, try adding the ([**increased memory limit**](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) to your app's entitlements.
+> **iOS memory requirement:** This model may exceed memory limit when running from an iOS app. If that's the case, try adding the ([increased memory limit](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) to your app's entitlements.
 
 ### On your Mac using built-in Command Line Tool
 

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -54,7 +54,7 @@ let response = try await session.respond(to: "What is quantum computing?")
 print(response)
 ```
 
-> **iOS memory requirement:** This model may exceed memory limit when running from an iOS app. If that's the case, try the **Increased Memory Limit** capability ([`com.apple.developer.kernel.increased-memory-limit`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) in your app's entitlements; without it, the app is terminated when the model loads.
+> **iOS memory requirement:** This model may exceed memory limit when running from an iOS app. If that's the case, try adding the ([**increased memory limit**](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) to your app's entitlements.
 
 ### On your Mac using built-in Command Line Tool
 

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -6,7 +6,14 @@ Mistral AI's Mistral models for on-device inference via Core AI.
 
 | Model               | Parameters | macOS | iOS |
 | ------------------- | ---------- | ----- | --- |
-| Mistral 7B Instruct | 7.0B       | Yes   | No  |
+| Mistral 7B Instruct | 7.0B       | Yes   | Yes |
+
+## Gated Access
+This Mistral model is gated on [Hugging Face](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3) (HF). You will need to accept the terms of the [license](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3), generate a HF token, and add your HF token to your machine before exporting this model.
+```bash
+brew install hf
+hf auth login --token <YOUR_TOKEN_HERE>
+```
 
 ## Setup to export models
 
@@ -26,6 +33,9 @@ uv run coreai.llm.export mistralai/Mistral-7B-Instruct-v0.3
 ```bash
 # Full precision
 uv run coreai.llm.export mistralai/Mistral-7B-Instruct-v0.3 --compression none
+
+# iOS variant
+uv run coreai.llm.export mistralai/Mistral-7B-Instruct-v0.3 --platform iOS
 
 # Custom output directory
 uv run coreai.llm.export mistralai/Mistral-7B-Instruct-v0.3 --output-dir ./my-models/
@@ -73,5 +83,9 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | ------------------- | ------------------------------------------ | --------------------- | -------- | ---------------- |
 | Mistral 7B Instruct | none (`float16`)                           | 16.00                 | macOS    | 8.29             |
 | Mistral 7B Instruct | [4-bit quantized][p-4bit]                  | 4.50                  | macOS    | 8.41             |
+| Mistral 7B Instruct | none (`float16`)                           | 16.00                 | iOS      | 8.29             |
+| Mistral 7B Instruct | [4-bit palettized (group size 32)][p-4bit] | 4.10\*                | iOS      | 10.46            |
+
+\* BPW computed from exported asset size (`.mlirb` bits ÷ parameter count) and includes the INT8 per-tensor embedding.
 
 [p-4bit]: ../README.md#quantization-options

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -54,6 +54,8 @@ let response = try await session.respond(to: "What is quantum computing?")
 print(response)
 ```
 
+> **iOS memory requirement:** This 7B model exceeds the default per-app memory limit on iOS. To load it in an iOS app, enable the **Increased Memory Limit** capability ([`com.apple.developer.kernel.increased-memory-limit`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) in your app's entitlements; without it, the app is terminated when the model loads.
+
 ### On your Mac using built-in Command Line Tool
 
 ```bash

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -54,7 +54,7 @@ let response = try await session.respond(to: "What is quantum computing?")
 print(response)
 ```
 
-> **iOS memory requirement:** This 7B model exceeds the default per-app memory limit on iOS. To load it in an iOS app, enable the **Increased Memory Limit** capability ([`com.apple.developer.kernel.increased-memory-limit`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) in your app's entitlements; without it, the app is terminated when the model loads.
+> **iOS memory requirement:** This model may exceed memory limit when running from an iOS app. If that's the case, try the **Increased Memory Limit** capability ([`com.apple.developer.kernel.increased-memory-limit`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.increased-memory-limit)) in your app's entitlements; without it, the app is terminated when the model loads.
 
 ### On your Mac using built-in Command Line Tool
 

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -79,6 +79,6 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | Mistral 7B Instruct | none (`float16`)                           | 16.00                 | iOS      | 8.29             |
 | Mistral 7B Instruct | [4-bit palettized (group size 8)][p-4bit]  | 4.11\*                | iOS      | 9.81             |
 
-\* BPW computed from exported asset size (`.mlirb` bits ÷ parameter count) and includes the INT8 per-tensor embedding.
+\* BPW is computed from exported asset size and includes the INT8 per-tensor quantized embedding.
 
 [p-4bit]: ../README.md#quantization-options

--- a/models/mistral/README.md
+++ b/models/mistral/README.md
@@ -8,13 +8,6 @@ Mistral AI's Mistral models for on-device inference via Core AI.
 | ------------------- | ---------- | ----- | --- |
 | Mistral 7B Instruct | 7.0B       | Yes   | Yes |
 
-## Gated Access
-This Mistral model is gated on [Hugging Face](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3) (HF). You will need to accept the terms of the [license](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3), generate a HF token, and add your HF token to your machine before exporting this model.
-```bash
-brew install hf
-hf auth login --token <YOUR_TOKEN_HERE>
-```
-
 ## Setup to export models
 
 If you haven't installed `uv`, install it by

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -123,6 +123,16 @@ LLM_PRESETS: list[ModelPreset] = [
         8192,
     ),
     ModelPreset(
+        "mistral-7b-instruct-v0.3",
+        "mistralai/Mistral-7B-Instruct-v0.3",
+        "mistral",
+        "llm",
+        "iOS",
+        "4bit_weight_palettized_group32",
+        "float16",
+        IOS_DEFAULT_MAX_CONTEXT_LENGTH,
+    ),
+    ModelPreset(
         "mixtral-8x7b-instruct-v0.1",
         "mistralai/Mixtral-8x7B-Instruct-v0.1",
         "mixtral",

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -128,7 +128,7 @@ LLM_PRESETS: list[ModelPreset] = [
         "mistral",
         "llm",
         "iOS",
-        "4bit_weight_palettized_group32",
+        "4bit_weight_palettized_group8",
         "float16",
         IOS_DEFAULT_MAX_CONTEXT_LENGTH,
     ),

--- a/python/tests/test_model_units/test_model_registry.py
+++ b/python/tests/test_model_units/test_model_registry.py
@@ -115,7 +115,7 @@ def test_output_name_llm_iOS_uses_yaml_stem_when_compression_config_set() -> Non
     [
         (
             "mistral-7b-instruct-v0.3",
-            "mistral_7b_instruct_v0_3_4bit_weight_palettized_group32_static",
+            "mistral_7b_instruct_v0_3_4bit_weight_palettized_group8_static",
         ),
     ],
 )

--- a/python/tests/test_model_units/test_model_registry.py
+++ b/python/tests/test_model_units/test_model_registry.py
@@ -110,6 +110,24 @@ def test_output_name_llm_iOS_uses_yaml_stem_when_compression_config_set() -> Non
     assert _preset_to_output_name(p) == "qwen3_0_6b_mixed_4bit_8bit_static"
 
 
+@pytest.mark.parametrize(
+    ("short_name", "expected"),
+    [
+        (
+            "mistral-7b-instruct-v0.3",
+            "mistral_7b_instruct_v0_3_4bit_weight_palettized_group32_static",
+        ),
+    ],
+)
+def test_output_name_llm_iOS_uses_named_preset_when_no_compression_config(
+    short_name: str, expected: str
+) -> None:
+    """Without a YAML config the iOS name is `<hf_tail>_<compression>_static`."""
+    p = lookup_preset(short_name, model_type="llm", variant="iOS")
+    assert p.compression_config is None
+    assert _preset_to_output_name(p) == expected
+
+
 def test_output_name_llm_iOS_prepends_hf_tail_when_yaml_stem_lacks_it() -> None:
     """A generic recipe stem (no model prefix) must still get the hf tail
     prepended so exports of different models with the same recipe don't


### PR DESCRIPTION
Registers `mistral-7b-instruct-v0.3` for iOS export using the `4bit_weight_palettized_group8` preset. `WikiText-2 word_perplexity`: 9.81 (iOS, INT4 weights + P4 group-8 palettization) vs 8.29 float16.