### PR TITLE
Fix Phi-4 RoPE runtime regression while preserving LongRoPE

### DIFF
--- a/python/src/coreai_models/models/macos/phi3.py
+++ b/python/src/coreai_models/models/macos/phi3.py
@@ -58,6 +58,11 @@ class Attention(nn.Module):
         rope_scaling = getattr(config, "rope_scaling", None)
         original_max_pos = getattr(config, "original_max_position_embeddings", None)
         native_max_pos = getattr(config, "_native_max_position_embeddings", max_pos)
+        # For partial rotary (e.g. Phi-4-mini, partial_rotary_factor=0.75) the
+        # runtime composite RoPE op rejects freqs.count != head_dim/2 on newer OS
+        # betas and falls back to a slow CPU scalar path. Request the decomposed
+        # (raw torch ops) path, which initialize_rope builds while preserving any
+        # LongRoPE scaling, so accuracy is unchanged.
         self.rope = initialize_rope(
             dims=rope_dims,
             base=rope_theta,
@@ -65,6 +70,7 @@ class Attention(nn.Module):
             max_position_embeddings=max_pos or original_max_pos,
             original_max_position_embeddings=original_max_pos,
             config_max_position_embeddings=native_max_pos,
+            decomposed=partial_rotary_factor < 1.0,
         )
 
     def forward(

--- a/python/src/coreai_models/primitives/macos/rope.py
+++ b/python/src/coreai_models/primitives/macos/rope.py
@@ -46,16 +46,27 @@ class DecomposedRoPE(torch.nn.Module):
       y1 = cos * x1 - sin * x2
       y2 = sin * x1 + cos * x2
       output = cat(y1, y2, passthrough)
+
+    ``inv_freq`` and ``attention_scale`` let this reproduce a scaled RoPE
+    variant (e.g. LongRoPE) with raw ops: pass precomputed per-dimension
+    inverse frequencies and the attention factor that scales the rotary
+    dims before rotation. See :meth:`LongRoPE.to_decomposed`.
     """
 
     def __init__(
         self: Self,
         dims: int | None = None,
         base: float = 1e4,
+        inv_freq: torch.Tensor | None = None,
+        attention_scale: float = 1.0,
     ) -> None:
         super().__init__()
         self.dims = dims
         self.base = base
+        # Stored as a plain attribute (like LongRoPE._freqs) so it stays a
+        # constant under torch.export; moved onto the input device in forward.
+        self._inv_freq = inv_freq
+        self.attention_scale = attention_scale
 
     def forward(
         self: Self,
@@ -95,9 +106,13 @@ class DecomposedRoPE(torch.nn.Module):
 
         pos = pos.float()
 
-        # Compute inverse frequencies in f32: 1 / (base ^ (i / half_dim))
-        exponent = torch.arange(half_dim, dtype=torch.float32, device=input.device) / half_dim
-        inv_freq = 1.0 / torch.pow(self.base, exponent)
+        # Inverse frequencies in f32. Use the precomputed per-dimension freqs
+        # when provided (e.g. LongRoPE), else the plain 1/base^(i/half_dim).
+        if self._inv_freq is not None:
+            inv_freq = self._inv_freq.to(device=input.device, dtype=torch.float32)
+        else:
+            exponent = torch.arange(half_dim, dtype=torch.float32, device=input.device) / half_dim
+            inv_freq = 1.0 / torch.pow(self.base, exponent)
 
         # Compute angles: (batch, 1, seq_len, 1) * (half_dim,) -> (batch, 1, seq_len, half_dim)
         angle = pos.unsqueeze(-1) * inv_freq
@@ -109,6 +124,12 @@ class DecomposedRoPE(torch.nn.Module):
         # Split input into two halves (non-interleaved)
         x1 = input[..., :half_dim]
         x2 = input[..., half_dim:rotation_dims]
+
+        # Scale the rotary dims by the attention factor before rotation, matching
+        # LongRoPE (rotation is linear, so scaling the input scales the output).
+        if self.attention_scale != 1.0:
+            x1 = x1 * self.attention_scale
+            x2 = x2 * self.attention_scale
 
         # Apply rotation
         y1 = cos * x1 - sin * x2
@@ -271,6 +292,19 @@ class LongRoPE(torch.nn.Module):
             offset=offset,
         )
 
+    def to_decomposed(self: Self) -> "DecomposedRoPE":
+        """Return a raw-torch equivalent that avoids the composite RoPE op.
+
+        The composite op rejects partial-rotary frequency tensors on newer OS
+        betas. This carries the LongRoPE per-dimension frequencies and the
+        attention factor into DecomposedRoPE, preserving numerical behavior.
+        """
+        return DecomposedRoPE(
+            dims=self.dims,
+            inv_freq=self._freqs,
+            attention_scale=self.attention_factor,
+        )
+
 
 def initialize_rope(
     dims: int | None = None,
@@ -280,12 +314,14 @@ def initialize_rope(
     max_position_embeddings: int | None = None,
     original_max_position_embeddings: int | None = None,
     config_max_position_embeddings: int | None = None,
+    decomposed: bool = False,
 ) -> torch.nn.Module:
-    # When FORCE_DECOMPOSED_ROPE=1, bypass the composite op entirely and use
-    # raw torch ops. This works around MLIR lowering bugs for partial rotary
-    # (similar to the FLUX.2 inline RoPE corruption: rdar://178555985).
-    if os.environ.get("FORCE_DECOMPOSED_ROPE") == "1":
-        return DecomposedRoPE(dims=dims, base=float(base))
+    # ``decomposed`` (or FORCE_DECOMPOSED_ROPE=1) emits the rotation with raw
+    # torch ops instead of the composite op, which the runtime mis-lowers for
+    # partial rotary embeddings on newer OS betas (rdar://178555985). The
+    # decomposed path preserves scaling: LongRoPE carries its per-dimension
+    # frequencies and attention factor across via LongRoPE.to_decomposed().
+    use_decomposed = decomposed or os.environ.get("FORCE_DECOMPOSED_ROPE") == "1"
 
     if scaling_config is not None:
         rope_type = scaling_config.get("type") or scaling_config.get("rope_type", "default")
@@ -352,5 +388,13 @@ def initialize_rope(
         case _:
             msg = f"Unsupported RoPE type {rope_type}"
             raise ValueError(msg)
+
+    if use_decomposed:
+        if isinstance(rope, LongRoPE):
+            return rope.to_decomposed()
+        if rope_type == "default":
+            return DecomposedRoPE(dims=dims, base=float(base))
+        msg = f"Decomposed RoPE is not supported for rope_type={rope_type!r}"
+        raise NotImplementedError(msg)
 
     return rope

--- a/python/tests/test_model_units/test_models/test_macos_layers/test_phi3.py
+++ b/python/tests/test_model_units/test_models/test_macos_layers/test_phi3.py
@@ -21,7 +21,7 @@ from transformers.models.phi3.modeling_phi3 import (
 
 from coreai_models.models.macos.phi3 import Phi3ForCausalLM
 from coreai_models.primitives.macos.cache import KVCache
-from coreai_models.primitives.macos.rope import LongRoPE, initialize_rope
+from coreai_models.primitives.macos.rope import DecomposedRoPE, LongRoPE, initialize_rope
 
 # --- Configs matching each variant's architecture ---
 
@@ -454,3 +454,101 @@ class TestLongRoPE:
             * 1e4 ** (torch.arange(0, 8, 2, dtype=torch.float32) / 8)
         )
         torch.testing.assert_close(rope._freqs, expected)
+
+
+class TestDecomposedPartialRotary:
+    """Partial-rotary models (e.g. Phi-4) use the decomposed RoPE path because
+    the composite op mis-lowers partial-rotary freqs on newer OS betas. These
+    tests lock that the decomposed path preserves LongRoPE scaling exactly —
+    plain decomposed RoPE would silently drop the attention factor and per-dim
+    frequency factors.
+    """
+
+    def test_to_decomposed_matches_longrope(self):
+        """LongRoPE.to_decomposed() reproduces LongRoPE output for partial rotary."""
+        dims = 12  # partial: rotary dims < head_dim (16)
+        lr = LongRoPE(
+            dims=dims,
+            base=10000.0,
+            short_factor=[1.0 + 0.02 * i for i in range(dims // 2)],
+            long_factor=[1.1 + 0.02 * i for i in range(dims // 2)],
+            original_max_position_embeddings=64,
+            max_position_embeddings=64,
+            config_max_position_embeddings=2048,
+        )
+        dec = lr.to_decomposed()
+        assert isinstance(dec, DecomposedRoPE)
+        assert dec.attention_scale > 1.0  # attention factor carried across
+        assert dec._inv_freq is not None  # per-dimension freqs carried across
+
+        for seq_len in (4, 32):
+            x = torch.randn(1, 2, seq_len, 16)
+            position_ids = torch.arange(seq_len, dtype=torch.int32).unsqueeze(0)
+            torch.testing.assert_close(
+                dec(x, position_ids=position_ids),
+                lr(x, position_ids=position_ids),
+                atol=1e-6,
+                rtol=1e-6,
+            )
+
+    def test_initialize_rope_decomposed_matches_composite_longrope(self):
+        """initialize_rope(decomposed=True) matches the composite LongRoPE it replaces."""
+        kwargs = dict(
+            dims=8,
+            scaling_config={
+                "type": "longrope",
+                "short_factor": _SHORT_FACTOR,
+                "long_factor": _LONG_FACTOR,
+            },
+            max_position_embeddings=4096,
+            original_max_position_embeddings=4096,
+            config_max_position_embeddings=131072,
+        )
+        composite = initialize_rope(**kwargs)
+        decomposed = initialize_rope(**kwargs, decomposed=True)
+        assert isinstance(composite, LongRoPE)
+        assert isinstance(decomposed, DecomposedRoPE)
+
+        x = torch.randn(1, 2, 6, 10)  # head_dim 10 > rotary dims 8 (partial)
+        position_ids = torch.arange(6, dtype=torch.int32).unsqueeze(0)
+        torch.testing.assert_close(
+            decomposed(x, position_ids=position_ids),
+            composite(x, position_ids=position_ids),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_initialize_rope_decomposed_plain_when_no_scaling(self):
+        """Without scaling, decomposed path is a plain DecomposedRoPE (no factors)."""
+        rope = initialize_rope(dims=12, base=10000.0, decomposed=True)
+        assert isinstance(rope, DecomposedRoPE)
+        assert rope._inv_freq is None
+        assert rope.attention_scale == 1.0
+
+    def test_phi4_partial_rotary_longrope_wired_to_decomposed(self):
+        """A Phi-4-style partial-rotary + longrope config routes to DecomposedRoPE
+        carrying the LongRoPE scaling (not a plain, scaling-dropping RoPE)."""
+        config = _phi4_mini_config()  # partial_rotary_factor=0.75
+        head_dim = config.hidden_size // config.num_attention_heads
+        rope_dims = int(head_dim * 0.75)
+        config.rope_scaling = {
+            "rope_type": "longrope",
+            "rope_theta": 10000.0,
+            "short_factor": [1.0] * (rope_dims // 2),
+            "long_factor": [1.05] * (rope_dims // 2),
+        }
+        config.original_max_position_embeddings = 32
+        config._native_max_position_embeddings = 1024  # extended context -> attn factor > 1
+
+        model = Phi3ForCausalLM(config, model_device="cpu")
+        rope = model.model.layers[0].self_attn.rope
+        assert isinstance(rope, DecomposedRoPE)
+        assert rope._inv_freq is not None
+        assert rope.attention_scale > 1.0
+
+    def test_phi4_full_rotary_keeps_composite_rope(self):
+        """Full-rotary Phi-3.5 keeps the composite (non-decomposed) RoPE path."""
+        config = _phi35_mini_config()  # partial_rotary_factor=1.0
+        model = Phi3ForCausalLM(config, model_device="cpu")
+        rope = model.model.layers[0].self_attn.rope
+        assert not isinstance(rope, DecomposedRoPE)


### PR DESCRIPTION
## Summary

The runtime composite RoPE op rejects `freqs.count != head_dim/2` on newer OS builds, which forces partial-rotary models (Phi-4-mini, `partial_rotary_factor=0.75`) onto a slow CPU scalar fallback (~2.7 tok/s instead of ~100 tok/s).

This routes partial-rotary models through the **decomposed** (raw torch ops) RoPE path, which the runtime lowers correctly.

## Why not just use plain `DecomposedRoPE`

A plain `DecomposedRoPE(dims, base)` emits *unscaled* rotary and silently drops Phi-4's LongRoPE scaling — the `attention_factor` (~1.19 for the 131072/4096 ratio) and the per-dimension short/long factors. Measured against the HF-faithful `LongRoPE`:

| context | attention-logit mean rel. error (plain decomposed) |
|---|---|
| 16 / 512 | ~29% (from `attention_factor` alone) |
| 4096 | 600%+ (per-dim factor mismatch compounds with position) |

So the decomposed path must **carry the LongRoPE scaling**:

- `DecomposedRoPE` gains optional `inv_freq` + `attention_scale`.
- `LongRoPE.to_decomposed()` reuses its (unit-tested, HF-validated) frequencies and attention factor.
- `initialize_rope(..., decomposed=True)` returns the correct decomposed equivalent per rope type, and unifies the existing `FORCE_DECOMPOSED_ROPE` env path.
- `phi3.py` just passes `decomposed=partial_rotary_factor < 1.0`.

## Verification

- `LongRoPE.to_decomposed()` output is **bitwise-equal (0.00)** to `LongRoPE` at seq 16/512/4096.
- New `TestDecomposedPartialRotary` parity tests (fail on the plain path, pass here).
- Full `test_phi3.py` + macOS `test_rope.py` pass (40 tests); ruff clean; no new type errors.
- Full-rotary models (Phi-3/3.5) are unaffected — they keep the composite RoPE path.