### PR TITLE
Add iOS export preset for Qwen3-8B

### DIFF
--- a/models/qwen3/README.md
+++ b/models/qwen3/README.md
@@ -9,7 +9,7 @@ Alibaba's Qwen3 models for on-device inference via Core AI.
 | Qwen3 0.6B | 0.6B       | Yes   | Yes |
 | Qwen3 1.7B | 1.7B       | Yes   | Yes |
 | Qwen3 4B   | 4.0B       | Yes   | Yes |
-| Qwen3 8B   | 8.0B       | Yes   | No  |
+| Qwen3 8B   | 8.0B       | Yes   | Yes |
 
 ## Setup to export models
 

--- a/python/src/coreai_models/model_registry.py
+++ b/python/src/coreai_models/model_registry.py
@@ -333,6 +333,16 @@ LLM_PRESETS: list[ModelPreset] = [
         4096,
         _model_type_override="qwen2",
     ),
+    ModelPreset(
+        "qwen3-8b",
+        "Qwen/Qwen3-8B",
+        "qwen3",
+        "llm",
+        "iOS",
+        "4bit_weight_palettized_group32",
+        "float16",
+        IOS_DEFAULT_MAX_CONTEXT_LENGTH,
+    ),
 ]
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_model_units/test_model_registry.py
+++ b/python/tests/test_model_units/test_model_registry.py
@@ -93,6 +93,16 @@ def test_export_args_iOS_emits_variant_flag() -> None:
     assert args[args.index("--platform") + 1] == "iOS"
 
 
+@pytest.mark.parametrize("short_name", ["qwen3-8b", "mistral-7b-instruct-v0.3"])
+def test_export_args_platform_flag_distinguishes_variants(short_name: str) -> None:
+    """Models registered for both platforms must emit `--platform iOS` only for
+    the iOS variant; macOS is the export tool's default and stays implicit."""
+    macos = _preset_to_export_args(lookup_preset(short_name, model_type="llm", variant="macOS"))
+    ios = _preset_to_export_args(lookup_preset(short_name, model_type="llm", variant="iOS"))
+    assert "--platform" not in macos
+    assert ios[ios.index("--platform") + 1] == "iOS"
+
+
 def test_export_args_diffusion_no_variant_no_context() -> None:
     p = lookup_preset("flux2-klein-4b", model_type="diffusion")
     args = _preset_to_export_args(p)
@@ -113,6 +123,7 @@ def test_output_name_llm_iOS_uses_yaml_stem_when_compression_config_set() -> Non
 @pytest.mark.parametrize(
     ("short_name", "expected"),
     [
+        ("qwen3-8b", "qwen3_8b_4bit_weight_palettized_group32_static"),
         (
             "mistral-7b-instruct-v0.3",
             "mistral_7b_instruct_v0_3_4bit_weight_palettized_group8_static",
@@ -178,6 +189,16 @@ def test_try_lookup_without_type_finds_across_tables() -> None:
 
 def test_try_lookup_prefers_macos_when_ambiguous() -> None:
     p = try_lookup_preset("qwen3-0.6b", model_type="llm")
+    assert p is not None
+    assert p.variant == "macOS"
+
+
+@pytest.mark.parametrize("short_name", ["qwen3-8b", "mistral-7b-instruct-v0.3"])
+def test_try_lookup_bare_short_name_still_resolves_to_macos(short_name: str) -> None:
+    """Adding an iOS variant makes these short-names ambiguous. The export CLI
+    calls try_lookup_preset with variant=None when --platform is omitted, so
+    macOS must keep winning or `uv run coreai.llm.export <name>` would break."""
+    p = try_lookup_preset(short_name, model_type="llm")
     assert p is not None
     assert p.variant == "macOS"
 


### PR DESCRIPTION
Qwen3-8B was registered for macOS only, so
`coreai.llm.export qwen3-8b --platform iOS` exited with "not available for iOS" even though the iOS model class (Qwen3ForCausalLMForiOS) already exists and is registered.

Register it for iOS using the default named palettization preset (4bit_weight_palettized_group32) at IOS_DEFAULT_MAX_CONTEXT_LENGTH, matching the style of the existing qwen2.5-1.5b-instruct iOS entry. No new compression YAMLs.

Adding this variant makes the short-name ambiguous, so include a regression test that a bare short-name still resolves to macOS via the macOS-preference branch in try_lookup_preset -- otherwise `coreai.llm.export qwen3-8b` would break.

The Mistral-7B iOS preset this change originally also added is now covered upstream at group size 8, so only the shared registry tests are extended to cover it.