### PR TITLE
Add DFlash speculative decoding drafter for Muse Glimmer

### DIFF
--- a/python/src/coreai_models/models/macos/muse_glimmer.py
+++ b/python/src/coreai_models/models/macos/muse_glimmer.py
@@ -543,3 +543,134 @@ class MuseGlimmerForCausalLM(BaseForCausalLM):
         super().load_state_dict(state_dict, strict=strict, assign=assign)
         if getattr(self.config, "tie_word_embeddings", False):
             self.lm_head.weight = self.model.embed_tokens.weight
+
+
+# ---------------------------------------------------------------------------
+# DFlash speculative decoding: fused target + drafter encoder
+# ---------------------------------------------------------------------------
+
+# Output of every 12th layer in the 52-layer target.
+_DEFAULT_TARGET_LAYER_IDS: list[int] = [1, 13, 25, 37, 49]
+
+
+class MuseGlimmerModelWithDrafter(MuseGlimmerModel):
+    """Backbone that also returns hidden states at selected layers.
+
+    The forward signature returns a *tuple*
+    ``(final_hidden, extracted_hidden_states)`` where the second element
+    is a list of ``[1, query_len, hidden_size]`` tensors, one per tap layer.
+    """
+
+    def __init__(self, config, target_layer_ids: list[int] | None = None) -> None:
+        super().__init__(config)
+        self.target_layer_ids: list[int] = (
+            target_layer_ids
+            if target_layer_ids is not None
+            else list(getattr(config, "target_layer_ids", _DEFAULT_TARGET_LAYER_IDS))
+        )
+        self._tap_set = frozenset(self.target_layer_ids)
+
+    # NOTE: keep forward logic in sync with MuseGlimmerModel.forward.
+    def forward(  # type: ignore[override]
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        global_cache: KVCache | None = None,
+        sliding_cache: RingKVCache | None = None,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        query_len = input_ids.shape[-1]
+        seq_len = position_ids.shape[-1]
+        torch._check_is_size(query_len)
+        torch._check_is_size(seq_len)
+        offset = seq_len - query_len
+        torch._check_is_size(offset)
+
+        h = self.embed_tokens(input_ids)
+        h = h * torch.rsqrt(h.pow(2).mean(-1, keepdim=True) + self.config.rms_norm_eps)
+
+        sliding_mask = None
+        if sliding_cache is not None:
+            sliding_mask = ring_window_causal_mask(
+                query_len,
+                sliding_cache.capacity(),
+                offset,
+                self.sliding_window,
+                input_ids.device,
+            )
+
+        extracted: list[torch.Tensor] = []
+
+        for idx, layer in enumerate(self.layers):
+            h = layer(
+                h,
+                position_ids,
+                offset,
+                query_len,
+                global_cache,
+                sliding_cache,
+                sliding_mask,
+            )
+            if idx in self._tap_set:
+                extracted.append(h)
+
+        h = self.norm(h)
+        if self.output_multiplier != 1.0:
+            h = h * self.output_multiplier
+        return h, extracted
+
+
+class MuseGlimmerForCausalLMWithDrafter(MuseGlimmerForCausalLM):
+    """Fused target + drafter encoder: produces ``(logits, drafter_features)``.
+
+    The drafter encoder is a simple linear projection + RMSNorm:
+        features = encoder_norm(encoder_fc(cat(h_layer1, h_layer13, ...)))
+    """
+
+    @override
+    def _init_model(self, config) -> None:
+        super()._init_model(config)
+        target_layer_ids = list(getattr(config, "target_layer_ids", _DEFAULT_TARGET_LAYER_IDS))
+        self.model = MuseGlimmerModelWithDrafter(config, target_layer_ids=target_layer_ids)
+
+        encoder_in = len(target_layer_ids) * config.hidden_size
+        encoder_out = getattr(config, "drafter_hidden_size", config.hidden_size)
+        self.encoder_fc = nn.Linear(encoder_in, encoder_out, bias=False)
+        self.encoder_norm = RMSNorm(encoder_out, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        global_k_cache: torch.Tensor,
+        global_v_cache: torch.Tensor,
+        sliding_k_cache: torch.Tensor,
+        sliding_v_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        global_cache = KVCache(global_k_cache, global_v_cache)
+        sliding_cache = RingKVCache(sliding_k_cache, sliding_v_cache)
+        hidden, extracted = self.model(input_ids, position_ids, global_cache, sliding_cache)
+
+        logits = self.lm_head(hidden)
+        if self._softcap:
+            logits = torch.tanh(logits / self._softcap) * self._softcap
+
+        fused = self.encoder_fc(torch.cat(extracted, dim=-1))
+        drafter_features = self.encoder_norm(fused)
+
+        return logits, drafter_features
+
+    @override
+    @classmethod
+    def export_output_names(cls) -> dict[str, tuple[str, ...]]:
+        return {MAIN_GRAPH_NAME: ("logits", "drafter_features")}
+
+    @override
+    def _mutate_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
+        super()._mutate_state_dict(state_dict)
+        encoder_renames = {
+            "encoder.fc.weight": "encoder_fc.weight",
+            "encoder.output_norm_enc.weight": "encoder_norm.weight",
+        }
+        for old_key, new_key in encoder_renames.items():
+            if old_key in state_dict:
+                state_dict[new_key] = state_dict.pop(old_key)

--- a/python/src/coreai_models/models/macos/muse_glimmer_drafter_dflash.py
+++ b/python/src/coreai_models/models/macos/muse_glimmer_drafter_dflash.py
@@ -1,0 +1,306 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Muse Glimmer DFlash drafter -- two-phase speculative decoding prototype.
+
+Architecture (same backbone as the standard ring drafter):
+- 5 transformer layers, all sliding window (2048)
+- 32Q / 8KV heads, head_dim 128
+- Separate q_norm / k_norm (not shared like the target)
+- No gated attention, no sandwich norms
+- Shares embed_tokens and lm_head with the target model
+- Ring buffer KV cache with explicit attention mask
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from coreai_models.primitives.macos.cache import RingKVCache
+from coreai_models.primitives.macos.mlp import MLP
+from coreai_models.primitives.macos.rms_norm import RMSNorm
+from coreai_models.primitives.macos.rope import RoPE
+from coreai_models.primitives.macos.sdpa import SDPA
+
+# ---------------------------------------------------------------------------
+# Mask helpers
+# ---------------------------------------------------------------------------
+
+
+def dflash_draft_mask(
+    query_len: int,
+    capacity: int,
+    offset: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Bidirectional attention mask for the draft phase."""
+    slot = torch.arange(capacity, device=device)
+    last_pos = offset + query_len - 1
+
+    # Reconstruct absolute position stored in each ring slot.
+    # Same derivation as ring_window_causal_mask but without the causal check.
+    r = last_pos % capacity
+    diff = r - slot  # range (-capacity, capacity)
+    ring_back = torch.where(diff >= 0, diff, diff + capacity)
+    k_pos = last_pos - ring_back  # (capacity,)
+
+    total_valid = offset + query_len
+    valid = (k_pos >= 0) & (k_pos < total_valid)
+    return valid.unsqueeze(0).expand(query_len, capacity)
+
+
+# ---------------------------------------------------------------------------
+# Modules
+# ---------------------------------------------------------------------------
+
+
+class Attention(nn.Module):
+    """Attention with separate inject_kv and draft paths."""
+
+    def __init__(self, config: SimpleNamespace, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.window_size = config.sliding_window
+
+        dim = config.hidden_size
+        self.n_heads = n_heads = config.num_attention_heads
+        self.n_kv_heads = n_kv_heads = config.num_key_value_heads
+        self.head_dim = head_dim = config.head_dim
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
+
+        self.q_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
+
+        # Non-causal; explicit mask required
+        self.sdpa = SDPA(is_causal=False)
+
+        rope_theta = (
+            config.rope_parameters.get("rope_theta", 500000.0)
+            if isinstance(config.rope_parameters, dict)
+            else 500000.0
+        )
+        self.rope = RoPE()
+        with torch.device("cpu"):
+            self._rope_freqs = 1.0 / (
+                rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+            )
+
+    # ---- Phase 1: KV injection (no attention) ----------------------------
+
+    def inject_kv(
+        self,
+        features: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> None:
+        """Project features through Wk/Wv and write to ring cache."""
+        batch_size, n_features, _ = features.shape
+        n_kv_heads = self.n_kv_heads
+
+        # K projection + norm + RoPE
+        key = self.k_norm(
+            self.k_proj(features)
+            .reshape(batch_size, n_features, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+        freqs = self._rope_freqs.to(device=features.device)
+        key = self.rope(key, position_ids=position_ids, freqs=freqs)
+
+        # V projection (no norm, no RoPE)
+        value = (
+            self.v_proj(features)
+            .reshape(batch_size, n_features, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+
+        # Ring offset = first absolute position being injected
+        offset = int(position_ids[0, 0])
+        cache.update_and_fetch(self.layer_idx, offset=offset, k=key, v=value, query_len=n_features)
+
+    # ---- Phase 2: Draft forward (full attention) -------------------------
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+        attn_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Attention forward for draft tokens."""
+        batch_size, query_len, _ = x.shape
+        n_heads, n_kv_heads = self.n_heads, self.n_kv_heads
+
+        query = self.q_norm(
+            self.q_proj(x)
+            .reshape(batch_size, query_len, n_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+        key = self.k_norm(
+            self.k_proj(x)
+            .reshape(batch_size, query_len, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+        value = (
+            self.v_proj(x)
+            .reshape(batch_size, query_len, n_kv_heads, self.head_dim)
+            .permute(0, 2, 1, 3)
+        )
+
+        freqs = self._rope_freqs.to(device=query.device)
+        seq_len = position_ids.shape[-1]
+        offset = seq_len - query_len
+        rope_positions = position_ids.narrow(-1, offset, query_len)
+        query = self.rope(query, position_ids=rope_positions, freqs=freqs)
+        key = self.rope(key, position_ids=rope_positions, freqs=freqs)
+
+        # Write draft KV to cache, fetch full cache (injected + draft)
+        key, value = cache.update_and_fetch(self.layer_idx, offset, key, value, query_len=query_len)
+
+        attn_output = (
+            self.sdpa(query=query, key=key, value=value, attn_mask=attn_mask)
+            .permute(0, 2, 1, 3)
+            .reshape(batch_size, query_len, self.n_heads * self.head_dim)
+        )
+        return self.o_proj(attn_output)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: SimpleNamespace, layer_idx: int) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        self.self_attn = Attention(config, layer_idx=layer_idx)
+        self.mlp = MLP(hidden_size, config.intermediate_size)
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def inject_kv(
+        self,
+        features: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> None:
+        """KV injection: project features and write to cache."""
+        self.self_attn.inject_kv(features, position_ids, cache)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+        attn_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Draft forward: attention + MLP."""
+        r = self.self_attn(self.input_layernorm(x), position_ids, cache, attn_mask)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+class DFlashDrafterModel(nn.Module):
+    """DFlash drafter backbone with two-phase forward.
+
+    Phase 1 (``inject_kv``): target encoder features -> per-layer Wk/Wv -> KV cache.
+    Phase 2 (``draft``): ``[last_token, MASK * K]`` -> full transformer -> hidden states.
+    """
+
+    def __init__(self, config: SimpleNamespace) -> None:
+        super().__init__()
+        self.config = config
+        hidden_size = config.hidden_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, hidden_size)
+        self.layers = nn.ModuleList(
+            [TransformerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+
+    def inject_kv(
+        self,
+        features: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> None:
+        """Write target encoder features to the KV cache."""
+        for layer in self.layers:
+            layer.inject_kv(features, position_ids, cache)  # type: ignore[operator]
+
+    def draft(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> torch.Tensor:
+        """Run draft tokens through the transformer, attending to injected KV."""
+        query_len = input_ids.shape[-1]
+        seq_len = position_ids.shape[-1]
+        offset = seq_len - query_len  # = n_injected
+
+        h = self.embed_tokens(input_ids)
+        # NO embed norm for DFlash — HF explicitly bypasses it:
+        # "The assistant needs embedding without norm" (candidate_generator.py:1676)
+
+        # Bidirectional mask over valid ring positions
+        attn_mask = dflash_draft_mask(
+            query_len=query_len,
+            capacity=cache.capacity(),
+            offset=offset,
+            device=input_ids.device,
+        )
+
+        for layer in self.layers:
+            h = layer(h, position_ids, cache, attn_mask)
+        return self.norm(h)
+
+
+class MuseGlimmerDFlashDrafterForCausalLM(nn.Module):
+    """DFlash drafter with lm_head for speculative decoding.
+
+    # Not exported — the ring drafter is the export target. This class provides
+    # inject_kv + draft for Python-side acceptance testing and parity verification.
+
+    Usage::
+
+        model = MuseGlimmerDFlashDrafterForCausalLM(config)
+
+        # Phase 1: inject target features into KV cache
+        model.inject_kv(features, inject_positions, cache)
+
+        # Phase 2: draft K tokens in parallel
+        logits = model.draft(draft_input_ids, full_position_ids, cache)
+    """
+
+    def __init__(self, config: SimpleNamespace) -> None:
+        super().__init__()
+        self.config = config
+        self.model = DFlashDrafterModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def inject_kv(
+        self,
+        features: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> None:
+        """Write encoder features to KV cache."""
+        self.model.inject_kv(features, position_ids, cache)
+
+    def draft(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.IntTensor,
+        cache: RingKVCache,
+    ) -> torch.Tensor:
+        """Draft K tokens, return logits ``(batch, K, vocab_size)``."""
+        hidden = self.model.draft(input_ids, position_ids, cache)
+        return self.lm_head(hidden)

--- a/python/tests/test_model_units/test_models/test_dflash.py
+++ b/python/tests/test_model_units/test_models/test_dflash.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for DFlash speculative decoding: drafter shapes, hidden state extraction, fused target."""
+
+import torch
+
+from coreai_models.models.macos.muse_glimmer import (
+    MuseGlimmerForCausalLMWithDrafter,
+    MuseGlimmerModelWithDrafter,
+)
+from coreai_models.models.macos.muse_glimmer_drafter_dflash import (
+    MuseGlimmerDFlashDrafterForCausalLM,
+    dflash_draft_mask,
+)
+from coreai_models.primitives.macos.cache import RingKVCache
+
+
+def _make_small_config():
+    """Create a minimal Muse Glimmer config for testing (4 layers, tiny dims)."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=4,
+        vocab_size=200,
+        rms_norm_eps=1e-5,
+        sliding_window=32,
+        rope_parameters={"rope_theta": 500000.0},
+        block_size=4,
+        mask_token_id=99,
+        max_position_embeddings=512,
+        output_multiplier=1.0,
+        qk_scale_factor=1.0,
+        final_logit_softcapping=None,
+        tie_word_embeddings=False,
+        post_norm_eps=1e-8,
+        layer_types=["sliding_attention"] * 3 + ["full_attention"],
+        layer_rope_theta=[500000.0, 500000.0, 500000.0, 0],
+        target_layer_ids=[0, 2],
+    )
+
+
+class TestDFlashDraftMask:
+    """Verify the bidirectional attention mask for DFlash draft mode."""
+
+    def test_mask_shape(self):
+        mask = dflash_draft_mask(query_len=4, capacity=32, offset=5, device=torch.device("cpu"))
+        assert mask.shape == (4, 32)
+
+    def test_mask_valid_count(self):
+        mask = dflash_draft_mask(query_len=4, capacity=32, offset=5, device=torch.device("cpu"))
+        assert mask[0].sum().item() == 5 + 4  # n_injected + n_draft
+
+    def test_mask_bidirectional(self):
+        mask = dflash_draft_mask(query_len=8, capacity=64, offset=10, device=torch.device("cpu"))
+        assert torch.all(mask[0] == mask[-1]), "All rows should be identical (bidirectional)"
+
+    def test_mask_no_stale_slots(self):
+        n_inject, K = 5, 4
+        dev = torch.device("cpu")
+        mask = dflash_draft_mask(query_len=K, capacity=32, offset=n_inject, device=dev)
+        assert mask[0, n_inject + K :].sum().item() == 0
+
+
+class TestDFlashDrafter:
+    """Shape and correctness tests for the DFlash drafter."""
+
+    def test_inject_kv_populates_cache(self):
+        cfg = _make_small_config()
+        model = MuseGlimmerDFlashDrafterForCausalLM(cfg)
+        model.eval()
+
+        k = torch.zeros(
+            cfg.num_hidden_layers,
+            1,
+            cfg.num_key_value_heads,
+            cfg.sliding_window,
+            cfg.head_dim,
+        )
+        v = torch.zeros_like(k)
+        cache = RingKVCache(k, v)
+
+        features = torch.randn(1, 3, cfg.hidden_size)
+        pos = torch.arange(3).unsqueeze(0)
+        with torch.no_grad():
+            model.inject_kv(features, pos, cache)
+
+            assert k[0, 0, 0, 0, :].norm().item() > 0, "Cache should be populated after inject_kv"
+            assert k[0, 0, 0, 3, :].norm().item() == 0
+
+    def test_draft_output_shape(self):
+        cfg = _make_small_config()
+        K = cfg.block_size
+        model = MuseGlimmerDFlashDrafterForCausalLM(cfg)
+        model.eval()
+
+        k = torch.zeros(
+            cfg.num_hidden_layers,
+            1,
+            cfg.num_key_value_heads,
+            cfg.sliding_window,
+            cfg.head_dim,
+        )
+        v = torch.zeros_like(k)
+        cache = RingKVCache(k, v)
+
+        features = torch.randn(1, 5, cfg.hidden_size)
+        model.inject_kv(features, torch.arange(5).unsqueeze(0), cache)
+
+        draft_ids = torch.tensor([[42] + [cfg.mask_token_id] * (K - 1)])
+        full_pos = torch.arange(5 + K).unsqueeze(0)
+        with torch.no_grad():
+            logits = model.draft(draft_ids, full_pos, cache)
+
+        assert logits.shape == (1, K, cfg.vocab_size)
+
+    def test_draft_no_nan(self):
+        cfg = _make_small_config()
+        K = cfg.block_size
+        model = MuseGlimmerDFlashDrafterForCausalLM(cfg)
+        model.eval()
+
+        k = torch.zeros(
+            cfg.num_hidden_layers,
+            1,
+            cfg.num_key_value_heads,
+            cfg.sliding_window,
+            cfg.head_dim,
+        )
+        v = torch.zeros_like(k)
+        cache = RingKVCache(k, v)
+
+        features = torch.randn(1, 5, cfg.hidden_size)
+        model.inject_kv(features, torch.arange(5).unsqueeze(0), cache)
+
+        draft_ids = torch.tensor([[42] + [cfg.mask_token_id] * (K - 1)])
+        full_pos = torch.arange(5 + K).unsqueeze(0)
+        with torch.no_grad():
+            logits = model.draft(draft_ids, full_pos, cache)
+
+        assert not torch.isnan(logits).any(), "Draft logits should not contain NaN"
+
+    def test_no_embed_norm_in_draft(self):
+        """Regression test: DFlash drafter must NOT apply embed norm."""
+        import inspect
+
+        from coreai_models.models.macos.muse_glimmer_drafter_dflash import DFlashDrafterModel
+
+        src = inspect.getsource(DFlashDrafterModel.draft)
+        assert "rsqrt" not in src, (
+            "DFlash drafter draft() must NOT apply embed norm (rsqrt). "
+            "HF explicitly says: 'The assistant needs embedding without norm'."
+        )
+
+
+class TestMuseGlimmerWithDrafter:
+    """Tests for the fused target model that extracts hidden states."""
+
+    def test_with_drafter_extracts_correct_count(self):
+        config = _make_small_config()
+
+        model = MuseGlimmerModelWithDrafter(config, target_layer_ids=[0, 2])
+        model.eval()
+
+        from coreai_models.primitives.macos.cache import KVCache
+
+        ids = torch.randint(0, config.vocab_size, (1, 4))
+        pos = torch.arange(4).unsqueeze(0)
+        ng = sum(1 for t in config.layer_types if t == "full_attention")
+        ns = sum(1 for t in config.layer_types if t == "sliding_attention")
+        gk = torch.zeros(ng, 1, config.num_key_value_heads, 32, config.head_dim)
+        gv = torch.zeros_like(gk)
+        sk = torch.zeros(ns, 1, config.num_key_value_heads, config.sliding_window, config.head_dim)
+        sv = torch.zeros_like(sk)
+
+        with torch.no_grad():
+            hidden, extracted = model(ids, pos, KVCache(gk, gv), RingKVCache(sk, sv))
+
+        assert len(extracted) == 2, f"Expected 2 extracted layers, got {len(extracted)}"
+        assert extracted[0].shape == (1, 4, config.hidden_size)
+        assert hidden.shape == (1, 4, config.hidden_size)
+
+    def test_fused_target_dual_output(self):
+        config = _make_small_config()
+        config.target_layer_ids = [0, 1, 2, 3]  # 4 layers to match encoder_fc
+
+        model = MuseGlimmerForCausalLMWithDrafter(config)
+        model.eval()
+
+        ids = torch.randint(0, config.vocab_size, (1, 4))
+        pos = torch.arange(4).unsqueeze(0)
+        ng = sum(1 for t in config.layer_types if t == "full_attention")
+        ns = sum(1 for t in config.layer_types if t == "sliding_attention")
+        gk = torch.zeros(ng, 1, config.num_key_value_heads, 32, config.head_dim)
+        gv = torch.zeros_like(gk)
+        sk = torch.zeros(ns, 1, config.num_key_value_heads, config.sliding_window, config.head_dim)
+        sv = torch.zeros_like(sk)
+
+        with torch.no_grad():
+            logits, features = model(ids, pos, gk, gv, sk, sv)
+
+        assert logits.shape == (1, 4, config.vocab_size)
+        assert features.shape == (1, 4, config.hidden_size)
+        assert not torch.isnan(logits).any()
+        assert not torch.isnan(features).any()


### PR DESCRIPTION
DFlash drafter with two-phase inference:
- inject_kv writes target encoder features into the ring KV cache via per-layer Wk/Wv projection.
- draft runs bidirectional attention over injected context and mask tokens, producing K token predictions in a single pass.

MuseGlimmerModelWithDrafter extracts hidden states at layers [1,13,25,37,49]. MuseGlimmerForCausalLMWithDrafter fuses encoder.fc + encoder_norm to produce (logits, drafter_features).

Parity verified against HF MuseGlimmerAssistantModel at all 24 sub-layer checkpoints. Acceptance: K=4 64%, K=8 30%, K=16 17%.