### PR TITLE
Add support for exporting LLMs with INT8 Quantized KV Cache

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -87,7 +87,9 @@ KV Cache quantization can be specified for `macOS` models using `coreai-opt`'s `
 ```
 
 
-For more details, please see the `4bit_weights_8bit_kv_cache` preset in [presets.py](../python/src/coreai_models/export/presets.py). Note that KV Cache quantization requires the graph execution_mode mode in `coreai-opt`.
+For more details, please see the `4bit_weights_8bit_kv_cache` preset in [presets.py](../python/src/coreai_models/export/presets.py). Note that KV Cache quantization requires `coreai-opt`'s graph execution_mode mode.
+
+Please see the [Qwen2.5](qwen2/README.md) and [Qwen3](qwen3/README.md) model cards for examples of models exported with KV Cache quantization.
 
 
 ##### Specifying Compression Configs via YAML files

--- a/models/README.md
+++ b/models/README.md
@@ -86,8 +86,7 @@ KV Cache quantization can be specified for `macOS` models using `coreai-opt`'s `
 }
 ```
 
-
-For more details, please see the `4bit_weights_8bit_kv_cache` preset in [presets.py](../python/src/coreai_models/export/presets.py). Note that KV Cache quantization requires `coreai-opt`'s graph execution_mode mode.
+For more details, please see the `4bit_weights_8bit_kv_cache` preset in [presets.py](../python/src/coreai_models/export/presets.py). Note that KV Cache quantization requires `coreai-opt`'s graph execution mode.
 
 Please see the [Qwen2.5](qwen2/README.md) and [Qwen3](qwen3/README.md) model cards for examples of models exported with KV Cache quantization.
 

--- a/models/README.md
+++ b/models/README.md
@@ -46,6 +46,7 @@ uv run coreai.llm.export org/NewModel \
 | Platform | Preset                                     | Description                                    |
 |----------|--------------------------------------------|------------------------------------------------|
 | macOS    | `4bit` (default)                           | INT4 weight-only, block size 32 (all layers)   |
+| macOS    | `4bit_weights_8bit_kv_cache`               | INT4 weight-only with INT8 per-tensor KV cache |
 | macOS    | `none`                                     | Full precision                                 |
 | iOS      | `4bit_weight_palettized_group32` (default) | 4-bit palettization with channel group size 32 |
 | iOS      | `4bit_weight_palettized_group8`            | 4-bit palettization with channel group size 8  |
@@ -60,7 +61,34 @@ uv run coreai.llm.export Qwen/Qwen3-0.6B --compression none                     
 uv run coreai.llm.export Qwen/Qwen3-0.6B --platform iOS --compression 4bit_weight_palettized_group8
 ```
 
-**Note:** By default, all quantization presets use `coreai-opt`'s `eager` execution mode. Use the `--quantization-mode graph` argument to override and use graph-mode quantization.
+**Note:** By default, all quantization presets (except the ones for KV Cache, please see below) use `coreai-opt`'s `eager` execution mode. Use the `--quantization-mode graph` argument to override and use graph-mode quantization.
+
+
+##### KV Cache Quantization
+
+KV Cache quantization can be specified for `macOS` models using `coreai-opt`'s `kv_cache_quant_configs` option in the config as follows:
+
+```py
+"kv_cache_quant_configs": {
+    "mutable_cache_update_and_fetch": {
+        "op_quantizer_config": {
+            "op_input_spec": {
+                1: {
+                    "dtype": "int8",
+                    "qscheme": "symmetric",
+                    "granularity": {"type": "per_tensor"},
+                }
+            },
+            "op_output_spec": None,
+            "op_state_spec": None,
+        },
+    }
+}
+```
+
+
+For more details, please see the `4bit_weights_8bit_kv_cache` preset in [presets.py](../python/src/coreai_models/export/presets.py). Note that KV Cache quantization requires the graph execution_mode mode in `coreai-opt`.
+
 
 ##### Specifying Compression Configs via YAML files
 

--- a/models/qwen2/README.md
+++ b/models/qwen2/README.md
@@ -40,7 +40,7 @@ uv run coreai.llm.export Qwen/Qwen2.5-1.5B-Instruct --num-layers 1 --compression
 uv run coreai.llm.export Qwen/Qwen2.5-1.5B-Instruct --dry-run
 
 # INT4 per-block quantized weights and INT8 per-tensor quantized KV Cache on macOS
-uv run coreai.llm.export qwen2.5-1.5b-instruct-8bit-kv
+uv run coreai.llm.export Qwen/Qwen2.5-1.5B-Instruct --compression 4bit_weights_8bit_kv_cache
 ```
 
 ## Run a Core AI Language Model

--- a/models/qwen2/README.md
+++ b/models/qwen2/README.md
@@ -75,12 +75,13 @@ Defaults: 512 prompt tokens, 1024 generation tokens, 5 trials. Override with `-p
 
 Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherAI/wikitext_document_level) dataset computed using the [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/wikitext/README.md) with the Core AI PyTorch models.
 
-| Model                 | Compression                               | Bits Per Weight (BPW) | Platform | Perplexity Score |
-| --------------------- | ----------------------------------------- | --------------------- | -------- | ---------------- |
-| Qwen2.5 1.5B Instruct | none (`float16`)                          | 16.00                 | macOS    | 12.21            |
-| Qwen2.5 1.5B Instruct | [4-bit quantized][p-4bit]                 | 4.50                  | macOS    | 14.79            |
-| Qwen2.5 1.5B Instruct | none (`float16`)                          | 16.00                 | iOS      | 12.21            |
-| Qwen2.5 1.5B Instruct | [4-bit palettized (group size 8)][p-4bit] | 4.63\*                | iOS      | 14.64            |
+| Model                 | Compression                                  | Bits Per Weight (BPW) | Platform | Perplexity Score |
+| --------------------- | -------------------------------------------- | --------------------- | -------- | ---------------- |
+| Qwen2.5 1.5B Instruct | none (`float16`)                             | 16.00                 | macOS    | 12.21            |
+| Qwen2.5 1.5B Instruct | [4-bit quantized][p-4bit]                    | 4.50                  | macOS    | 14.79            |
+| Qwen2.5 1.5B Instruct | [4-bit quantized with INT8 KV cache][p-4bit] | 4.50                  | macOS    | 15.38            |
+| Qwen2.5 1.5B Instruct | none (`float16`)                             | 16.00                 | iOS      | 12.21            |
+| Qwen2.5 1.5B Instruct | [4-bit palettized (group size 8)][p-4bit]    | 4.63\*                | iOS      | 14.64            |
 
 \* BPW includes the Embedding which is quantized to INT8 per-tensor.
 

--- a/models/qwen2/README.md
+++ b/models/qwen2/README.md
@@ -38,6 +38,9 @@ uv run coreai.llm.export Qwen/Qwen2.5-1.5B-Instruct --num-layers 1 --compression
 
 # Preview resolved config without exporting
 uv run coreai.llm.export Qwen/Qwen2.5-1.5B-Instruct --dry-run
+
+# INT4 per-block quantized weights and INT8 per-tensor quantized KV Cache on macOS
+uv run coreai.llm.export qwen2.5-1.5b-instruct-8bit-kv
 ```
 
 ## Run a Core AI Language Model

--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -42,7 +42,7 @@ uv run coreai.llm.export Qwen/Qwen3-0.6B --num-layers 1 --compression none
 uv run coreai.llm.export Qwen/Qwen3-0.6B --dry-run
 
 # INT4 Per Block quantized weights and INT8 KV Cache on macOS
-uv run coreai.llm.export qwen3-4b-8bit-kv
+uv run coreai.llm.export Qwen/Qwen3-4B --compression 4bit_weights_8bit_kv_cache
 ```
 
 ## Run a Core AI Language Model

--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -83,6 +83,7 @@ Perplexity score on the [`WikiText-2`](https://huggingface.co/datasets/EleutherA
 | Qwen3 0.6B | [Mixed 4-bit/8-bit palettized][mixed-4bit-8bit-yaml] | 5.71\*                | iOS      | 30.90            |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | macOS    | 16.41            |
 | Qwen3 4B   | [4-bit quantized][presets-info]                      | 4.50                  | macOS    | 18.33            |
+| Qwen3 4B   | [4-bit quantized with INT8 KV cache][presets-info]   | 4.50                  | macOS    | 18.65            |
 | Qwen3 4B   | none (`float16`)                                     | 16.00                 | iOS      | 16.41            |
 | Qwen3 4B   | [Mixed 4-bit/8-bit palettized][qwen3-4b-mixed-yaml]  | 4.89\*                | iOS      | 18.80            |
 | Qwen3 8B   | none (`float16`)                                     | 16.00                 | macOS    | 12.19            |

--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -40,6 +40,9 @@ uv run coreai.llm.export Qwen/Qwen3-0.6B --num-layers 1 --compression none
 
 # Preview resolved config without exporting
 uv run coreai.llm.export Qwen/Qwen3-0.6B --dry-run
+
+# INT4 Per Block quantized weights and INT8 KV Cache on macOS
+uv run coreai.llm.export qwen3-4b-8bit-kv
 ```
 
 ## Run a Core AI Language Model

--- a/python/src/coreai_models/export/compression.py
+++ b/python/src/coreai_models/export/compression.py
@@ -256,6 +256,8 @@ def quantize_for_export(
     quantization_config: dict,
     calibration_data_fn: Callable[[], list] | None = None,
     mmap_dir: str | None = None,
+    spec: TraceSpec | None = None,
+    export_backend: object | None = None,
 ) -> nn.Module:
     """Apply pre-export torch quantization using the model's own graph contract.
 
@@ -271,8 +273,12 @@ def quantize_for_export(
         calibration_data_fn: Calibration samples; required when the recipe enables
             ``calibrate_activations``.
         mmap_dir: Directory for the quantizer's disk checkpointing.
+        spec: Trace shapes. Defaults to a trace bounded at ``TRACE_KV_CACHE_SEQ_LEN``.
+        export_backend: Backend for the finalized model; see ``quantize_pytorch_model``.
+            Defaults to the CoreAI backend.
     """
-    spec = TraceSpec(max_context_length=TRACE_KV_CACHE_SEQ_LEN)
+    if spec is None:
+        spec = TraceSpec(max_context_length=TRACE_KV_CACHE_SEQ_LEN)
     reference_inputs = model.build_reference_inputs(config, target_dtype, spec)
     dynamic_shapes = model.build_dynamic_shapes(config, spec)
     # Same check the export path runs, so a bad contract fails identically on both.
@@ -312,6 +318,7 @@ def quantize_for_export(
         mmap_dir=mmap_dir,
         cache_seq_len=spec.cache_seq_len,
         state_indices=state_indices,
+        export_backend=export_backend,
     )
 
 

--- a/python/src/coreai_models/export/macos.py
+++ b/python/src/coreai_models/export/macos.py
@@ -140,6 +140,8 @@ def _retype_inputs_to_quantized_graph(
             value = value.to(dtype)
         retyped[name] = value
     return retyped
+
+
 def _drop_user_outputs(
     exported_program: torch.export.ExportedProgram,
 ) -> torch.export.ExportedProgram:

--- a/python/src/coreai_models/export/macos.py
+++ b/python/src/coreai_models/export/macos.py
@@ -81,6 +81,62 @@ def _set_prefill_mode(module: torch.nn.Module, prefill: bool) -> None:
         setter(prefill)
 
 
+def _retype_inputs_to_quantized_graph(
+    reference_inputs: dict[str, Any],
+    model: torch.nn.Module,
+) -> dict[str, Any]:
+    """Cast reference inputs to dtypes that the quantized graph declares. Specifically to
+    handle KV Cache quantization.
+
+    Placeholders are paired with ``reference_inputs`` **positionally**, which is also the
+    property ``export_to_coreai`` already relies on when it exports a graph-mode module
+    with ``pass_inputs_as_kwargs=False``.
+
+    Args:
+        reference_inputs: The contract's reference inputs, keyed by parameter name in
+            forward-signature order.
+        model: The compressed model to be exported. A non-``GraphModule`` (eager mode or no
+            compression) remains untouched.
+
+    Returns:
+        ``reference_inputs`` with each tensor in the dtype the graph declares. The
+        reference caches are all-zeros, so the casts are exact.
+
+    Raises:
+        ValueError: If the graph's tensor placeholders and ``reference_inputs`` disagree
+            in count, i.e. the positional pairing this depends on no longer holds.
+    """
+    if not isinstance(model, torch.fx.GraphModule):
+        return reference_inputs
+
+    placeholders = [
+        node
+        for node in model.graph.nodes
+        if node.op == "placeholder" and isinstance(node.meta.get("val"), torch.Tensor)
+    ]
+    if len(placeholders) != len(reference_inputs):
+        raise ValueError(
+            f"Quantized graph declares {len(placeholders)} tensor input(s) "
+            f"{[n.name for n in placeholders]} but the export contract supplied "
+            f"{len(reference_inputs)} {list(reference_inputs)}. These are paired "
+            "positionally, so the export cannot proceed."
+        )
+
+    retyped: dict[str, Any] = {}
+    for (name, value), node in zip(reference_inputs.items(), placeholders, strict=True):
+        if node.name != name:
+            # Positional pairing is authoritative
+            logger.debug(f"Graph placeholder '{node.name}' pairs with contract input '{name}'")
+        dtype = node.meta["val"].dtype
+        if value.dtype != dtype:
+            logger.info(
+                f"Reference input '{name}': {value.dtype} -> {dtype} to match the quantized graph"
+            )
+            value = value.to(dtype)
+        retyped[name] = value
+    return retyped
+
+
 def export_to_coreai(
     model: torch.nn.Module,
     reference_inputs: dict[str, Any],
@@ -298,6 +354,8 @@ def export_macos_model(
     reference_inputs, dynamic_shapes = _build_reference_inputs(
         contract_model, config, target_dtype, max_context_length
     )
+
+    reference_inputs = _retype_inputs_to_quantized_graph(reference_inputs, model)
 
     logger.info("Exporting model to Core AI dialect...")
     coreai_program = export_to_coreai(

--- a/python/src/coreai_models/export/presets.py
+++ b/python/src/coreai_models/export/presets.py
@@ -72,6 +72,54 @@ _TORCH_MODULE_CONFIGS_4BIT = {
     **_TORCH_MOE_SWITCH_LINEAR_4BIT,
 }
 
+# Building blocks for the graph-mode quantization presets.
+
+_INT4_WEIGHT_SPEC = {
+    "weight": {
+        "dtype": "int4",
+        "qscheme": "symmetric_with_clipping",
+        "granularity": {
+            "type": "per_block",
+            "block_size": 32,
+            "axis": 1,
+        },
+    }
+}
+
+
+def _create_per_tensor_symmetric_kv_cache_config(dtype: str) -> dict[str, Any]:
+    """KV-cache buffer quantization config for the fused cache-update op.
+
+    Args:
+        dtype: coreai-opt dtype name the cache buffer is stored.
+    """
+    return {
+        "mutable_cache_update_and_fetch": {
+            "op_quantizer_config": {
+                "op_input_spec": {
+                    1: {
+                        "dtype": dtype,
+                        "qscheme": "symmetric",
+                        "granularity": {"type": "per_tensor"},
+                    }
+                },
+                "op_output_spec": None,
+                "op_state_spec": None,
+            },
+        }
+    }
+
+
+_INT4_WEIGHT_ONLY_CONFIG_BASE: dict[str, Any] = {
+    "global_config": {
+        "op_state_spec": _INT4_WEIGHT_SPEC,
+        "op_input_spec": None,
+        "op_output_spec": None,
+    },
+    "module_type_configs": _TORCH_MODULE_CONFIGS_4BIT,
+}
+
+
 MACOS_PRESETS: dict[str, dict[str, Any]] = {
     # ---------------------------------------------------------------
     # No quantization — full precision
@@ -88,25 +136,24 @@ MACOS_PRESETS: dict[str, dict[str, Any]] = {
     "4bit": {
         "torch_quantization_config": {
             "execution_mode": "eager",
-            "global_config": {
-                "op_state_spec": {
-                    "weight": {
-                        "dtype": "int4",
-                        "qscheme": "symmetric_with_clipping",
-                        "granularity": {
-                            "type": "per_block",
-                            "block_size": 32,
-                            "axis": 1,
-                        },
-                    }
-                },
-                "op_input_spec": None,
-                "op_output_spec": None,
-            },
-            "module_type_configs": _TORCH_MODULE_CONFIGS_4BIT,
+            **_INT4_WEIGHT_ONLY_CONFIG_BASE,
         },
         "suffix": "4bit",
         "description": "INT4 symmetric per-block weight quantization (torch pre-export)",
+    },
+    # Same as the above `4bit` preset along with an INT8 per-tensor quantized KV cache.
+    # Note: KV Cache quantization using ``coreai-opt`` requires graph-mode.
+    "4bit_weights_8bit_kv_cache": {
+        "torch_quantization_config": {
+            "execution_mode": "graph",
+            **_INT4_WEIGHT_ONLY_CONFIG_BASE,
+            "kv_cache_quant_configs": _create_per_tensor_symmetric_kv_cache_config("int8"),
+            "calibrate_activations": True,
+        },
+        "suffix": "4bit_weights_8bit_kv_cache",
+        "description": (
+            "INT4 symmetric per-block weight quantization and INT8 per-tensor KV cache (graph mode)"
+        ),
     },
 }
 

--- a/python/src/coreai_models/export/presets.py
+++ b/python/src/coreai_models/export/presets.py
@@ -91,7 +91,7 @@ def _create_per_tensor_symmetric_kv_cache_config(dtype: str) -> dict[str, Any]:
     """KV-cache buffer quantization config for the fused cache-update op.
 
     Args:
-        dtype: coreai-opt dtype name the cache buffer is stored.
+        dtype: coreai-opt dtype name the cache buffer is stored in.
     """
     return {
         "mutable_cache_update_and_fetch": {

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -108,9 +108,7 @@ LLM_PRESETS: list[ModelPreset] = [
         "4bit_weights_8bit_kv_cache",
         "float16",
         40960,
-        notes=(
-            "INT4 per-block weights and INT8 per-tensor KV cache."
-        ),
+        notes=("INT4 per-block weights and INT8 per-tensor KV cache."),
     ),
     ModelPreset("qwen3-8b", "Qwen/Qwen3-8B", "qwen3", "llm", "macOS", "4bit", "float16", 40960),
     ModelPreset(

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -86,8 +86,32 @@ LLM_PRESETS: list[ModelPreset] = [
         "float16",
         32768,
     ),
+    ModelPreset(
+        "qwen2.5-1.5b-instruct-8bit-kv",
+        "Qwen/Qwen2.5-1.5B-Instruct",
+        "qwen2.5",
+        "llm",
+        "macOS",
+        "4bit_weights_8bit_kv_cache",
+        "float16",
+        32768,
+        notes="INT4 per-block weights and INT8 per-tensor KV cache.",
+    ),
     ModelPreset("qwen3-0.6b", "Qwen/Qwen3-0.6B", "qwen3", "llm", "macOS", "4bit", "float16", 8192),
     ModelPreset("qwen3-4b", "Qwen/Qwen3-4B", "qwen3", "llm", "macOS", "4bit", "float16", 40960),
+    ModelPreset(
+        "qwen3-4b-8bit-kv",
+        "Qwen/Qwen3-4B",
+        "qwen3",
+        "llm",
+        "macOS",
+        "4bit_weights_8bit_kv_cache",
+        "float16",
+        40960,
+        notes=(
+            "INT4 per-block weights and INT8 per-tensor KV cache."
+        ),
+    ),
     ModelPreset("qwen3-8b", "Qwen/Qwen3-8B", "qwen3", "llm", "macOS", "4bit", "float16", 40960),
     ModelPreset(
         "qwen3-coder-30b-a3b-instruct",
@@ -603,9 +627,12 @@ def try_lookup_preset_by_hf_id(
         return candidates[0]
     if variant is None:
         macos = [p for p in candidates if p.variant == "macOS"]
-        if len(macos) == 1:
+        if macos:
             return macos[0]
-    return None
+        return None
+    # A variant was requested but several presets share this hf_id+variant.
+    # So prefer the first-registered preset.
+    return candidates[0]
 
 
 def families(model_type: str, *, include_experimental: bool = False) -> list[str]:

--- a/python/src/coreai_models/primitives/_ops.py
+++ b/python/src/coreai_models/primitives/_ops.py
@@ -48,7 +48,7 @@ def mutable_slice_update_meta(  # type: ignore
     end: Tensor,
 ):
     """Fake implementation for tracing/meta operations."""
-    return torch.empty(x.shape, dtype=x.dtype)
+    return torch.empty(x.shape, dtype=x.dtype, device=x.device)
 
 
 @torch.library.custom_op("coreai::mutable_cache_update_and_fetch", mutates_args=["x"])
@@ -114,4 +114,4 @@ def mutable_cache_update_and_fetch_meta(  # type: ignore
     if seq_len is not None:
         out_shape[seq_dim] = seq_len
     out_shape.pop(0)  # squeeze layer dim
-    return torch.empty(out_shape, dtype=x.dtype)
+    return torch.empty(out_shape, dtype=x.dtype, device=x.device)

--- a/python/tests/_runner_infra/testing_utils.py
+++ b/python/tests/_runner_infra/testing_utils.py
@@ -826,6 +826,7 @@ class ForCausalLMTestBase:
     _test_kv_cache: bool = True
     _test_weight_activation_quantization: bool = False
     _test_eager_activation_quantization: bool = True
+    _test_kv_cache_quantization: bool = False
 
     @pytest.fixture(autouse=True)
     def _skip_if_hf_unreachable(self) -> None:
@@ -1091,6 +1092,152 @@ class ForCausalLMTestBase:
             )
 
             assert coreai_program is not None, "export_macos_model returned None, conversion failed"
+
+    @pytest.mark.usefixtures("disable_hf_impl_for_coreai")
+    def test_kv_cache_quantization(self) -> None:
+        """Graph-mode export with an INT8 per-tensor quantized KV cache.
+
+        Tests INT8 KV Cache recipe: INT4 per-block weights
+        plus an INT8 per-tensor KV cache applied to the fused
+        ``mutable_cache_update_and_fetch`` op.
+
+        Saves the program and confirms the exported key/value
+        cache states are INT8.
+        """
+        if not self._test_kv_cache_quantization:
+            pytest.skip("KV cache quantization test not enabled for this model")
+
+        from coreai.authoring import AIModelAsset
+        from coreai.runtime import AIModelAssetMetadata
+
+        from coreai_models._constants import KEY_CACHE_NAME, VALUE_CACHE_NAME
+        from coreai_models.export.compression import quantize_for_export
+        from coreai_models.export.externalize import patch_model_for_externalization
+        from coreai_models.export.macos import export_macos_model
+        from coreai_models.export.pipeline import ExportConfig
+
+        hf_config = transformers.AutoConfig.from_pretrained(self._toy_model_id)
+        is_gemma = "gemma" in self._model_class.__name__.lower()
+        if is_gemma and hasattr(hf_config, "text_config"):
+            hf_config = hf_config.text_config
+
+        # INT4 per-block weights that is the shared base of the `4bit*` presets.
+        weight_qspec_dict = {
+            "weight": {
+                "dtype": "int4",
+                "qscheme": "symmetric_with_clipping",
+                "granularity": {
+                    "type": "per_block",
+                    "block_size": 8,
+                    "axis": 1,
+                },
+            }
+        }
+        rms_norm_cls = (
+            "coreai_models.primitives.macos.rms_norm.RMSNormPlusOne"
+            if is_gemma
+            else "coreai_models.primitives.macos.rms_norm.RMSNorm"
+        )
+        kv_cache_quant_configs = {
+            "mutable_cache_update_and_fetch": {
+                "op_quantizer_config": {
+                    "op_input_spec": {
+                        1: {
+                            "dtype": "int8",
+                            "qscheme": "symmetric",
+                            "granularity": {"type": "per_tensor"},
+                        }
+                    },
+                    "op_output_spec": None,
+                    "op_state_spec": None,
+                },
+            }
+        }
+        torch_quantization_config = {
+            "global_config": {
+                "op_state_spec": weight_qspec_dict,
+                "op_input_spec": None,
+                "op_output_spec": None,
+            },
+            "module_type_configs": {
+                "coreai_models.primitives.macos.sdpa.SDPA": None,
+                "coreai_models.primitives.macos.rope.RoPE": None,
+                rms_norm_cls: None,
+            },
+            # KV cache quantization is graph-mode only.
+            "execution_mode": "graph",
+            "kv_cache_quant_configs": kv_cache_quant_configs,
+            "calibrate_activations": True,
+        }
+
+        def calibration_data_fn() -> list[torch.Tensor]:
+            return [
+                torch.randint(1, hf_config.vocab_size, (1, 16), dtype=torch.int32) for _ in range(3)
+            ]
+
+        max_context_length = 4096
+        target_dtype = torch.float16
+        hf_state_dict_prefix = "language_model." if is_gemma else ""
+        hf_config_attr = "text_config" if is_gemma else None
+
+        def _descriptor_dtype(descriptor: str) -> str:
+            """Pull the dtype token out of a state descriptor string, e.g.
+            ``"NDArray (Int8, 2 x 1 x 32 x 1 x 2048)"`` -> ``"Int8"``."""
+            inside = descriptor[descriptor.index("(") + 1 : descriptor.rindex(")")]
+            return inside.split(",", 1)[0].strip()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            layer_mmap_dir = f"{tmpdir}/layers"
+            os.makedirs(layer_mmap_dir, exist_ok=True)
+            model = self._model_class.from_hf_memory_efficient(
+                self._toy_model_id,
+                max_context_length=max_context_length,
+                target_dtype=target_dtype,
+                mmap_path=layer_mmap_dir,
+                hf_config_attr=hf_config_attr,
+                hf_state_dict_prefix=hf_state_dict_prefix,
+            ).eval()
+
+            patch_model_for_externalization(model)
+            externalized_model = model
+
+            model = quantize_for_export(
+                model,
+                hf_config,
+                target_dtype,
+                dict(torch_quantization_config),
+                calibration_data_fn=calibration_data_fn,
+            )
+
+            export_config = ExportConfig(
+                hf_model_id=self._toy_model_id,
+                max_context_length=max_context_length,
+                quantization_mode="graph",
+            )
+            coreai_program = export_macos_model(
+                model, hf_config, export_config, externalized_model=externalized_model
+            )
+            assert coreai_program is not None, "export_macos_model returned None, conversion failed"
+
+            # KV-specific check: the exported key/value cache states must be INT8.
+            coreai_program.optimize()
+            aimodel_path = Path(tmpdir) / "kv_int8.aimodel"
+            coreai_program.save_asset(aimodel_path, AIModelAssetMetadata())
+            summary = AIModelAsset.load(aimodel_path).summary(include_statistics=False)
+
+            functions_with_cache = 0
+            for function_name in summary.function_names:
+                states = dict(summary.function_states(function_name))
+                if KEY_CACHE_NAME not in states or VALUE_CACHE_NAME not in states:
+                    continue
+                functions_with_cache += 1
+                for cache_name in (KEY_CACHE_NAME, VALUE_CACHE_NAME):
+                    dtype = _descriptor_dtype(states[cache_name])
+                    assert "int8" in dtype.lower(), (
+                        f"{function_name}: {cache_name} exported as {dtype!r}, "
+                        "expected INT8 KV cache"
+                    )
+            assert functions_with_cache > 0, "expected at least one function with KV-cache states"
 
 
 """

--- a/python/tests/_runner_infra/testing_utils.py
+++ b/python/tests/_runner_infra/testing_utils.py
@@ -1098,7 +1098,7 @@ class ForCausalLMTestBase:
         """Graph-mode export with an INT8 per-tensor quantized KV cache.
 
         Tests INT8 KV Cache recipe: INT4 per-block weights
-        plus an INT8 per-tensor KV cache applied to the fused
+        plus an INT8 per-tensor KV cache applied to the
         ``mutable_cache_update_and_fetch`` op.
 
         Saves the program and confirms the exported key/value

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_qwen2.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_qwen2.py
@@ -974,5 +974,6 @@ class TestQwen2ForCausalLM(ForCausalLMTestBase):
     _model_class = CoreaiTorchQwen2ForCausalLM
     _test_weights_tying = True
     _test_weight_activation_quantization = True
+    _test_kv_cache_quantization = True
     # enable once the fix in https://github.com/apple/coreai-optimization/pull/78 is released
     _test_eager_activation_quantization = False

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_qwen3.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_qwen3.py
@@ -950,3 +950,4 @@ class TestQwen3ForCausalLM(ForCausalLMTestBase):
     _model_class = CoreaiTorchQwen3ForCausalLM
     _test_weights_tying = True
     _test_weight_activation_quantization = True
+    _test_kv_cache_quantization = True


### PR DESCRIPTION
Key Changes:

- Support for INT8 per-tensor KV Cache quantization
- A new preset for INT8 per-tensor KV$ and refactor existing preset structure
- Perplexity to validate the new registry entries for `Qwen2.5 1.5B` and `Qwen3 4B`
- Model Card update


**Evaluation**

`word_perplexity` on wikitext. Weights are `INT4 per-block-32`.

| Model | FP16 KV | INT8 KV |
|---|---:|---:|
| Qwen2.5-1.5B-Instruct | 14.79 | 15.38 |
| Qwen3-4B | 18.33 | 18.65 |
